### PR TITLE
Recharts fix

### DIFF
--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -105,6 +105,8 @@ export const MapComponent: React.FC = () => {
       zoom: MAP_OPTIONS.zoom,
       maxZoom: MAP_OPTIONS.maxZoom,
     });
+    map.current.scrollZoom.setWheelZoomRate(1 / 300);
+    map.current.scrollZoom.setZoomRate(1 / 300);
 
     map.current.addControl(new maplibregl.NavigationControl());
 

--- a/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
+++ b/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
@@ -1,11 +1,11 @@
 import { useMapStore } from "@/app/store/mapStore";
 import { Flex, Heading, Text } from "@radix-ui/themes";
-import { BarChart, Bar, ResponsiveContainer, XAxis, Cell } from "recharts";
+import { BarChart, Bar, ResponsiveContainer,  Tooltip, XAxis, YAxis, Cell } from "recharts";
 import { color10 } from "@/app/constants/colors";
 
 export const HorizontalBar = () => {
-  const { mapMetrics } = useMapStore((state) => ({
-    mapMetrics: state.mapMetrics,
+  const mapMetrics = useMapStore((state) => ({
+    ...state.mapMetrics,
   }));
   const numberFormat = new Intl.NumberFormat("en-US");
 
@@ -39,8 +39,8 @@ export const HorizontalBar = () => {
           width={500}
           data={mapMetrics.data}
           layout="vertical"
-          barSize={10}
-          barGap={2}
+          barGap={0.5}
+          maxBarSize={50}
         >
           <XAxis
             allowDataOverflow={true}
@@ -48,6 +48,8 @@ export const HorizontalBar = () => {
             domain={[0, "maxData"]}
             tickFormatter={(value) => numberFormat.format(value)}
           />
+        <YAxis type="category" hide />
+          <Tooltip formatter={(value, name, props) => value.toLocaleString()} />
           <Bar dataKey="total_pop">
             {mapMetrics.data.map((entry, index) => (
               <Cell key={`cell-${index}`} fill={color10[entry.zone - 1]} />

--- a/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
+++ b/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
@@ -1,7 +1,28 @@
 import { useMapStore } from "@/app/store/mapStore";
-import { Flex, Heading, Text } from "@radix-ui/themes";
-import { BarChart, Bar, ResponsiveContainer,  Tooltip, XAxis, YAxis, Cell } from "recharts";
+import { Card, Flex, Heading, Text } from "@radix-ui/themes";
+import {
+  BarChart,
+  Bar,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  Cell,
+} from "recharts";
 import { color10 } from "@/app/constants/colors";
+
+const CustomTooltip = ({ active, payload: items }) => {
+  if (active && items && items.length) {
+    const payload = items[0].payload;
+    console.log(payload);
+    return (
+      <Card>
+        <span>({payload.zone}) Population: </span>
+        <span>{payload.total_pop.toLocaleString()}</span>
+      </Card>
+    );
+  }
+};
 
 export const HorizontalBar = () => {
   const mapMetrics = useMapStore((state) => ({
@@ -48,8 +69,8 @@ export const HorizontalBar = () => {
             domain={[0, "maxData"]}
             tickFormatter={(value) => numberFormat.format(value)}
           />
-        <YAxis type="category" hide />
-          <Tooltip formatter={(value, name, props) => value.toLocaleString()} />
+          <YAxis type="category" hide />
+          <Tooltip content={<CustomTooltip />} />
           <Bar dataKey="total_pop">
             {mapMetrics.data.map((entry, index) => (
               <Cell key={`cell-${index}`} fill={color10[entry.zone - 1]} />

--- a/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
+++ b/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
@@ -14,7 +14,6 @@ import { color10 } from "@/app/constants/colors";
 const CustomTooltip = ({ active, payload: items }) => {
   if (active && items && items.length) {
     const payload = items[0].payload;
-    console.log(payload);
     return (
       <Card>
         <span>({payload.zone}) Population: </span>


### PR DESCRIPTION
Thanks to Raphael for helping me get an interactive map set up on my machine

Here's my proposed fix for the Recharts bar chart; their default types for XAxis and YAxis were causing some rendering issues.  This updates the hidden YAxis and adds a tooltip when hovering over the chart.

<img width="380" alt="Screenshot 2024-09-03 at 3 30 21 PM" src="https://github.com/user-attachments/assets/4888df09-4d07-4718-8d6c-1216ccde68d3">


I also added some code for controlling the scroll zoom for mouse + trackpad, I don't have proof if this does anything here, but the UI/UX felt a little different from Districtr so I was trying to slow down.