### PR TITLE
Amend types in recharts PR

### DIFF
--- a/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
+++ b/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
@@ -39,6 +39,7 @@ export const HorizontalBar = () => {
     (state) =>
       ({
         ...state.mapMetrics,
+        data: state.mapMetrics?.data?.sort((a, b) => a.zone - b.zone),
       }) as MapMetricsType,
   );
 

--- a/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
+++ b/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
@@ -1,6 +1,5 @@
 import { useMapStore } from "@/app/store/mapStore";
 import { Card, Flex, Heading, Text } from "@radix-ui/themes";
-import type { UseQueryResult } from "@tanstack/react-query";
 import {
   BarChart,
   Bar,
@@ -11,7 +10,6 @@ import {
   Cell,
 } from "recharts";
 import { color10 } from "@/app/constants/colors";
-import { ZonePopulation } from "@/app/api/apiHandlers";
 
 type TooltipInput = {
   active?: boolean;
@@ -32,16 +30,10 @@ const CustomTooltip = ({ active, payload: items }: TooltipInput) => {
   }
 };
 
-type MapMetricsType = UseQueryResult<ZonePopulation[], Error> | null;
-
 export const HorizontalBar = () => {
-  const mapMetrics = useMapStore(
-    (state) =>
-      ({
-        ...state.mapMetrics,
-        data: state.mapMetrics?.data?.sort((a, b) => a.zone - b.zone),
-      }) as MapMetricsType,
-  );
+  const { mapMetrics } = useMapStore((state) => ({
+    mapMetrics: state.mapMetrics,
+  }));
 
   if (mapMetrics?.isPending) {
     return <div>Loading...</div>;
@@ -85,9 +77,11 @@ export const HorizontalBar = () => {
           <YAxis type="category" hide />
           <Tooltip content={<CustomTooltip />} />
           <Bar dataKey="total_pop">
-            {mapMetrics.data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={color10[entry.zone - 1]} />
-            ))}
+            {mapMetrics.data
+              .sort((a, b) => a.zone - b.zone)
+              .map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={color10[entry.zone - 1]} />
+              ))}
           </Bar>
         </BarChart>
       </ResponsiveContainer>

--- a/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
+++ b/app/src/app/components/sidebar/charts/HorizontalBarChart.tsx
@@ -1,5 +1,6 @@
 import { useMapStore } from "@/app/store/mapStore";
 import { Card, Flex, Heading, Text } from "@radix-ui/themes";
+import type { UseQueryResult } from "@tanstack/react-query";
 import {
   BarChart,
   Bar,
@@ -10,24 +11,36 @@ import {
   Cell,
 } from "recharts";
 import { color10 } from "@/app/constants/colors";
+import { ZonePopulation } from "@/app/api/apiHandlers";
 
-const CustomTooltip = ({ active, payload: items }) => {
+type TooltipInput = {
+  active?: boolean;
+  payload?: [{ payload: { total_pop: number; zone: number } }];
+};
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+const CustomTooltip = ({ active, payload: items }: TooltipInput) => {
   if (active && items && items.length) {
     const payload = items[0].payload;
     return (
       <Card>
         <span>({payload.zone}) Population: </span>
-        <span>{payload.total_pop.toLocaleString()}</span>
+        <span>{numberFormat.format(payload.total_pop)}</span>
       </Card>
     );
   }
 };
 
+type MapMetricsType = UseQueryResult<ZonePopulation[], Error> | null;
+
 export const HorizontalBar = () => {
-  const mapMetrics = useMapStore((state) => ({
-    ...state.mapMetrics,
-  }));
-  const numberFormat = new Intl.NumberFormat("en-US");
+  const mapMetrics = useMapStore(
+    (state) =>
+      ({
+        ...state.mapMetrics,
+      }) as MapMetricsType,
+  );
 
   if (mapMetrics?.isPending) {
     return <div>Loading...</div>;


### PR DESCRIPTION
Updates the previous recharts PR #78 with types for TypeScript build:

- label types for the custom tooltip component
- revert changes to `useMapStore` syntax - typing was too verbose
- sort `mapMetrics.data` by zone before rendering the chart
- ALSO reuse `numberFormat.format` in the custom tooltip component