### PR TITLE
Eraser feature!

### DIFF
--- a/app/src/app/api/apiHandlers.ts
+++ b/app/src/app/api/apiHandlers.ts
@@ -198,20 +198,3 @@ export const patchUpdateAssignments: (
       return res.data;
     });
 };
-
-/**
- *
- * @param assignments
- * @returns server object containing the updated assignments per geoid
- */
-export const patchEraseAssignments: (
-  assignments: Assignment[],
-) => Promise<AssignmentsCreate> = async (assignments: Assignment[]) => {
-  return await axios
-    .patch(`${process.env.NEXT_PUBLIC_API_URL}/api/erase_assignments`, {
-      assignments: assignments,
-    })
-    .then((res) => {
-      return res.data;
-    });
-};

--- a/app/src/app/api/apiHandlers.ts
+++ b/app/src/app/api/apiHandlers.ts
@@ -198,3 +198,20 @@ export const patchUpdateAssignments: (
       return res.data;
     });
 };
+
+/**
+ *
+ * @param assignments
+ * @returns server object containing the updated assignments per geoid
+ */
+export const patchEraseAssignments: (
+  assignments: Assignment[],
+) => Promise<AssignmentsCreate> = async (assignments: Assignment[]) => {
+  return await axios
+    .patch(`${process.env.NEXT_PUBLIC_API_URL}/api/erase_assignments`, {
+      assignments: assignments,
+    })
+    .then((res) => {
+      return res.data;
+    });
+};

--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -20,7 +20,6 @@ import {
   FormatAssignments,
   getDocument,
   DocumentObject,
-  patchEraseAssignments,
   patchUpdateAssignments,
   AssignmentsCreate,
   getAssignments,
@@ -47,22 +46,6 @@ export const MapComponent: React.FC = () => {
     onSuccess: (data: AssignmentsCreate) => {
       console.log(
         `Successfully upserted ${data.assignments_upserted} assignments`,
-      );
-      mapMetrics.refetch();
-    },
-  });
-
-  const patchErase = useMutation({
-    mutationFn: patchEraseAssignments,
-    onMutate: () => {
-      console.log("Erasing assignments");
-    },
-    onError: (error) => {
-      console.log("Error erasing assignments: ", error);
-    },
-    onSuccess: (data: AssignmentsCreate) => {
-      console.log(
-        `Successfully erased ${data.assignments_upserted} assignments`,
       );
       mapMetrics.refetch();
     },
@@ -191,16 +174,9 @@ export const MapComponent: React.FC = () => {
    */
   useEffect(() => {
     if (mapLoaded && map.current && zoneAssignments.size) {
-      const assignments = FormatAssignments();
-      if (activeTool === "brush") {
-        const modAssignments = assignments.filter(
-          (block) => block.zone !== null,
-        );
-        if (modAssignments.length) {
-          patchUpdates.mutate(modAssignments);
-        }
-      } else if (activeTool === "eraser") {
-        patchErase.mutate(assignments);
+      if (activeTool === "brush" || activeTool === "eraser") {
+        const assignments = FormatAssignments();
+        patchUpdates.mutate(assignments);
       }
     }
   }, [mapLoaded, zoneAssignments]);

--- a/app/src/app/components/sidebar/MapModeSelector.jsx
+++ b/app/src/app/components/sidebar/MapModeSelector.jsx
@@ -17,7 +17,7 @@ export function MapModeSelector() {
   const activeTools = [
     { mode: "pan", disabled: false, label: "Pan", icon: <HandIcon /> },
     { mode: "brush", disabled: false, label: "Brush", icon: <Pencil2Icon /> },
-    { mode: "erase", disabled: true, label: "Erase", icon: <EraserIcon /> },
+    { mode: "eraser", disabled: false, label: "Erase", icon: <EraserIcon /> },
   ];
 
   const handleRadioChange = (value) => {

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -26,11 +26,15 @@ export default function SidebarComponent() {
         </Heading>
         <GerryDBViewSelector />
         <MapModeSelector />
+        {activeTool === "brush" || activeTool === "eraser" ? (
+          <div>
+            <BrushSizeSelector />
+            <PaintByCounty />{" "}
+          </div>
+        ) : null}
         {activeTool === "brush" ? (
           <div>
             <ColorPicker />
-            <BrushSizeSelector />
-            <PaintByCounty />{" "}
           </div>
         ) : null}
         <ResetMapButton />

--- a/app/src/app/constants/types.ts
+++ b/app/src/app/constants/types.ts
@@ -1,6 +1,6 @@
 import type { MapOptions, MapLibreEvent } from "maplibre-gl";
 
-export type Zone = number;
+export type Zone = number | null;
 
 export type GEOID = string;
 

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -39,7 +39,7 @@ export interface MapStore {
   setSelectedZone: (zone: Zone) => void;
   accumulatedBlockPopulations: Map<string, number>;
   resetAccumulatedBlockPopulations: () => void;
-  zoneAssignments: Map<string, number>; // geoid -> zone
+  zoneAssignments: Map<string, Zone>; // geoid -> zone
   setZoneAssignments: (zone: Zone, gdbPaths: Set<GDBPath>) => void;
   resetZoneAssignments: () => void;
   zonePopulations: Map<Zone, number>;

--- a/app/src/app/utils/events/handlers.ts
+++ b/app/src/app/utils/events/handlers.ts
@@ -2,6 +2,7 @@ import { BLOCK_SOURCE_ID } from "@/app/constants/layers";
 import { MutableRefObject } from "react";
 import { Map, MapGeoJSONFeature } from "maplibre-gl";
 import { debounce } from "lodash";
+import { Zone } from "@/app/constants/types";
 import { MapStore } from "@/app/store/mapStore";
 
 /**
@@ -11,7 +12,7 @@ import { MapStore } from "@/app/store/mapStore";
  * @returns void - but updates the zoneAssignments and zonePopulations in the store
  */
 const debouncedSetZoneAssignments = debounce(
-  (mapStoreRef: MapStore, selectedZone: number | null, geoids: Set<string>) => {
+  (mapStoreRef: MapStore, selectedZone: Zone, geoids: Set<string>) => {
     mapStoreRef.setZoneAssignments(selectedZone, geoids);
 
     const accumulatedBlockPopulations = mapStoreRef.accumulatedBlockPopulations;

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -27,7 +27,7 @@ MapEvent handling; these functions are called by the event listeners in the MapC
 export const handleMapClick = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -50,7 +50,7 @@ export const handleMapClick = (
 export const handleMapMouseUp = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -66,7 +66,7 @@ export const handleMapMouseUp = (
 export const handleMapMouseDown = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -84,19 +84,19 @@ export const handleMapMouseDown = (
 export const handleMapMouseEnter = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {};
 
 export const handleMapMouseOver = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {};
 
 export const handleMapMouseLeave = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -113,7 +113,7 @@ export const handleMapMouseLeave = (
 export const handleMapMouseOut = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {
   // console.log("mouse out");
 };
@@ -121,7 +121,7 @@ export const handleMapMouseOut = (
 export const handleMapMouseMove = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -145,7 +145,7 @@ export const handleMapMouseMove = (
 export const handleMapZoom = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {};
 
 export const handleMapIdle = () => {};
@@ -155,11 +155,11 @@ export const handleMapMoveEnd = () => {};
 export const handleMapZoomEnd = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>,
+  hoverFeatureIds: React.MutableRefObject<Set<string>>
 ) => {};
 
 export const handleResetMapSelectState = (
-  map: MutableRefObject<Map | null>,
+  map: MutableRefObject<Map | null>
 ) => {
   const mapStore = useMapStore.getState();
   const sourceLayer = mapStore.selectedLayer?.name;

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -27,7 +27,7 @@ MapEvent handling; these functions are called by the event listeners in the MapC
 export const handleMapClick = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -36,14 +36,11 @@ export const handleMapClick = (
   if (activeTool === "brush" || activeTool === "eraser") {
     const selectedFeatures = mapStore.paintFunction(map, e, mapStore.brushSize);
 
-    if (activeTool === "brush" && sourceLayer) {
+    if (sourceLayer) {
       // select on both the map object and the store
       SelectMapFeatures(selectedFeatures, map, mapStore).then(() => {
         SelectZoneAssignmentFeatures(mapStore);
       });
-    } else if (activeTool === "eraser") {
-      // erase features
-      // TODO: implement eraser
     }
   } else {
     // tbd, for pan mode - is there an info mode on click?
@@ -53,13 +50,13 @@ export const handleMapClick = (
 export const handleMapMouseUp = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
   const isPainting = mapStore.isPainting;
 
-  if (activeTool === "brush" && isPainting) {
+  if ((activeTool === "brush" || activeTool === "eraser") && isPainting) {
     // set isPainting to false
     mapStore.setIsPainting(false);
     SelectZoneAssignmentFeatures(mapStore);
@@ -69,7 +66,7 @@ export const handleMapMouseUp = (
 export const handleMapMouseDown = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -80,36 +77,35 @@ export const handleMapMouseDown = (
   } else if (activeTool === "brush" || activeTool === "eraser") {
     // disable drag pan
     map.current?.dragPan.disable();
-    if (activeTool === "brush") {
-      mapStore.setIsPainting(true);
-      return;
-    } else if (activeTool === "eraser") {
-      // erase features tbd
-    }
+    mapStore.setIsPainting(true);
   }
 };
 
 export const handleMapMouseEnter = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {};
 
 export const handleMapMouseOver = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {};
 
 export const handleMapMouseLeave = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
   const sourceLayer = mapStore.selectedLayer?.name;
-  if (sourceLayer && hoverFeatureIds.current.size && activeTool === "brush") {
+  if (
+    sourceLayer &&
+    hoverFeatureIds.current.size &&
+    (activeTool === "brush" || activeTool === "eraser")
+  ) {
     UnhighlightFeature(map, hoverFeatureIds, sourceLayer);
   }
 };
@@ -117,7 +113,7 @@ export const handleMapMouseLeave = (
 export const handleMapMouseOut = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {
   // console.log("mouse out");
 };
@@ -125,17 +121,21 @@ export const handleMapMouseOut = (
 export const handleMapMouseMove = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
   const isPainting = mapStore.isPainting;
   const sourceLayer = mapStore.selectedLayer?.name;
   const selectedFeatures = mapStore.paintFunction(map, e, mapStore.brushSize);
-  if (sourceLayer && activeTool === "brush") {
+  if (sourceLayer && (activeTool === "brush" || activeTool === "eraser")) {
     HighlightFeature(selectedFeatures, map, hoverFeatureIds, sourceLayer);
-  } 
-   if (activeTool === "brush" && isPainting && sourceLayer) {
+  }
+  if (
+    (activeTool === "brush" || activeTool === "eraser") &&
+    isPainting &&
+    sourceLayer
+  ) {
     // selects in the map object; the store object
     // is updated in the mouseup event
     SelectMapFeatures(selectedFeatures, map, mapStore);
@@ -145,7 +145,7 @@ export const handleMapMouseMove = (
 export const handleMapZoom = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {};
 
 export const handleMapIdle = () => {};
@@ -155,11 +155,11 @@ export const handleMapMoveEnd = () => {};
 export const handleMapZoomEnd = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MutableRefObject<Map | null>,
-  hoverFeatureIds: React.MutableRefObject<Set<string>>
+  hoverFeatureIds: React.MutableRefObject<Set<string>>,
 ) => {};
 
 export const handleResetMapSelectState = (
-  map: MutableRefObject<Map | null>
+  map: MutableRefObject<Map | null>,
 ) => {
   const mapStore = useMapStore.getState();
   const sourceLayer = mapStore.selectedLayer?.name;

--- a/backend/app/alembic/versions/09d011c1b387_zones_can_be_null.py
+++ b/backend/app/alembic/versions/09d011c1b387_zones_can_be_null.py
@@ -1,0 +1,27 @@
+"""zones_can_be_null
+
+Revision ID: 09d011c1b387
+Revises: 8437ce954087
+Create Date: 2024-09-09 13:34:59.347083
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '09d011c1b387'
+down_revision: Union[str, None] = '8437ce954087'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("ALTER TABLE document.assignments ALTER zone DROP NOT NULL"))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM document.assignments WHERE zone IS NULL"))
+    op.execute(sa.text("ALTER TABLE document.assignments ALTER zone SET NOT NULL"))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,6 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 from sqlmodel import Session, select
 from starlette.middleware.cors import CORSMiddleware
-from sqlalchemy import delete
 from sqlalchemy.dialects.postgresql import insert
 import logging
 
@@ -132,23 +131,6 @@ async def update_document(
     return db_document
 
 
-@app.patch("/api/erase_assignments")
-async def erase_assignments(
-    data: AssignmentsCreate, session: Session = Depends(get_session)
-):
-    ids_to_delete = []
-    document_id = None
-    for block in data.model_dump()["assignments"]:
-        if block["zone"] is None:
-            ids_to_delete.append(block["geo_id"])
-            document_id = block["document_id"]
-    mydocCondition = Assignments.document_id == document_id
-    stmt = delete(Assignments).where(mydocCondition).where(Assignments.geo_id.in_(ids_to_delete))
-    session.exec(stmt)
-    session.commit()
-    return {"assignments_erased": len(ids_to_delete)}
-
-
 @app.patch("/api/update_assignments")
 async def update_assignments(
     data: AssignmentsCreate, session: Session = Depends(get_session)
@@ -192,7 +174,7 @@ async def get_document(document_id: str, session: Session = Depends(get_session)
 async def get_total_population(
     document_id: str, session: Session = Depends(get_session)
 ):
-    stmt = text("SELECT * from get_total_population(:document_id)")
+    stmt = text("SELECT * from get_total_population(:document_id) WHERE zone IS NOT NULL")
     try:
         result = session.execute(stmt, {"document_id": document_id})
         return [

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -75,7 +75,7 @@ class AssignmentsBase(SQLModel):
     metadata = MetaData(schema=DOCUMENT_SCHEMA)
     document_id: str = Field(sa_column=Column(UUIDType, primary_key=True))
     geo_id: str = Field(primary_key=True)
-    zone: int
+    zone: int | None
 
 
 class Assignments(AssignmentsBase, table=True):

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -383,6 +383,21 @@ def test_patch_assignments(client, document_id):
     assert response.json() == {"assignments_upserted": 3}
 
 
+def test_patch_assignments_nulls(client, document_id):
+    response = client.patch(
+        "/api/update_assignments",
+        json={
+            "assignments": [
+                {"document_id": document_id, "geo_id": "202090416004010", "zone": 1},
+                {"document_id": document_id, "geo_id": "202090416003004", "zone": 1},
+                {"document_id": document_id, "geo_id": "202090434001003", "zone": None},
+            ]
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"assignments_upserted": 3}
+
+
 def test_patch_assignments_twice(client, document_id):
     response = client.patch(
         "/api/update_assignments",
@@ -428,6 +443,29 @@ def test_get_document_population_totals(
     assert result.status_code == 200
     data = result.json()
     assert data == [{"zone": 1, "total_pop": 67}, {"zone": 2, "total_pop": 130}]
+
+
+def test_get_document_population_totals_null_assignments(
+    client, document_id, ks_demo_view_census_blocks
+):
+    response = client.patch(
+        "/api/update_assignments",
+        json={
+            "assignments": [
+                {"document_id": document_id, "geo_id": "202090416004010", "zone": 1},
+                {"document_id": document_id, "geo_id": "202090416003004", "zone": 1},
+                {"document_id": document_id, "geo_id": "202090434001003", "zone": None},
+            ]
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"assignments_upserted": 3}
+
+    doc_uuid = str(uuid.UUID(document_id))
+    result = client.get(f"/api/document/{doc_uuid}/total_pop")
+    assert result.status_code == 200
+    data = result.json()
+    assert data == [{"zone": 1, "total_pop": 67}]
 
 
 def test_get_document_vap_totals(


### PR DESCRIPTION
Concepts:
- enable Eraser button
- when `activeTool === "eraser"`, we see the hover-highlight on the map
- clicking in eraser mode stores zoneAssignment = null in frontend parts of the app
- in eraser mode, we call `patchEraseAssignments` to delete rows; server confirms that zone assignment is null/None.
- `patchUpdateAssignments` has a filter to store only non-eraser areas on the server

Thoughts:
- now that I understand how `patchEraseAssignments` needs to work on the server, maybe I should rename it to delete
- old zone: null assignments should be cleared on the frontend after they've been successfully passed to the server

<img width="1074" alt="Screenshot 2024-09-07 at 3 37 24 PM" src="https://github.com/user-attachments/assets/88fb80e9-1632-471d-88bb-810d4928faf2">
