### PR TITLE
Undo/redo actions support

### DIFF
--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Heading } from "@radix-ui/themes";
 import { MapModeSelector } from "./MapModeSelector";
 import { ColorPicker } from "./ColorPicker";
 import { ResetMapButton } from "./ResetMapButton";
-import { UndoButton } from "./UndoButton";
+import { UndoRedoButton } from "./UndoRedoButton";
 import { GerryDBViewSelector } from "./GerryDBViewSelector";
 import { HorizontalBar } from "./charts/HorizontalBarChart";
 import { useMapStore } from "@/app/store/mapStore";
@@ -39,7 +39,10 @@ export default function SidebarComponent() {
           </div>
         ) : null}
         <ResetMapButton />
-        <UndoButton />
+        <Flex direction="row" gap="3">
+          <UndoRedoButton isRedo={false} />
+          <UndoRedoButton isRedo />
+        </Flex>
         <Tabs.Root defaultValue="layers">
           <Tabs.List>
             <Tabs.Trigger value="population"> Population </Tabs.Trigger>

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Heading } from "@radix-ui/themes";
 import { MapModeSelector } from "./MapModeSelector";
 import { ColorPicker } from "./ColorPicker";
 import { ResetMapButton } from "./ResetMapButton";
+import { UndoButton } from "./UndoButton";
 import { GerryDBViewSelector } from "./GerryDBViewSelector";
 import { HorizontalBar } from "./charts/HorizontalBarChart";
 import { useMapStore } from "@/app/store/mapStore";
@@ -38,6 +39,7 @@ export default function SidebarComponent() {
           </div>
         ) : null}
         <ResetMapButton />
+        <UndoButton />
         <Tabs.Root defaultValue="layers">
           <Tabs.List>
             <Tabs.Trigger value="population"> Population </Tabs.Trigger>

--- a/app/src/app/components/sidebar/UndoButton.tsx
+++ b/app/src/app/components/sidebar/UndoButton.tsx
@@ -1,16 +1,25 @@
+import { BLOCK_SOURCE_ID } from "@/app/constants/layers";
+import { Zone } from "@/app/constants/types";
 import { useMapStore } from "@/app/store/mapStore";
 import { Button } from "@radix-ui/themes";
-
-import { Zone } from "../../constants/types";
 
 export function UndoButton() {
   const mapStore = useMapStore.getState();
 
   const handleClickUndo = () => {
+    const sourceLayer = mapStore.selectedLayer?.name;
     const lastAction = mapStore.recentZoneAssignments[mapStore.recentZoneAssignments.length - 1];
     const restoreMap: { [id: number]: Set<string> } = {};
     const nullList = new Set<string>();
     lastAction.forEach((zone, geoid) => {
+      mapStore.mapRef?.current?.setFeatureState(
+        {
+          source: BLOCK_SOURCE_ID,
+          id: geoid,
+          sourceLayer,
+        },
+        { zone },
+      );
       if (zone === null) {
         nullList.add(geoid);
       } else {
@@ -24,6 +33,7 @@ export function UndoButton() {
     for (const numericZone in Object.keys(restoreMap)) {
       mapStore.setZoneAssignments(Number(numericZone), restoreMap[numericZone], true);
     }
+    mapStore.recentZoneAssignments.pop();
   };
 
   return (

--- a/app/src/app/components/sidebar/UndoButton.tsx
+++ b/app/src/app/components/sidebar/UndoButton.tsx
@@ -1,0 +1,38 @@
+import { useMapStore } from "@/app/store/mapStore";
+import { Button } from "@radix-ui/themes";
+
+import { Zone } from "../../constants/types";
+
+export function UndoButton() {
+  const mapStore = useMapStore.getState();
+
+  const handleClickUndo = () => {
+    const lastAction = mapStore.recentZoneAssignments[mapStore.recentZoneAssignments.length - 1];
+    const restoreMap: { [id: number]: Set<string> } = {};
+    const nullList = new Set<string>();
+    lastAction.forEach((zone, geoid) => {
+      if (zone === null) {
+        nullList.add(geoid);
+      } else {
+        if (!restoreMap[zone]) {
+          restoreMap[zone] = new Set<string>();
+        }
+        restoreMap[zone].add(geoid);
+      }
+    });
+    mapStore.setZoneAssignments(null, nullList, true);
+    for (const numericZone in Object.keys(restoreMap)) {
+      mapStore.setZoneAssignments(Number(numericZone), restoreMap[numericZone], true);
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleClickUndo}
+      variant="outline"
+      disabled={mapStore.recentZoneAssignments.length === 0}
+    >
+      ↺ Undo
+    </Button>
+  );
+}

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -10,11 +10,12 @@ export function UndoRedoButton({ isRedo = false }) {
   const handleClickUndoRedo = () => {
     if (isRedo) {
       mapStore.undoCursor++;
-    } else {
+    }
+    const lastAction = mapStore.recentZoneAssignments[mapStore.undoCursor];
+    if (!isRedo) {
       mapStore.undoCursor--;
     }
     const sourceLayer = mapStore.selectedLayer?.name;
-    const lastAction = mapStore.recentZoneAssignments[mapStore.recentZoneAssignments.length - 1];
     const restoreMap: { [id: number]: Set<string> } = {};
     const nullList = new Set<string>();
     lastAction.forEach((zones, geoid) => {
@@ -38,19 +39,27 @@ export function UndoRedoButton({ isRedo = false }) {
     });
     mapStore.setZoneAssignments(null, nullList, true);
     Object.keys(restoreMap).forEach((numericZone: string) =>
-      mapStore.setZoneAssignments(Number(numericZone), restoreMap[Number(numericZone)], true));
+      mapStore.setZoneAssignments(
+        Number(numericZone),
+        restoreMap[Number(numericZone)],
+        true,
+      ),
+    );
   };
 
   return (
     <Button
       onClick={handleClickUndoRedo}
       variant="outline"
-      disabled={isRedo
-        ? ((mapStore.recentZoneAssignments.length === 0) || (mapStore.undoCursor >= mapStore.recentZoneAssignments.length - 1))
-        : (mapStore.undoCursor < 0)}
+      disabled={
+        isRedo
+          ? mapStore.recentZoneAssignments.length === 0 ||
+            mapStore.undoCursor >= mapStore.recentZoneAssignments.length - 1
+          : mapStore.undoCursor < 0
+      }
     >
       <div style={{ transform: isRedo ? "rotateY(180deg)" : "" }}>
-        <ResetIcon/>
+        <ResetIcon />
       </div>
       {isRedo ? "Redo" : "Undo"}
     </Button>

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -42,7 +42,11 @@ export interface MapStore {
   undoCursor: number;
   recentZoneAssignments: Map<string, Zone[]>[];
   zoneAssignments: Map<string, Zone>; // geoid -> zone
-  setZoneAssignments: (zone: Zone, gdbPaths: Set<GDBPath>, isUndo?: boolean) => void;
+  setZoneAssignments: (
+    zone: Zone,
+    gdbPaths: Set<GDBPath>,
+    isUndo?: boolean,
+  ) => void;
   resetZoneAssignments: () => void;
   zonePopulations: Map<Zone, number>;
   setZonePopulations: (zone: Zone, population: number) => void;
@@ -80,7 +84,6 @@ export const useMapStore = create(
           });
         }
         state.setFreshMap(true);
-        state.resetZoneAssignments();
         return { mapDocument: mapDocument };
       }),
     selectedLayer: null,
@@ -119,7 +122,10 @@ export const useMapStore = create(
         if (changedAssignments.size > 0) {
           if (state.undoCursor < state.recentZoneAssignments.length - 1) {
             // this is not an undo action, so new drawing clears redo-able items
-            state.recentZoneAssignments = state.recentZoneAssignments.slice(0, state.undoCursor);
+            state.recentZoneAssignments = state.recentZoneAssignments.slice(
+              0,
+              state.undoCursor,
+            );
           }
           state.recentZoneAssignments.push(changedAssignments);
           if (state.recentZoneAssignments.length > 7) {

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -122,7 +122,11 @@ export const useMapStore = create(
             state.recentZoneAssignments = state.recentZoneAssignments.slice(0, state.undoCursor);
           }
           state.recentZoneAssignments.push(changedAssignments);
-          state.undoCursor++;
+          if (state.recentZoneAssignments.length > 7) {
+            state.recentZoneAssignments.shift();
+          } else {
+            state.undoCursor++;
+          }
         }
         return {
           zoneAssignments: newZoneAssignments,


### PR DESCRIPTION
## Description
- Adds undo and redo buttons with radix-icons for #69 

<img width="375" alt="Screenshot 2024-10-06 at 11 39 57 PM" src="https://github.com/user-attachments/assets/60d4d0b6-84fe-4ea4-8ef5-9b4db51ecfa6">

- There is an undo stack (`recentZoneAssignments`, to reverse the last mousedown -> mouseup draw action. 
- Once you undo an action, the "Redo" button is enabled and it reapplies draw actions
- Because undo/redo use `setFeatureState` and `setZoneAssignments`, they update the map, chart, and serverside doc
- If you undo and then draw new districts, the future Redo-able actions are erased
- A new flag prevents Undo/Redo from adding its actions to the undo stack

## Remaining issues
- Better integration into drawing UI 
- `Object.keys(..).forEach(...)` was odd syntax to re-apply zone draws, could be refactored & consider issues with debouncing if we update several zones at once
- ~Limit the number of actions in the undo stack~ (**did 7**) before erasing the first actions
- ~Doesn't work with changes to zones from the original map load, because those are not in `state.zoneAssignments`~