### PR TITLE
State enhancements: serializable and dev tools

### DIFF
--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -54,7 +54,7 @@ export const MapComponent: React.FC = () => {
             action.action as keyof MapLayerEventType,
             layer, // to be updated with the scale-agnostic layer id
             (e: MapLayerMouseEvent | MapLayerTouchEvent) => {
-              action.handler(e, map);
+              action.handler(e, map.current);
             }
           );
         }
@@ -64,7 +64,7 @@ export const MapComponent: React.FC = () => {
     return () => {
       mapEvents.forEach((action) => {
         map.current?.off(action.action, (e) => {
-          action.handler(e, map);
+          action.handler(e, map.current);
         });
       });
     };

--- a/app/src/app/components/sidebar/Layers.tsx
+++ b/app/src/app/components/sidebar/Layers.tsx
@@ -16,13 +16,13 @@ import { toggleLayerVisibility } from "../../utils/helpers";
  * - Support tribes and communities
  */
 export default function Layers() {
-  const mapRef = useMapStore((state) => state.mapRef);
+  const mapRef = useMapStore((state) => state.getMapRef());
   const mapDocument = useMapStore((state) => state.mapDocument);
   const visibleLayerIds = useMapStore((state) => state.visibleLayerIds);
   const updateVisibleLayerIds = useMapStore((state) => state.updateVisibleLayerIds);
 
   const toggleLayers = (layerIds: string[]) => {
-    if (!mapRef || !mapRef?.current) return;
+    if (!mapRef) return;
     const layerUpdates = toggleLayerVisibility(mapRef, layerIds);
     updateVisibleLayerIds(layerUpdates);
   };

--- a/app/src/app/components/sidebar/PaintByCounty.tsx
+++ b/app/src/app/components/sidebar/PaintByCounty.tsx
@@ -8,17 +8,17 @@ import {
 } from "../../utils/helpers";
 
 export default function PaintByCounty() {
-  const mapRef = useMapStore((state) => state.mapRef);
+  const mapRef = useMapStore((state) => state.getMapRef());
   const addVisibleLayerIds = useMapStore((state) => state.addVisibleLayerIds);
   const setPaintFunction = useMapStore((state) => state.setPaintFunction);
   const [checked, setChecked] = useState(false);
 
   useEffect(() => {
-    if (!mapRef || !mapRef.current) return;
+    if (!mapRef) return;
 
     if (checked) {
       COUNTY_LAYER_IDS.forEach((layerId) => {
-        mapRef.current?.setLayoutProperty(layerId, "visibility", "visible");
+        mapRef.setLayoutProperty(layerId, "visibility", "visible");
       });
       addVisibleLayerIds(COUNTY_LAYER_IDS);
       setPaintFunction(getFeaturesIntersectingCounties);

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -3,7 +3,6 @@ import {
   FilterSpecification,
   LayerSpecification,
 } from "maplibre-gl";
-import { MutableRefObject } from "react";
 import { Map } from "maplibre-gl";
 import { getBlocksSource } from "./sources";
 import { DocumentObject } from "../utils/api/apiHandlers";
@@ -165,21 +164,21 @@ export function getBlocksHoverLayerSpecification(
 }
 
 const addBlockLayers = (
-  map: MutableRefObject<Map | null>,
+  map: Map | null,
   mapDocument: DocumentObject,
 ) => {
-  if (!map.current || !mapDocument.tiles_s3_path) {
+  if (!map || !mapDocument.tiles_s3_path) {
     console.log("map or mapDocument not ready", mapDocument);
     return;
   }
   const blockSource = getBlocksSource(mapDocument.tiles_s3_path);
   removeBlockLayers(map);
-  map.current?.addSource(BLOCK_SOURCE_ID, blockSource);
-  map.current?.addLayer(
+  map?.addSource(BLOCK_SOURCE_ID, blockSource);
+  map?.addLayer(
     getBlocksLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID),
     LABELS_BREAK_LAYER_ID,
   );
-  map.current?.addLayer(
+  map?.addLayer(
     getBlocksHoverLayerSpecification(
       mapDocument.parent_layer,
       BLOCK_HOVER_LAYER_ID,
@@ -187,14 +186,14 @@ const addBlockLayers = (
     LABELS_BREAK_LAYER_ID,
   );
   if (mapDocument.child_layer) {
-    map.current?.addLayer(
+    map?.addLayer(
       getBlocksLayerSpecification(
         mapDocument.child_layer,
         BLOCK_LAYER_ID_CHILD,
       ),
       LABELS_BREAK_LAYER_ID,
     );
-    map.current?.addLayer(
+    map?.addLayer(
       getBlocksHoverLayerSpecification(
         mapDocument.child_layer,
         BLOCK_HOVER_LAYER_ID_CHILD,
@@ -205,22 +204,22 @@ const addBlockLayers = (
   useMapStore.getState().setMapRenderingState("loaded")
 };
 
-export function removeBlockLayers(map: MutableRefObject<Map | null>) {
+export function removeBlockLayers(map: Map | null) {
   useMapStore.getState().setMapRenderingState("loading")
-  if (map.current?.getLayer(BLOCK_LAYER_ID)) {
-    map.current?.removeLayer(BLOCK_LAYER_ID);
+  if (map.getLayer(BLOCK_LAYER_ID)) {
+    map.removeLayer(BLOCK_LAYER_ID);
   }
-  if (map.current?.getLayer(BLOCK_HOVER_LAYER_ID)) {
-    map.current?.removeLayer(BLOCK_HOVER_LAYER_ID);
+  if (map.getLayer(BLOCK_HOVER_LAYER_ID)) {
+    map.removeLayer(BLOCK_HOVER_LAYER_ID);
   }
-  if (map.current?.getLayer(BLOCK_LAYER_ID_CHILD)) {
-    map.current?.removeLayer(BLOCK_LAYER_ID_CHILD);
+  if (map.getLayer(BLOCK_LAYER_ID_CHILD)) {
+    map.removeLayer(BLOCK_LAYER_ID_CHILD);
   }
-  if (map.current?.getLayer(BLOCK_HOVER_LAYER_ID_CHILD)) {
-    map.current?.removeLayer(BLOCK_HOVER_LAYER_ID_CHILD);
+  if (map.getLayer(BLOCK_HOVER_LAYER_ID_CHILD)) {
+    map.removeLayer(BLOCK_HOVER_LAYER_ID_CHILD);
   }
-  if (map.current?.getSource(BLOCK_SOURCE_ID)) {
-    map.current?.removeSource(BLOCK_SOURCE_ID);
+  if (map.getSource(BLOCK_SOURCE_ID)) {
+    map.removeSource(BLOCK_SOURCE_ID);
   }
 }
 

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -164,7 +164,7 @@ export function getBlocksHoverLayerSpecification(
 }
 
 const addBlockLayers = (
-  map: Map | null,
+  map: Map,
   mapDocument: DocumentObject,
 ) => {
   if (!map || !mapDocument.tiles_s3_path) {
@@ -204,7 +204,7 @@ const addBlockLayers = (
   useMapStore.getState().setMapRenderingState("loaded")
 };
 
-export function removeBlockLayers(map: Map | null) {
+export function removeBlockLayers(map: Map) {
   useMapStore.getState().setMapRenderingState("loading")
   if (map.getLayer(BLOCK_LAYER_ID)) {
     map.removeLayer(BLOCK_LAYER_ID);

--- a/app/src/app/constants/types.ts
+++ b/app/src/app/constants/types.ts
@@ -1,6 +1,7 @@
 import type { MapOptions, MapLibreEvent } from "maplibre-gl";
 
-export type Zone = number | null;
+export type Zone = number;
+export type NullableZone = Zone | null
 
 export type GEOID = string;
 

--- a/app/src/app/store/mapEditSubs.ts
+++ b/app/src/app/store/mapEditSubs.ts
@@ -9,13 +9,13 @@ import { useMapStore as _useMapStore, MapStore } from "./mapStore";
 import { shallowCompareArray } from "../utils/helpers";
 
 const zoneUpdates = ({
-  mapRef,
+  getMapRef,
   zoneAssignments,
   appLoadingState,
 }: Partial<MapStore>) => {
   if (
-    mapRef?.current &&
-    zoneAssignments?.size &&
+    getMapRef?.() &&
+    (zoneAssignments && Object.keys(zoneAssignments)?.length) &&
     appLoadingState === "loaded"
   ) {
     const assignments = FormatAssignments();
@@ -26,11 +26,11 @@ const debouncedZoneUpdate = debounce(zoneUpdates, 25);
 
 export const getMapEditSubs = (useMapStore: typeof _useMapStore) => {
   const sendZonesOnMapRefSub = useMapStore.subscribe(
-    (state) => [state.mapRef, state.zoneAssignments],
+    (state) => [state.getMapRef, state.zoneAssignments],
     () => {
-      const { mapRef, zoneAssignments, appLoadingState } =
+      const { getMapRef, zoneAssignments, appLoadingState } =
         useMapStore.getState();
-      debouncedZoneUpdate({ mapRef, zoneAssignments, appLoadingState });
+      debouncedZoneUpdate({ getMapRef, zoneAssignments, appLoadingState });
     },
     { equalityFn: shallowCompareArray}
   );

--- a/app/src/app/utils/api/apiHandlers.ts
+++ b/app/src/app/utils/api/apiHandlers.ts
@@ -4,7 +4,7 @@ import { useMapStore } from "@/app/store/mapStore";
 
 export const FormatAssignments = () => {
   const assignments = Array.from(
-    useMapStore.getState().zoneAssignments.entries(),
+    Object.entries(useMapStore.getState().zoneAssignments),
   ).map(
     // @ts-ignore
     ([geo_id, zone]: [string, number]): {

--- a/app/src/app/utils/arrays.ts
+++ b/app/src/app/utils/arrays.ts
@@ -1,0 +1,3 @@
+export const onlyUnique = (value: unknown, index: number, self: unknown[]) => {
+    return self.indexOf(value) === index;
+};

--- a/app/src/app/utils/events/handlers.ts
+++ b/app/src/app/utils/events/handlers.ts
@@ -42,32 +42,30 @@ export const SelectMapFeatures = (
   map: Map | null,
   mapStoreRef: MapStore,
 ) => {
-  if (!map) {
-    return
-  }
+  if (map) {
+    let {
+      accumulatedGeoids,
+      accumulatedBlockPopulations,
+      activeTool,
+    } = mapStoreRef;
+    const selectedZone = activeTool === 'eraser' ? null : mapStoreRef.selectedZone
 
-  let {
-    accumulatedGeoids,
-    accumulatedBlockPopulations,
-    activeTool,
-  } = mapStoreRef;
-  const selectedZone = activeTool === 'eraser' ? null : mapStoreRef.selectedZone
-
-  features?.forEach((feature) => {
-    map.setFeatureState(
-      {
-        source: BLOCK_SOURCE_ID,
-        id: feature?.id ?? undefined,
-        sourceLayer: feature.sourceLayer,
-      },
-      { selected: true, zone: selectedZone },
-    );
-  });
-  if (features?.length) {
-    features.forEach((feature) => {
-      accumulatedGeoids.push(feature.properties?.path);
-      accumulatedBlockPopulations[feature.properties?.path] = feature.properties?.total_pop
+    features?.forEach((feature) => {
+      map.setFeatureState(
+        {
+          source: BLOCK_SOURCE_ID,
+          id: feature?.id ?? undefined,
+          sourceLayer: feature.sourceLayer,
+        },
+        { selected: true, zone: selectedZone },
+      );
     });
+    if (features?.length) {
+      features.forEach((feature) => {
+        accumulatedGeoids.push(feature.properties?.path);
+        accumulatedBlockPopulations[feature.properties?.path] = feature.properties?.total_pop
+      });
+    }
   }
   return new Promise<void>((resolve) => {
     // Resolve the Promise after the function completes

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -52,7 +52,7 @@ export const handleMapClick = (
       paintLayers,
     );
 
-    if (sourceLayer && selectedFeatures && map && mapStore) {
+    if (sourceLayer && selectedFeatures?.length && map && mapStore) {
       // select on both the map object and the store
       SelectMapFeatures(selectedFeatures, map, mapStore).then(() => {
         SelectZoneAssignmentFeatures(mapStore);

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -8,7 +8,6 @@ import type {
   MapLayerTouchEvent,
 } from "maplibre-gl";
 import { useMapStore } from "@store/mapStore";
-import { MutableRefObject } from "react";
 import { SelectMapFeatures, SelectZoneAssignmentFeatures } from "./handlers";
 import { ResetMapSelectState } from "@utils/events/handlers";
 import {
@@ -34,11 +33,11 @@ function getLayerIdsToPaint(child_layer: string | undefined | null) {
 /**
  * What happens when the map is clicked on; incomplete implementation
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
- * @param map - MutableRefObject<Map | null>, the maplibre map instance
+ * @param map - Map | null, the maplibre map instance
  */
 export const handleMapClick = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -53,7 +52,7 @@ export const handleMapClick = (
       paintLayers,
     );
 
-    if (sourceLayer) {
+    if (sourceLayer && selectedFeatures && map && mapStore) {
       // select on both the map object and the store
       SelectMapFeatures(selectedFeatures, map, mapStore).then(() => {
         SelectZoneAssignmentFeatures(mapStore);
@@ -66,7 +65,7 @@ export const handleMapClick = (
 
 export const handleMapMouseUp = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -81,34 +80,34 @@ export const handleMapMouseUp = (
 
 export const handleMapMouseDown = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
 
   if (activeTool === "pan") {
     // enable drag pan
-    map.current?.dragPan.enable();
+    map?.dragPan.enable();
   } else if (activeTool === "brush" || activeTool === "eraser") {
     // disable drag pan
-    map.current?.dragPan.disable();
+    map?.dragPan.disable();
     mapStore.setIsPainting(true);
   }
 };
 
 export const handleMapMouseEnter = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {};
 
 export const handleMapMouseOver = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {};
 
 export const handleMapMouseLeave = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -119,12 +118,12 @@ export const handleMapMouseLeave = (
 
 export const handleMapMouseOut = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {};
 
 export const handleMapMouseMove = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
@@ -153,7 +152,7 @@ export const handleMapMouseMove = (
 
 export const handleMapZoom = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {};
 
 export const handleMapIdle = () => {};
@@ -162,11 +161,11 @@ export const handleMapMoveEnd = () => {};
 
 export const handleMapZoomEnd = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {};
 
 export const handleResetMapSelectState = (
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   const sourceLayer = mapStore.mapDocument?.parent_layer;
@@ -179,7 +178,7 @@ export const handleResetMapSelectState = (
 
 export const handleMapContextMenu = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
-  map: MutableRefObject<MapLibreMap | null>,
+  map: MapLibreMap | null,
 ) => {
   const mapStore = useMapStore.getState();
   if (mapStore.activeTool !== "pan") {
@@ -194,7 +193,7 @@ export const handleMapContextMenu = (
     ? INTERACTIVE_LAYERS
     : [BLOCK_HOVER_LAYER_ID];
   const selectedFeatures = mapStore.paintFunction(map, e, 0, paintLayers);
-  if (!selectedFeatures?.length || !map.current || !sourceLayer) return;
+  if (!selectedFeatures?.length || !map || !sourceLayer) return;
 
   setHoverFeatures(selectedFeatures.slice(0, 1));
 
@@ -203,7 +202,7 @@ export const handleMapContextMenu = (
     setHoverFeatures([]);
   };
 
-  map.current.once("movestart", handleClose);
+  map.once("movestart", handleClose);
 
   mapStore.setContextMenu({
     x: e.point.x,

--- a/app/src/app/utils/helpers.ts
+++ b/app/src/app/utils/helpers.ts
@@ -178,7 +178,7 @@ export const mousePos = (
   map: Map | null,
   e: MapLayerMouseEvent | MapLayerTouchEvent,
 ) => {
-  const canvas = map.current?.getCanvasContainer();
+  const canvas = map?.getCanvasContainer();
   if (!canvas) return new Point(0, 0);
   const rect = canvas.getBoundingClientRect();
   return new Point(

--- a/app/src/app/utils/helpers.ts
+++ b/app/src/app/utils/helpers.ts
@@ -7,7 +7,6 @@ import {
   LngLat,
   LngLatLike,
 } from "maplibre-gl";
-import { MutableRefObject } from "react";
 import { Point } from "maplibre-gl";
 import {
   BLOCK_HOVER_LAYER_ID,
@@ -23,12 +22,12 @@ import { MapStore, useMapStore } from "../store/mapStore";
 /**
  * PaintEventHandler
  * A function that takes a map reference, a map event object, and a brush size.
- * @param map - MutableRefObject<Map | null>, the maplibre map instance
+ * @param map - Map | null, the maplibre map instance
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
  * @param brushSize - number, the size of the brush
  */
 export type PaintEventHandler = (
-  map: React.MutableRefObject<Map | null>,
+  map: Map | null,
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   brushSize: number,
   layers?: string[],
@@ -71,39 +70,39 @@ export const boxAroundPoint = (
 /**
  * getFeaturesInBbox
  * Get the features in a bounding box on the map.
- * @param map - MutableRefObject<Map | null>, the maplibre map instance
+ * @param map - Map | null, the maplibre map instance
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
  * @param brushSize - number, the size of the brush
  * @returns MapGeoJSONFeature[] | undefined - An array of map features or undefined
  */
 export const getFeaturesInBbox = (
-  map: MutableRefObject<Map | null>,
+  map: Map | null,
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   brushSize: number,
   layers: string[] = [BLOCK_LAYER_ID],
 ): MapGeoJSONFeature[] | undefined => {
   const bbox = boxAroundPoint(e, brushSize);
 
-  return map.current?.queryRenderedFeatures(bbox, { layers });
+  return map?.queryRenderedFeatures(bbox, { layers });
 };
 
 /**
  * getFeaturesIntersectingCounties
  * Get the features intersecting counties on the map.
- * @param map - MutableRefObject<Map | null>, the maplibre map instance
+ * @param map - Map | null, the maplibre map instance
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
  * @param brushSize - number, the size of the brush
  * @returns MapGeoJSONFeature[] | undefined - An array of map features or undefined
  */
 export const getFeaturesIntersectingCounties = (
-  map: MutableRefObject<Map | null>,
+  map: Map | null,
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   brushSize: number,
   layers: string[] = [BLOCK_LAYER_ID],
 ): MapGeoJSONFeature[] | undefined => {
-  if (!map.current) return;
+  if (!map) return;
 
-  const countyFeatures = map.current.queryRenderedFeatures(e.point, {
+  const countyFeatures = map.queryRenderedFeatures(e.point, {
     layers: ["counties_fill"],
   });
 
@@ -113,10 +112,9 @@ export const getFeaturesIntersectingCounties = (
 
   if (!featureBbox) return;
 
-  const sw = map.current.project(featureBbox[0]);
-  const ne = map.current.project(featureBbox[1]);
-
-  const features = map.current?.queryRenderedFeatures([sw, ne], {
+  const sw = map.project(featureBbox[0]);
+  const ne = map.project(featureBbox[1]);
+  const features = map.queryRenderedFeatures([sw, ne], {
     layers,
   });
 
@@ -172,12 +170,12 @@ const getBoundingBoxFromFeatures = (
 /**
  * mousePos
  * Get the position of the mouse on the map.
- * @param map - MutableRefObject<Map | null>, the maplibre map instance
+ * @param map - Map | null, the maplibre map instance
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
  * @returns Point - The position of the mouse on the map
  */
 export const mousePos = (
-  map: MutableRefObject<Map | null>,
+  map: Map | null,
   e: MapLayerMouseEvent | MapLayerTouchEvent,
 ) => {
   const canvas = map.current?.getCanvasContainer();
@@ -207,18 +205,19 @@ export interface LayerVisibility {
  * @returns {LayerVisibility[]} - An array of objects containing the layer ID and the new visibility state.
  */
 export function toggleLayerVisibility(
-  mapRef: MutableRefObject<maplibregl.Map | null>,
+  mapRef: maplibregl.Map,
   layerIds: string[],
 ): LayerVisibility[] {
+
   const activeLayerIds = getVisibleLayers(mapRef)?.map((layer) => layer.id);
   if (!activeLayerIds) return [];
 
   return layerIds.map((layerId) => {
     if (activeLayerIds && activeLayerIds.includes(layerId)) {
-      mapRef.current?.setLayoutProperty(layerId, "visibility", "none");
+      mapRef.setLayoutProperty(layerId, "visibility", "none");
       return { layerId: layerId, visibility: "none" };
     } else {
-      mapRef.current?.setLayoutProperty(layerId, "visibility", "visible");
+      mapRef.setLayoutProperty(layerId, "visibility", "visible");
       return { layerId: layerId, visibility: "visible" };
     }
   }, {});
@@ -228,10 +227,10 @@ export function toggleLayerVisibility(
  * getVisibleLayers
  * Returning an array of visible layers on the map based on the visibility layout property.
  * i.e. it's not based on what the user actually sees.
- * @param {MutableRefObject<maplibregl.Map>} map - The map reference.
+ * @param {maplibregl.Map} map - The map reference.
  */
-export function getVisibleLayers(map: MutableRefObject<Map | null>) {
-  return map.current?.getStyle().layers.filter((layer) => {
+export function getVisibleLayers(map: Map | null) {
+  return map?.getStyle().layers.filter((layer) => {
     return layer.layout?.visibility === "visible";
   });
 }
@@ -239,24 +238,22 @@ export function getVisibleLayers(map: MutableRefObject<Map | null>) {
 export type ColorZoneAssignmentsState = [
   MapStore["zoneAssignments"],
   MapStore["mapDocument"],
-  MapStore["mapRef"],
+  MapStore["getMapRef"],
   MapStore["shatterIds"],
   MapStore["appLoadingState"],
   MapStore["mapRenderingState"],
 ];
 
-export const getMap = (_mapRef?: MapStore["mapRef"]) => {
-  const mapRef = _mapRef || useMapStore.getState().mapRef;
+export const getMap = (_getMapRef?: MapStore["getMapRef"]) => {
+  const mapRef = _getMapRef?.() || useMapStore.getState().getMapRef();
   if (
-    mapRef?.current &&
-    mapRef.current
-      ?.getStyle()
+    mapRef?.getStyle()
       .layers.findIndex((layer) => layer.id === BLOCK_HOVER_LAYER_ID) !== -1
   ) {
     return null;
   }
 
-  return mapRef as MutableRefObject<maplibregl.Map>;
+  return mapRef as maplibregl.Map;
 };
 
 /**
@@ -285,15 +282,15 @@ export const colorZoneAssignments = (
   const [
     zoneAssignments,
     mapDocument,
-    mapRef,
+    getMapRef,
     _,
     appLoadingState,
     mapRenderingState,
   ] = state;
   const previousZoneAssignments = previousState?.[0] || null;
-
+  const mapRef = getMapRef()
   if (
-    !mapRef?.current ||
+    !mapRef ||
     !mapDocument ||
     appLoadingState !== "loaded" ||
     mapRenderingState !== "loaded"
@@ -303,17 +300,17 @@ export const colorZoneAssignments = (
   const isInitialRender =
     previousState?.[4] !== "loaded" || previousState?.[5] !== "loaded";
 
-  zoneAssignments.forEach((zone, id) => {
+  Object.entries(zoneAssignments).forEach(([id, zone]) => {
     if (
-      !isInitialRender &&
-      previousZoneAssignments?.get(id) === zoneAssignments.get(id)
+      (id && !isInitialRender &&
+      previousZoneAssignments?.[id] === zoneAssignments[id]) || (!id)
     ) {
       return;
     }
 
     // This is awful
     // we need information on whether an assignment is parent or child
-    const isParent = id.toString().includes("vtd");
+    const isParent = id?.toString().includes("vtd");
     const sourceLayer = isParent
       ? mapDocument.parent_layer
       : mapDocument.child_layer;
@@ -322,7 +319,7 @@ export const colorZoneAssignments = (
       return;
     }
 
-    mapRef.current?.setFeatureState(
+    mapRef?.setFeatureState(
       {
         source: BLOCK_SOURCE_ID,
         id,
@@ -362,12 +359,12 @@ export const setZones = (
   parent: string,
   children: Set<string>,
 ) => {
-  const zone = zoneAssignments.get(parent);
+  const zone = zoneAssignments[parent]
   if (zone) {
     children.forEach((childId) => {
-      zoneAssignments.set(childId, zone);
+      zoneAssignments[childId] = zone
     });
-    zoneAssignments.delete(parent);
+    zoneAssignments[parent] = null
   }
 };
 


### PR DESCRIPTION
Zustand is a generally good state management library but we hit a couple edge cases:

1. React MutableRefs of an HTML element break redux dev tools, so the current `MapStore['mapRef']` makes observing the state harder
2. On de-focus from the tab/window, the state serializes and goes to sleep, but that does not work for JS classes like `Set` or `Map` that do not serialize

To resolve this, we need to do one of the following:
1. Swap to a more robust state library
2. Refactor slightly to use vanilla JS objects and access the map ref slightly differently
3. Hack Zustand in some slightly non-standard ways

## Description
This PR takes the second approach and swaps out `Set` and `Map` for `Array`s and `Record`s (objects) repsectively. Additionally, this swaps `mapRef` to `getMapRef`, which can be set as a function that returns the map object, rather than a direct reference. 

## Reviewers
- Primary:
- Secondary:

## Checklist
- [ ] Refactor the state to no longer use set/maps
- [ ] Refactor mapRef to getMapRef
- [ ] Update all instances referring to old methods like `.size` or `.get`
- [ ] Ensure items are not being duplicated (eg. set automatically de-duplicates list)
- [ ] Sanity check performance implications
- [ ] Test interactions 

## Screenshots (if applicable):
