### PR TITLE
Implement undo/redo with zundo

### DIFF
--- a/.github/workflows/fly-deploy-pr.yml
+++ b/.github/workflows/fly-deploy-pr.yml
@@ -1,4 +1,4 @@
-name: Fly Deploy Disctictr V2 Pull Request app
+name: Fly Deploy Districtr V2 Pull Request app
 on:
     pull_request:
         types: [opened, reopened, synchronize, closed]

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,6 +30,7 @@
         "react-resizable": "^3.0.5",
         "recharts": "^2.12.7",
         "superjson": "^2.2.1",
+        "zundo": "^2.2.0",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -13251,6 +13252,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zundo": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.2.0.tgz",
+      "integrity": "sha512-WYCiSO3Uqm7TN9KtT3dpfhOuAS1t5CixjYJuPfVMKl88BZVpP449XtXeiuHWEtRAfYE3yFvRkFCgAThm7v3QuQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
       }
     },
     "node_modules/zustand": {

--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,7 @@
     "react-resizable": "^3.0.5",
     "recharts": "^2.12.7",
     "superjson": "^2.2.1",
+    "zundo": "^2.2.0",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import {Box, Flex, Heading} from '@radix-ui/themes';
 import {MapModeSelector} from './MapModeSelector';
 import {ColorPicker} from './ColorPicker';
 import {ResetMapButton} from './ResetMapButton';
+import { UndoRedoButton } from "./UndoRedoButton";
 import {GerryDBViewSelector} from './GerryDBViewSelector';
 import {useMapStore} from '@/app/store/mapStore';
 import PaintByCounty from './PaintByCounty';

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -16,12 +16,12 @@ export default function SidebarComponent() {
   return (
     <Box
       p="3"
-      className="w-full z-10 shadow-md flex-none overflow-y-auto 
+      className="w-full z-10 shadow-md flex-none overflow-y-auto
       border-t lg:border-t-0
       lg:h-screen lg:max-w-sidebar lg:w-sidebar
        landscape:border-t-0
       landscape:h-screen landscape:max-w-[40vw] landscape:w-[40vw]
-      
+
       "
     >
       <Flex direction="column" gap="3">
@@ -31,7 +31,7 @@ export default function SidebarComponent() {
         <GerryDBViewSelector />
         <MapModeSelector />
         {activeTool === "brush" || activeTool === "eraser" ? (
-          <div 
+          <div
           className="gap-4 lg:gap-0 landscape:gap-0
           flex flex-row-reverse lg:flex-col landscape:flex-col
           justify-around
@@ -53,6 +53,10 @@ export default function SidebarComponent() {
           </div>
         ) : null}
         <ResetMapButton />
+        <Flex direction="row" gap="3">
+          <UndoRedoButton isRedo={false} />
+          <UndoRedoButton isRedo />
+        </Flex>
         <Box
           display={{
             initial: "none",

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -3,14 +3,16 @@ import { Button } from "@radix-ui/themes";
 import { ResetIcon } from "@radix-ui/react-icons";
 import type { TemporalState } from "zundo";
 
+import type { MapStore } from "../../store/mapStore";
+
 export function UndoRedoButton({ isRedo = false }) {
-  const mapStore = useMapStore.getState() as TemporalState;
+  const mapStore = useMapStore.temporal.getState() as TemporalState<MapStore>;
 
   const handleClickUndoRedo = () => {
     if (isRedo) {
-      mapStore.redo(1);
+      mapStore.redo();
     } else {
-      mapStore.undo(1);
+      mapStore.undo();
     }
   };
 

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -1,9 +1,10 @@
 import { useMapStore } from "@/app/store/mapStore";
 import { Button } from "@radix-ui/themes";
 import { ResetIcon } from "@radix-ui/react-icons";
+import type { TemporalState } from "zundo";
 
 export function UndoRedoButton({ isRedo = false }) {
-  const mapStore = useMapStore.getState();
+  const mapStore = useMapStore.getState() as TemporalState;
 
   const handleClickUndoRedo = () => {
     if (isRedo) {

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -1,0 +1,32 @@
+import { useMapStore } from "@/app/store/mapStore";
+import { Button } from "@radix-ui/themes";
+import { ResetIcon } from "@radix-ui/react-icons";
+
+export function UndoRedoButton({ isRedo = false }) {
+  const mapStore = useMapStore.getState();
+
+  const handleClickUndoRedo = () => {
+    if (isRedo) {
+      mapStore.redo(1);
+    } else {
+      mapStore.undo(1);
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleClickUndoRedo}
+      variant="outline"
+      disabled={
+        isRedo
+          ? mapStore.futureStates.length === 0
+          : mapStore.pastStates.length === 0
+      }
+    >
+      <div style={{ transform: isRedo ? "rotateY(180deg)" : "" }}>
+        <ResetIcon />
+      </div>
+      {isRedo ? "Redo" : "Undo"}
+    </Button>
+  );
+}

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -6,7 +6,7 @@ import { useStore } from "zustand";
 
 /* convert zundo to a React hook */
 const useTemporalStore = <T,>(
-  selector: (state: TemporalState<StoreState>) => T,
+  selector: (state: TemporalState<MapStore>) => T,
   equality?: (a: T, b: T) => boolean,
 ) => useStore(useMapStore.temporal, selector, equality);
 

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -1,20 +1,27 @@
-import { useCallback } from "react";
 import { useMapStore, type MapStore } from "@/app/store/mapStore";
 import { Button } from "@radix-ui/themes";
 import { ResetIcon } from "@radix-ui/react-icons";
 import type { TemporalState } from "zundo";
+import { useStore } from "zustand";
+
+/* convert zundo to a React hook */
+const useTemporalStore = <T,>(
+  selector: (state: TemporalState<StoreState>) => T,
+  equality?: (a: T, b: T) => boolean,
+) => useStore(useMapStore.temporal, selector, equality);
 
 export function UndoRedoButton({ isRedo = false }) {
-  const { futureStates, pastStates, redo, undo } = useMapStore.temporal.getState();
-  // as TemporalState<MapStore>
+  const { futureStates, pastStates, redo, undo } = useTemporalStore(
+    (state) => state,
+  ); // TemporalState<MapStore>
 
-  const handleClickUndoRedo = useCallback(() => {
+  const handleClickUndoRedo = () => {
     if (isRedo) {
       redo();
     } else {
       undo();
     }
-  }, [redo, undo, isRedo]);
+  };
 
   return (
     <Button

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -30,7 +30,7 @@ export function UndoRedoButton({ isRedo = false }) {
       disabled={
         isRedo
           ? futureStates.length === 0
-          : pastStates.length === 0
+          : pastStates.filter((state) => state.zoneAssignments?.size).length <= 1
       }
     >
       <div style={{ transform: isRedo ? "rotateY(180deg)" : "" }}>

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -1,12 +1,12 @@
-import { useMapStore, type MapStore } from "@/app/store/mapStore";
 import { Button } from "@radix-ui/themes";
 import { ResetIcon } from "@radix-ui/react-icons";
 import type { TemporalState } from "zundo";
 import { useStore } from "zustand";
+import { useMapStore, type MapStore } from "@/app/store/mapStore";
 
 /* convert zundo to a React hook */
 const useTemporalStore = <T,>(
-  selector: (state: TemporalState<MapStore>) => T,
+  selector: (state: TemporalState<Partial<MapStore>>) => T,
   equality?: (a: T, b: T) => boolean,
 ) => useStore(useMapStore.temporal, selector, equality);
 

--- a/app/src/app/components/sidebar/UndoRedoButton.tsx
+++ b/app/src/app/components/sidebar/UndoRedoButton.tsx
@@ -1,20 +1,20 @@
-import { useMapStore } from "@/app/store/mapStore";
+import { useCallback } from "react";
+import { useMapStore, type MapStore } from "@/app/store/mapStore";
 import { Button } from "@radix-ui/themes";
 import { ResetIcon } from "@radix-ui/react-icons";
 import type { TemporalState } from "zundo";
 
-import type { MapStore } from "../../store/mapStore";
-
 export function UndoRedoButton({ isRedo = false }) {
-  const mapStore = useMapStore.temporal.getState() as TemporalState<MapStore>;
+  const { futureStates, pastStates, redo, undo } = useMapStore.temporal.getState();
+  // as TemporalState<MapStore>
 
-  const handleClickUndoRedo = () => {
+  const handleClickUndoRedo = useCallback(() => {
     if (isRedo) {
-      mapStore.redo();
+      redo();
     } else {
-      mapStore.undo();
+      undo();
     }
-  };
+  }, [redo, undo, isRedo]);
 
   return (
     <Button
@@ -22,8 +22,8 @@ export function UndoRedoButton({ isRedo = false }) {
       variant="outline"
       disabled={
         isRedo
-          ? mapStore.futureStates.length === 0
-          : mapStore.pastStates.length === 0
+          ? futureStates.length === 0
+          : pastStates.length === 0
       }
     >
       <div style={{ transform: isRedo ? "rotateY(180deg)" : "" }}>

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -149,7 +149,7 @@ export const useMapStore = create(
               return;
             }
             get().setFreshMap(true);
-            //get().resetZoneAssignments();
+            get().resetZoneAssignments();
             get().upcertUserMap({
               mapDocument,
             })
@@ -381,14 +381,22 @@ export const useMapStore = create(
       persistOptions
     ),
     {
+      diff: (pastState: Partial<MapStore>, currentState: Partial<MapStore>) => {
+        currentState.zoneAssignments.keys().forEach((geoid) => {
+          if (!pastState.zoneAssignments.has(geoid)) {
+            pastState.zoneAssignments.set(geoid, null);
+          }
+        });
+        return pastState as Partial<MapStore>;
+      },
       equality: (pastState, currentState) => {
         return (pastState.zoneAssignments === currentState.zoneAssignments) &&
         (pastState.zoneAssignments.size === currentState.zoneAssignments.size);
       },
       limit: 7,
-      partialize: (state) => {
+      partialize: (state: Partial<MapStore>) => {
         const { zoneAssignments } = state;
-        return { zoneAssignments };
+        return { zoneAssignments } as Partial<MapStore>;
       }
     }
   )

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -382,37 +382,13 @@ export const useMapStore = create(
     ),
     {
       equality: (pastState, currentState) => {
-        return (pastState.mapDocument?.parent_layer === currentState.mapDocument?.parent_layer) &&
-        (pastState.zoneAssignments === currentState.zoneAssignments);
+        return (pastState.zoneAssignments === currentState.zoneAssignments) &&
+        (pastState.zoneAssignments.size === currentState.zoneAssignments.size);
       },
       limit: 7,
-      onSave: (pastState, currentState) => {
-        if (currentState.isDrawing) {
-          return;
-        }
-
-        const map = currentState.getMapRef();
-        const sourceLayer = currentState.mapDocument?.parent_layer;
-
-        const changedAssignments = new Map<string, Zone[]>();
-        currentState.zoneAssignments.keys().forEach((geoid) => {
-          const prevZone = pastState.zoneAssignments.get(geoid);
-          const currentZone = currentState.zoneAssignments.get(geoid);
-          if (prevZone !== currentZone) {
-            map?.setFeatureState(
-              {
-                source: BLOCK_SOURCE_ID,
-                id: geoid,
-                sourceLayer,
-              },
-              { zone: currentZone },
-            );
-          }
-        });
-      },
       partialize: (state) => {
-        const { getMapRef, isDrawing, mapDocument, zoneAssignments } = state;
-        return { getMapRef, isDrawing, mapDocument, zoneAssignments };
+        const { zoneAssignments } = state;
+        return { zoneAssignments };
       }
     }
   )

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -382,11 +382,12 @@ export const useMapStore = create(
     ),
     {
       diff: (pastState: Partial<MapStore>, currentState: Partial<MapStore>) => {
-        currentState.zoneAssignments.keys().forEach((geoid) => {
+        if (!currentState.zoneAssignments || !pastState.zoneAssignments) return pastState;
+        for (const geoid of currentState.zoneAssignments.keys()) {
           if (!pastState.zoneAssignments.has(geoid)) {
             pastState.zoneAssignments.set(geoid, null);
           }
-        });
+        }
         return pastState as Partial<MapStore>;
       },
       equality: (pastState, currentState) => {
@@ -394,7 +395,8 @@ export const useMapStore = create(
         (pastState.zoneAssignments.size === currentState.zoneAssignments.size);
       },
       limit: 7,
-      partialize: (state: Partial<MapStore>) => {
+      // @ts-ignore: save only partial store
+      partialize: (state) => {
         const { zoneAssignments } = state;
         return { zoneAssignments } as Partial<MapStore>;
       }

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -119,271 +119,275 @@ const initialLoadingState =
     : "initializing";
 
 export const useMapStore = create(
-  persist(
-    temporal(
-    devwrapper(
-      subscribeWithSelector<MapStore>((set, get) => ({
-        appLoadingState: initialLoadingState,
-        setAppLoadingState: (appLoadingState) => set({ appLoadingState }),
-        mapRenderingState: "initializing",
-        setMapRenderingState: (mapRenderingState) => set({ mapRenderingState }),
-        getMapRef: () => null,
-        setMapRef: (mapRef) => {
-          set({
-            getMapRef: () => mapRef.current,
-            appLoadingState:
-              initialLoadingState === "initializing"
-                ? "loaded"
-                : get().appLoadingState,
-          });
-        },
-        mapLock: false,
-        setMapLock: (mapLock) => set({ mapLock }),
-        mapViews: { isPending: true },
-        setMapViews: (mapViews) => set({ mapViews }),
-        mapDocument: null,
-        setMapDocument: (mapDocument) => {
-          const currentMapDocument = get().mapDocument;
-          if (currentMapDocument?.document_id === mapDocument.document_id) {
-            return;
-          }
-          get().setFreshMap(true);
-          //get().resetZoneAssignments();
-          get().upcertUserMap({
-            mapDocument,
-          })
-          set({
-            mapDocument: mapDocument,
-            shatterIds: { parents: new Set(), children: new Set() },
-          });
-        },
-        upcertUserMap: ({ mapDocument, userMapData, userMapDocumentId }) => {
-          let userMaps = [ ...get().userMaps ];
-          const mapViews = get().mapViews.data
-          if (mapDocument?.document_id && mapViews) {
-            const documentIndex = userMaps.findIndex(
-              (f) => f.document_id === mapDocument?.document_id
-            );
-            const documentInfo = mapViews.find(
-              (view) => view.gerrydb_table_name === mapDocument.gerrydb_table
-            );
-            if (documentIndex !== -1) {
-              userMaps[documentIndex] = {
-                ...documentInfo,
-                ...userMaps[documentIndex],
-                ...mapDocument,
-              };
-            } else {
-              userMaps = [{ ...mapDocument, ...documentInfo }, ...userMaps];
-            }
-          } else if (userMapDocumentId) {
-            const i = userMaps.findIndex(map => map.document_id === userMapDocumentId)
-            if (userMapData) {
-              userMaps.splice(i, 1, userMapData); // Replace the map at index i with the new data
-            } else {
-              const urlParams = new URL(window.location.href).searchParams;
-              urlParams.delete("document_id"); // Remove the document_id parameter
-              window.history.pushState({}, '', window.location.pathname + '?' + urlParams.toString()); // Update the URL without document_id
-              userMaps.splice(i, 1); 
-            }
-          }
-          set({
-            userMaps,
-          });
-        },
-        shatterIds: {
-          parents: new Set(),
-          children: new Set(),
-        },
-        handleShatter: async (document_id, geoids) => {
-          set({ mapLock: true });
-          const shatterResult = await patchShatter.mutate({
-            document_id,
-            geoids,
-          });
-
-          const zoneAssignments = new Map(get().zoneAssignments);
-          const shatterIds = get().shatterIds;
-
-          let existingParents = new Set(shatterIds.parents);
-          let existingChildren = new Set(shatterIds.children);
-
-          const newParent = shatterResult.parents.geoids;
-          const newChildren = new Set(
-            shatterResult.children.map((child) => child.geo_id)
-          );
-
-          const multipleShattered = shatterResult.parents.geoids.length > 1;
-          if (!multipleShattered) {
-            setZones(zoneAssignments, newParent[0], newChildren);
-          } else {
-            // todo handle multiple shattered case
-          }
-          newParent.forEach((parent) => existingParents.add(parent));
-          // there may be a faster way to do this
-          [newChildren].forEach(
-            (children) =>
-              (existingChildren = new Set([...existingChildren, ...children]))
-          );
-
-          set({
-            shatterIds: {
-              parents: existingParents,
-              children: existingChildren,
-            },
-            zoneAssignments,
-          });
-        },
-        setShatterIds: (
-          existingParents,
-          existingChildren,
-          newParent,
-          newChildren,
-          multipleShattered
-        ) => {
-          const zoneAssignments = new Map(get().zoneAssignments);
-
-          if (!multipleShattered) {
-            setZones(zoneAssignments, newParent[0], newChildren[0]);
-          } else {
-            // todo handle multiple shattered case
-          }
-          newParent.forEach((parent) => existingParents.add(parent));
-          // there may be a faster way to do this
-          newChildren.forEach(
-            (children) =>
-              (existingChildren = new Set([...existingChildren, ...children]))
-          );
-
-          set({
-            shatterIds: {
-              parents: existingParents,
-              children: existingChildren,
-            },
-            zoneAssignments,
-          });
-        },
-        hoverFeatures: [],
-        setHoverFeatures: (_features) => {
-          const hoverFeatures = _features
-            ? _features.map((f) => ({
-                source: f.source,
-                sourceLayer: f.sourceLayer,
-                id: f.id,
-              }))
-            : [];
-
-          set({ hoverFeatures });
-        },
-        mapOptions: {
-          center: [-98.5795, 39.8283],
-          zoom: 3,
-          pitch: 0,
-          bearing: 0,
-          container: "",
-        },
-        setMapOptions: (options) => set({ mapOptions: options }),
-        activeTool: "pan",
-        setActiveTool: (tool) => set({ activeTool: tool }),
-        spatialUnit: "tract",
-        setSpatialUnit: (unit) => set({ spatialUnit: unit }),
-        selectedZone: 1,
-        setSelectedZone: (zone) => set({ selectedZone: zone }),
-        zoneAssignments: new Map(),
-        accumulatedGeoids: new Set<string>(),
-        setAccumulatedGeoids: (accumulatedGeoids) => set({ accumulatedGeoids }),
-        setZoneAssignments: (zone, geoids) => {
-          const zoneAssignments = get().zoneAssignments;
-          const newZoneAssignments = new Map(zoneAssignments);
-          geoids.forEach((geoid) => {
-            newZoneAssignments.set(geoid, zone);
-          });
-          set({
-            zoneAssignments: newZoneAssignments,
-            accumulatedGeoids: new Set<string>(),
-          });
-        },
-        loadZoneAssignments: (assignments) => {
-          const zoneAssignments = new Map<string, number>();
-          const shatterIds = {
-            parents: new Set<string>(),
-            children: new Set<string>(),
-          };
-          assignments.forEach((assignment) => {
-            zoneAssignments.set(assignment.geo_id, assignment.zone);
-            if (assignment.parent_path) {
-              shatterIds.parents.add(assignment.parent_path);
-              shatterIds.children.add(assignment.geo_id);
-            }
-          });
-          set({ zoneAssignments, shatterIds, appLoadingState: "loaded" });
-        },
-        accumulatedBlockPopulations: new Map<string, number>(),
-        resetAccumulatedBlockPopulations: () =>
-          set({ accumulatedBlockPopulations: new Map<string, number>() }),
-        zonePopulations: new Map(),
-        setZonePopulations: (zone, population) =>
-          set((state) => {
-            const newZonePopulations = new Map(state.zonePopulations);
-            newZonePopulations.set(zone, population);
-            return {
-              zonePopulations: newZonePopulations,
-            };
-          }),
-        resetZoneAssignments: () => set({ zoneAssignments: new Map() }),
-        brushSize: 50,
-        setBrushSize: (size) => set({ brushSize: size }),
-        isPainting: false,
-        setIsPainting: (isPainting) => set({ isPainting }),
-        paintFunction: getFeaturesInBbox,
-        setPaintFunction: (paintFunction) => set({ paintFunction }),
-        clearMapEdits: () =>
-          set({
-            zoneAssignments: new Map(),
-            accumulatedGeoids: new Set<string>(),
-            selectedZone: 1,
-          }),
-        freshMap: false,
-        setFreshMap: (resetMap) => set({ freshMap: resetMap }),
-        mapMetrics: null,
-        setMapMetrics: (metrics) => set({ mapMetrics: metrics }),
-        visibleLayerIds: ["counties_boundary", "counties_labels"],
-        setVisibleLayerIds: (layerIds) => set({ visibleLayerIds: layerIds }),
-        addVisibleLayerIds: (layerIds: string[]) => {
-          set((state) => {
-            const newVisibleLayerIds = new Set(state.visibleLayerIds);
-            layerIds.forEach((layerId) => {
-              newVisibleLayerIds.add(layerId);
+  temporal(
+    persist(
+      devwrapper(
+        subscribeWithSelector<MapStore>((set, get) => ({
+          appLoadingState: initialLoadingState,
+          setAppLoadingState: (appLoadingState) => set({ appLoadingState }),
+          mapRenderingState: "initializing",
+          setMapRenderingState: (mapRenderingState) => set({ mapRenderingState }),
+          getMapRef: () => null,
+          setMapRef: (mapRef) => {
+            set({
+              getMapRef: () => mapRef.current,
+              appLoadingState:
+                initialLoadingState === "initializing"
+                  ? "loaded"
+                  : get().appLoadingState,
             });
-            return { visibleLayerIds: Array.from(newVisibleLayerIds) };
-          });
-        },
-        updateVisibleLayerIds: (layerVisibilities: LayerVisibility[]) => {
-          set((state) => {
-            const newVisibleLayerIds = new Set(state.visibleLayerIds);
-            layerVisibilities.forEach((layerVisibility) => {
-              if (layerVisibility.visibility === "visible") {
-                newVisibleLayerIds.add(layerVisibility.layerId);
+          },
+          mapLock: false,
+          setMapLock: (mapLock) => set({ mapLock }),
+          mapViews: { isPending: true },
+          setMapViews: (mapViews) => set({ mapViews }),
+          mapDocument: null,
+          setMapDocument: (mapDocument) => {
+            const currentMapDocument = get().mapDocument;
+            if (currentMapDocument?.document_id === mapDocument.document_id) {
+              return;
+            }
+            get().setFreshMap(true);
+            //get().resetZoneAssignments();
+            get().upcertUserMap({
+              mapDocument,
+            })
+            set({
+              mapDocument: mapDocument,
+              shatterIds: { parents: new Set(), children: new Set() },
+            });
+          },
+          upcertUserMap: ({ mapDocument, userMapData, userMapDocumentId }) => {
+            let userMaps = [ ...get().userMaps ];
+            const mapViews = get().mapViews.data
+            if (mapDocument?.document_id && mapViews) {
+              const documentIndex = userMaps.findIndex(
+                (f) => f.document_id === mapDocument?.document_id
+              );
+              const documentInfo = mapViews.find(
+                (view) => view.gerrydb_table_name === mapDocument.gerrydb_table
+              );
+              if (documentIndex !== -1) {
+                userMaps[documentIndex] = {
+                  ...documentInfo,
+                  ...userMaps[documentIndex],
+                  ...mapDocument,
+                };
               } else {
-                newVisibleLayerIds.delete(layerVisibility.layerId);
+                userMaps = [{ ...mapDocument, ...documentInfo }, ...userMaps];
+              }
+            } else if (userMapDocumentId) {
+              const i = userMaps.findIndex(map => map.document_id === userMapDocumentId)
+              if (userMapData) {
+                userMaps.splice(i, 1, userMapData); // Replace the map at index i with the new data
+              } else {
+                const urlParams = new URL(window.location.href).searchParams;
+                urlParams.delete("document_id"); // Remove the document_id parameter
+                window.history.pushState({}, '', window.location.pathname + '?' + urlParams.toString()); // Update the URL without document_id
+                userMaps.splice(i, 1);
+              }
+            }
+            set({
+              userMaps,
+            });
+          },
+          shatterIds: {
+            parents: new Set(),
+            children: new Set(),
+          },
+          handleShatter: async (document_id, geoids) => {
+            set({ mapLock: true });
+            const shatterResult = await patchShatter.mutate({
+              document_id,
+              geoids,
+            });
+
+            const zoneAssignments = new Map(get().zoneAssignments);
+            const shatterIds = get().shatterIds;
+
+            let existingParents = new Set(shatterIds.parents);
+            let existingChildren = new Set(shatterIds.children);
+
+            const newParent = shatterResult.parents.geoids;
+            const newChildren = new Set(
+              shatterResult.children.map((child) => child.geo_id)
+            );
+
+            const multipleShattered = shatterResult.parents.geoids.length > 1;
+            if (!multipleShattered) {
+              setZones(zoneAssignments, newParent[0], newChildren);
+            } else {
+              // todo handle multiple shattered case
+            }
+            newParent.forEach((parent) => existingParents.add(parent));
+            // there may be a faster way to do this
+            [newChildren].forEach(
+              (children) =>
+                (existingChildren = new Set([...existingChildren, ...children]))
+            );
+
+            set({
+              shatterIds: {
+                parents: existingParents,
+                children: existingChildren,
+              },
+              zoneAssignments,
+            });
+          },
+          setShatterIds: (
+            existingParents,
+            existingChildren,
+            newParent,
+            newChildren,
+            multipleShattered
+          ) => {
+            const zoneAssignments = new Map(get().zoneAssignments);
+
+            if (!multipleShattered) {
+              setZones(zoneAssignments, newParent[0], newChildren[0]);
+            } else {
+              // todo handle multiple shattered case
+            }
+            newParent.forEach((parent) => existingParents.add(parent));
+            // there may be a faster way to do this
+            newChildren.forEach(
+              (children) =>
+                (existingChildren = new Set([...existingChildren, ...children]))
+            );
+
+            set({
+              shatterIds: {
+                parents: existingParents,
+                children: existingChildren,
+              },
+              zoneAssignments,
+            });
+          },
+          hoverFeatures: [],
+          setHoverFeatures: (_features) => {
+            const hoverFeatures = _features
+              ? _features.map((f) => ({
+                  source: f.source,
+                  sourceLayer: f.sourceLayer,
+                  id: f.id,
+                }))
+              : [];
+
+            set({ hoverFeatures });
+          },
+          mapOptions: {
+            center: [-98.5795, 39.8283],
+            zoom: 3,
+            pitch: 0,
+            bearing: 0,
+            container: "",
+          },
+          setMapOptions: (options) => set({ mapOptions: options }),
+          activeTool: "pan",
+          setActiveTool: (tool) => set({ activeTool: tool }),
+          spatialUnit: "tract",
+          setSpatialUnit: (unit) => set({ spatialUnit: unit }),
+          selectedZone: 1,
+          setSelectedZone: (zone) => set({ selectedZone: zone }),
+          zoneAssignments: new Map(),
+          accumulatedGeoids: new Set<string>(),
+          setAccumulatedGeoids: (accumulatedGeoids) => set({ accumulatedGeoids }),
+          setZoneAssignments: (zone, geoids) => {
+            const zoneAssignments = get().zoneAssignments;
+            const newZoneAssignments = new Map(zoneAssignments);
+            geoids.forEach((geoid) => {
+              newZoneAssignments.set(geoid, zone);
+            });
+            set({
+              zoneAssignments: newZoneAssignments,
+              accumulatedGeoids: new Set<string>(),
+            });
+          },
+          loadZoneAssignments: (assignments) => {
+            const zoneAssignments = new Map<string, number>();
+            const shatterIds = {
+              parents: new Set<string>(),
+              children: new Set<string>(),
+            };
+            assignments.forEach((assignment) => {
+              zoneAssignments.set(assignment.geo_id, assignment.zone);
+              if (assignment.parent_path) {
+                shatterIds.parents.add(assignment.parent_path);
+                shatterIds.children.add(assignment.geo_id);
               }
             });
-            return { visibleLayerIds: Array.from(newVisibleLayerIds) };
-          });
-        },
-        contextMenu: null,
-        setContextMenu: (contextMenu) => set({ contextMenu }),
-        userMaps: [],
-        setUserMaps: (userMaps) => set({ userMaps }),
-      }),
-   ),
-  { onSave: console.log, limit: 7, partialize: (state) => {
-  const { zoneAssignments } = state;
-  return { zoneAssignments };
-}}
+            set({ zoneAssignments, shatterIds, appLoadingState: "loaded" });
+          },
+          accumulatedBlockPopulations: new Map<string, number>(),
+          resetAccumulatedBlockPopulations: () =>
+            set({ accumulatedBlockPopulations: new Map<string, number>() }),
+          zonePopulations: new Map(),
+          setZonePopulations: (zone, population) =>
+            set((state) => {
+              const newZonePopulations = new Map(state.zonePopulations);
+              newZonePopulations.set(zone, population);
+              return {
+                zonePopulations: newZonePopulations,
+              };
+            }),
+          resetZoneAssignments: () => set({ zoneAssignments: new Map() }),
+          brushSize: 50,
+          setBrushSize: (size) => set({ brushSize: size }),
+          isPainting: false,
+          setIsPainting: (isPainting) => set({ isPainting }),
+          paintFunction: getFeaturesInBbox,
+          setPaintFunction: (paintFunction) => set({ paintFunction }),
+          clearMapEdits: () =>
+            set({
+              zoneAssignments: new Map(),
+              accumulatedGeoids: new Set<string>(),
+              selectedZone: 1,
+            }),
+          freshMap: false,
+          setFreshMap: (resetMap) => set({ freshMap: resetMap }),
+          mapMetrics: null,
+          setMapMetrics: (metrics) => set({ mapMetrics: metrics }),
+          visibleLayerIds: ["counties_boundary", "counties_labels"],
+          setVisibleLayerIds: (layerIds) => set({ visibleLayerIds: layerIds }),
+          addVisibleLayerIds: (layerIds: string[]) => {
+            set((state) => {
+              const newVisibleLayerIds = new Set(state.visibleLayerIds);
+              layerIds.forEach((layerId) => {
+                newVisibleLayerIds.add(layerId);
+              });
+              return { visibleLayerIds: Array.from(newVisibleLayerIds) };
+            });
+          },
+          updateVisibleLayerIds: (layerVisibilities: LayerVisibility[]) => {
+            set((state) => {
+              const newVisibleLayerIds = new Set(state.visibleLayerIds);
+              layerVisibilities.forEach((layerVisibility) => {
+                if (layerVisibility.visibility === "visible") {
+                  newVisibleLayerIds.add(layerVisibility.layerId);
+                } else {
+                  newVisibleLayerIds.delete(layerVisibility.layerId);
+                }
+              });
+              return { visibleLayerIds: Array.from(newVisibleLayerIds) };
+            });
+          },
+          contextMenu: null,
+          setContextMenu: (contextMenu) => set({ contextMenu }),
+          userMaps: [],
+          setUserMaps: (userMaps) => set({ userMaps }),
+        }))
+      ),
+      persistOptions
     ),
-    persistOptions
-)  )
+    {
+      limit: 7,
+      onSave: (s) => console.log(s),
+      partialize: (state) => {
+        const { zoneAssignments } = state;
+        return { zoneAssignments };
+      }
+    }
+  )
 );
 
 // these need to initialize after the map store

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -2,6 +2,7 @@
 import type { MapGeoJSONFeature, MapOptions } from "maplibre-gl";
 import { create } from "zustand";
 import { devtools, subscribeWithSelector, persist } from "zustand/middleware";
+import { temporal } from "zundo";
 import type {
   ActiveTool,
   MapFeatureInfo,
@@ -119,6 +120,7 @@ const initialLoadingState =
 
 export const useMapStore = create(
   persist(
+    temporal(
     devwrapper(
       subscribeWithSelector<MapStore>((set, get) => ({
         appLoadingState: initialLoadingState,
@@ -146,7 +148,7 @@ export const useMapStore = create(
             return;
           }
           get().setFreshMap(true);
-          get().resetZoneAssignments();
+          //get().resetZoneAssignments();
           get().upcertUserMap({
             mapDocument,
           })
@@ -373,10 +375,15 @@ export const useMapStore = create(
         setContextMenu: (contextMenu) => set({ contextMenu }),
         userMaps: [],
         setUserMaps: (userMaps) => set({ userMaps }),
-      }))
+      }),
+   ),
+  { onSave: console.log, limit: 7, partialize: (state) => {
+  const { zoneAssignments } = state;
+  return { zoneAssignments };
+}}
     ),
     persistOptions
-  )
+)  )
 );
 
 // these need to initialize after the map store


### PR DESCRIPTION
Testing if we can replace #118 with the zundo plugin , and whether GitHub Actions will produce a test build for this
- Adds undo/redo buttons to UI
- Wraps mapState in temporal(...)

Issues:
`onSave` still needs to update MapBox and the server