### PR TITLE
Highlight unassigned geographies

### DIFF
--- a/app/src/app/components/sidebar/Layers.tsx
+++ b/app/src/app/components/sidebar/Layers.tsx
@@ -26,6 +26,7 @@ export default function Layers() {
   const toggleLockAllAreas = useMapStore(state => state.toggleLockAllAreas);
   const parentsAreBroken = useMapStore(state => state.shatterIds.parents.size);
   const mapOptions = useMapStore(state => state.mapOptions);
+  const setMapOptions = useMapStore(state => state.setMapOptions);
 
   const toggleLayers = (layerIds: string[]) => {
     if (!mapRef) return;
@@ -45,6 +46,7 @@ export default function Layers() {
           visibleLayerIds.includes(BLOCK_LAYER_ID) ? '1' : '',
           parentsAreBroken && mapOptions.showBrokenDistricts ? '3' : '',
           mapOptions.lockPaintedAreas === true ? '4' : '',
+          mapOptions.higlightUnassigned === true ? 'higlightUnassigned' : ''
         ]}
       >
         <CheckboxGroup.Item
@@ -70,6 +72,11 @@ export default function Layers() {
           onClick={() => toggleHighlightBrokenDistricts()}
         >
           Highlight Broken Voter Districts
+        </CheckboxGroup.Item>
+        <CheckboxGroup.Item value="higlightUnassigned" onClick={() => setMapOptions({
+          higlightUnassigned: !mapOptions.higlightUnassigned
+        })}>
+          Highlight Unassigned Districts
         </CheckboxGroup.Item>
         <CheckboxGroup.Item value="4" onClick={() => toggleLockAllAreas()}>
           Lock All Painted Areas

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -132,7 +132,6 @@ export function getHighlightLayerSpecification(
   layerId: string,
   highlightUnassgned?: boolean
 ): LineLayerSpecification {
-  const [unassignedHighlightColor, unassignedHighlightWidth] = highlightUnassgned ? ['#FF0000', 5] : ['#000000', 0]
   return {
     id: layerId,
     source: BLOCK_SOURCE_ID,
@@ -154,21 +153,25 @@ export function getHighlightLayerSpecification(
         '#e5ff00', // yellow color when highlighted
         // @ts-ignore right behavior, wrong types
         ['==', ['feature-state', 'zone'], null],
-        unassignedHighlightColor, // optionally red color when zone is not assigned
+        '#FF0000', // optionally red color when zone is not assigned
         '#000000', // Default color
       ],
       'line-width': [
         'case',
         ['boolean', ['feature-state', 'broken'], false],
         0, // none when broken parent
-        ['boolean', ['feature-state', 'focused'], false],
-        5, // Width of 5 when focused
-        ['boolean', ['feature-state', 'highlighted'], false],
-        5, // Width of 5 when highlighted
-        // @ts-ignore right behavior, wrong types
-        ['==', ['feature-state', 'zone'], null],
-        unassignedHighlightWidth, // optionally with 5 when zone is not assigned
-        0, // Default width
+        [
+          'any',
+          ['boolean', ['feature-state', 'focused'], false],
+          ['boolean', ['feature-state', 'highlighted'], false],
+          ['all',
+            // @ts-ignore correct logic, wrong types
+            ['==', ['feature-state', 'zone'], null],
+            ['boolean', !!highlightUnassgned]
+          ]
+        ],
+        3.5,
+        0, // Default width if none of the conditions are met
       ],
     },
   };

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -3,6 +3,7 @@ import {
   ExpressionSpecification,
   FilterSpecification,
   LayerSpecification,
+  LineLayerSpecification,
 } from 'maplibre-gl';
 import {Map} from 'maplibre-gl';
 import {getBlocksSource} from './sources';
@@ -124,8 +125,10 @@ export function getLayerFill(
 }
 export function getHighlightLayerSpecification(
   sourceLayer: string,
-  layerId: string
-): LayerSpecification {
+  layerId: string,
+  highlightUnassgned?: boolean
+): LineLayerSpecification {
+  const [unassignedHighlightColor, unassignedHighlightWidth] = highlightUnassgned ? ['#FF0000', 5] : ['#000000', 0]
   return {
     id: layerId,
     source: BLOCK_SOURCE_ID,
@@ -143,6 +146,11 @@ export function getHighlightLayerSpecification(
         '#000000', // Black color when focused
         ['boolean', ['feature-state', 'highlighted'], false],
         '#e5ff00', // yellow color when highlighted
+        ['boolean', ['feature-state', 'highlighted'], false],
+        '#e5ff00', // yellow color when highlighted
+        // @ts-ignore right behavior, wrong types
+        ['==', ['feature-state', 'zone'], null],
+        unassignedHighlightColor, // optionally red color when zone is not assigned
         '#000000', // Default color
       ],
       'line-width': [
@@ -151,6 +159,9 @@ export function getHighlightLayerSpecification(
         5, // Width of 5 when focused
         ['boolean', ['feature-state', 'highlighted'], false],
         5, // Width of 5 when highlighted
+        // @ts-ignore right behavior, wrong types
+        ['==', ['feature-state', 'zone'], null],
+        unassignedHighlightWidth, // optionally with 5 when zone is not assigned
         0, // Default width
       ],
     },

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -271,10 +271,14 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       // set the layer BLOCK_LAYER_ID_HIGHLIGHT style to be the return from getHighlightLayerSpecification
       const paintStyle = getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT, higlightUnassigned)['paint']
       if (!paintStyle) return
-      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-width', paintStyle['line-width']);
-      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-color', paintStyle['line-color']);
-      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT_CHILD, 'line-width', paintStyle['line-width']);
-      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT_CHILD, 'line-color', paintStyle['line-color']);
+      if(mapRef.getLayer(BLOCK_LAYER_ID_HIGHLIGHT)){
+        mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-width', paintStyle['line-width']);
+        mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-color', paintStyle['line-color']);
+      }
+      if(mapRef.getLayer(BLOCK_LAYER_ID_HIGHLIGHT_CHILD)){
+        mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT_CHILD, 'line-width', paintStyle['line-width']);
+        mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT_CHILD, 'line-color', paintStyle['line-color']);
+      } 
     }
   );
   return [

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -267,6 +267,7 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       if (!mapRef || !mapDocument?.parent_layer) return;
       // set the layer BLOCK_LAYER_ID_HIGHLIGHT style to be the return from getHighlightLayerSpecification
       const highlightLayerSpecification = getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT, higlightUnassigned)
+      if (!highlightLayerSpecification.paint) return
       mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-width', highlightLayerSpecification['paint']['line-width']);
       mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-color', highlightLayerSpecification['paint']['line-color']);
     }

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -8,6 +8,8 @@ import {
   getLayerFilter,
   getLayerFill,
   BLOCK_SOURCE_ID,
+  BLOCK_LAYER_ID_HIGHLIGHT,
+  getHighlightLayerSpecification,
 } from '../constants/layers';
 import {
   ColorZoneAssignmentsState,
@@ -256,6 +258,19 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       });
     }
   );
+
+  const highlightUnassignedSub = useMapStore.subscribe(
+    state => state.mapOptions.higlightUnassigned,
+    (higlightUnassigned) => {
+      const {getMapRef, mapDocument} = useMapStore.getState();
+      const mapRef = getMapRef();
+      if (!mapRef || !mapDocument?.parent_layer) return;
+      // set the layer BLOCK_LAYER_ID_HIGHLIGHT style to be the return from getHighlightLayerSpecification
+      const highlightLayerSpecification = getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT, higlightUnassigned)
+      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-width', highlightLayerSpecification['paint']['line-width']);
+      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-color', highlightLayerSpecification['paint']['line-color']);
+    }
+  );
   return [
     addLayerSubMapDocument,
     _shatterMapSideEffectRender,
@@ -263,5 +278,6 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
     _zoneAssignmentMapSideEffectRender,
     _updateMapCursor,
     _applyFocusFeatureState,
+    highlightUnassignedSub,
   ];
 };

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -10,6 +10,7 @@ import {
   BLOCK_SOURCE_ID,
   BLOCK_LAYER_ID_HIGHLIGHT,
   getHighlightLayerSpecification,
+  BLOCK_LAYER_ID_HIGHLIGHT_CHILD,
 } from '../constants/layers';
 import {
   ColorZoneAssignmentsState,
@@ -58,10 +59,12 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       );
       // remove zone from parents
       shatterIds.parents.forEach(id => {
-        mapRef?.removeFeatureState({
+        mapRef?.setFeatureState({
           source: BLOCK_SOURCE_ID,
           id,
           sourceLayer: mapDocument?.parent_layer,
+        }, {
+          broken: true
         });
       });
 
@@ -266,10 +269,12 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       const mapRef = getMapRef();
       if (!mapRef || !mapDocument?.parent_layer) return;
       // set the layer BLOCK_LAYER_ID_HIGHLIGHT style to be the return from getHighlightLayerSpecification
-      const highlightLayerSpecification = getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT, higlightUnassigned)
-      if (!highlightLayerSpecification.paint) return
-      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-width', highlightLayerSpecification['paint']['line-width']);
-      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-color', highlightLayerSpecification['paint']['line-color']);
+      const paintStyle = getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT, higlightUnassigned)['paint']
+      if (!paintStyle) return
+      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-width', paintStyle['line-width']);
+      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT, 'line-color', paintStyle['line-color']);
+      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT_CHILD, 'line-width', paintStyle['line-width']);
+      mapRef.setPaintProperty(BLOCK_LAYER_ID_HIGHLIGHT_CHILD, 'line-color', paintStyle['line-color']);
     }
   );
   return [

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -551,6 +551,13 @@ export const useMapStore = create(
               delete shatterMappings[parent.parentId];
               newShatterIds.parents.delete(parent.parentId);
               newZoneAssignments.set(parent.parentId, parent.zone!);
+              mapRef?.setFeatureState({
+                source: BLOCK_SOURCE_ID,
+                id: parent.parentId,
+                sourceLayer: mapDocument?.parent_layer,
+              }, {
+                broken: false
+              });
             });
 
             set({

--- a/app/src/app/store/types.ts
+++ b/app/src/app/store/types.ts
@@ -2,6 +2,7 @@ import {NullableZone} from '../constants/types';
 
 export type DistrictrMapOptions = {
   showBrokenDistricts?: boolean;
+  higlightUnassigned?: boolean;
   lockPaintedAreas: boolean | Array<NullableZone>;
   mode: 'default' | 'break';
 };


### PR DESCRIPTION
#169 

## Description
- Adds option to highlight un assigned geometries to make them easier to find and paint

## Reviewers
- Primary: @mapmeld 
- Secondary: @raphaellaude 

## Checklist
- [x] Update `mapOptions` type
- [x] Update highlight layer specification to optionally show these ares
- [x] Add subscription to mapOptions to update layer rendering based on options
- [x] Add checkbox in sidebar with this option
- [x] Added child layer highlight, when present

## Screenshots (if applicable):
![Screenshot 2024-11-13 at 1 27 48 PM](https://github.com/user-attachments/assets/744fee9f-84ad-4fe5-a29a-3a3f9c86efff)