### PR TITLE
Alert dialog for map reset

### DIFF
--- a/app/src/app/components/sidebar/ResetMapButton.tsx
+++ b/app/src/app/components/sidebar/ResetMapButton.tsx
@@ -8,7 +8,7 @@ export function ResetMapButton() {
   return (
     <AlertDialog.Root>
       <AlertDialog.Trigger disabled={noZonesAreAssigned}>
-        <Button color="red">Reset Map</Button>
+        <Button variant='outline'>Reset Map</Button>
       </AlertDialog.Trigger>
       <AlertDialog.Content maxWidth="450px">
         <AlertDialog.Title>Reset Map</AlertDialog.Title>

--- a/app/src/app/components/sidebar/ResetMapButton.tsx
+++ b/app/src/app/components/sidebar/ResetMapButton.tsx
@@ -1,13 +1,35 @@
 import {useMapStore} from '@/app/store/mapStore';
-import {Button} from '@radix-ui/themes';
+import {AlertDialog, Button, Flex} from '@radix-ui/themes';
 
 export function ResetMapButton() {
   const handleClickResetMap = useMapStore(state => state.handleReset);
   const noZonesAreAssigned = useMapStore(state => !state.zoneAssignments.size);
 
   return (
-    <Button onClick={handleClickResetMap} variant={'outline'} disabled={noZonesAreAssigned}>
-      Reset Map
-    </Button>
+    <AlertDialog.Root>
+      <AlertDialog.Trigger disabled={noZonesAreAssigned}>
+        <Button color="red">Reset Map</Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content maxWidth="450px">
+        <AlertDialog.Title>Reset Map</AlertDialog.Title>
+        <AlertDialog.Description size="2">
+          Are you sure? This will reset all zone assignments and broken geographies. Resetting your
+          map cannot be undone.
+        </AlertDialog.Description>
+
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button variant="solid" color="red" onClick={handleClickResetMap}>
+              Reset Map
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
   );
 }


### PR DESCRIPTION
#168 

## Description
- Adds dialog to confirm reset

## Reviewers
- Primary: @raphaellaude 

## Checklist
- [x] Adds dialog
- [x] Dialog specifies what gets reset, and that the action cannot be undone

## Screenshots (if applicable):
![Screenshot 2024-11-13 at 2 32 10 PM](https://github.com/user-attachments/assets/eaf1cc19-f49e-496b-b7e0-0b83e7c31cf5)
