### PR TITLE
Fix logic for checking individual locked areas

### DIFF
--- a/app/src/app/components/sidebar/ZonePicker.tsx
+++ b/app/src/app/components/sidebar/ZonePicker.tsx
@@ -19,9 +19,9 @@ export function ZonePicker() {
   const handleRadioChange = (index: number, _color: string) => {
     const value = index + 1;
     console.log('setting accumulated geoids to old zone', selectedZone, 'new zone is', value);
-    setZoneAssignments(selectedZone, accumulatedGeoids);
+    // setZoneAssignments(selectedZone, accumulatedGeoids);
     setSelectedZone(value);
-    resetAccumulatedBlockPopulations();
+    // resetAccumulatedBlockPopulations();
   };
 
   return (


### PR DESCRIPTION
#176 

## Description
- Bug fix
- Adds the following logic

When setting locked features after a zone assignment change, app will check if the zone assignment is:
- Included in the locked zones
- Not null
- When locked areas did not change, was the feature already in the locked features
- When locked areas did change, was the zone previously locked and is now unlocked and was the feature already in the locked features

This allows individually locked features to remain locked while doing other business, AND allows individual features in a locked zone to be unlocked and painted 

## Reviewers
- Primary: @raphaellaude 
- Secondary: @mapmeld 

## Checklist
- [x] Additional logic in lock subscription

## Screenshots (if applicable):
