### PR TITLE
Highlight bugfix

### DIFF
--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -130,7 +130,7 @@ export function getLayerFill(
 export function getHighlightLayerSpecification(
   sourceLayer: string,
   layerId: string,
-  highlightUnassgned?: boolean
+  highlightUnassigned?: boolean
 ): LineLayerSpecification {
   return {
     id: layerId,
@@ -165,7 +165,7 @@ export function getHighlightLayerSpecification(
           ['all',
             // @ts-ignore correct logic, wrong types
             ['==', ['feature-state', 'zone'], null],
-            ['boolean', !!highlightUnassgned],
+            ['boolean', !!highlightUnassigned],
             ['!', ['boolean', ['feature-state', 'broken'], false]],
           ]
         ],

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -158,8 +158,6 @@ export function getHighlightLayerSpecification(
       ],
       'line-width': [
         'case',
-        ['boolean', ['feature-state', 'broken'], false],
-        0, // none when broken parent
         [
           'any',
           ['boolean', ['feature-state', 'focused'], false],
@@ -167,7 +165,8 @@ export function getHighlightLayerSpecification(
           ['all',
             // @ts-ignore correct logic, wrong types
             ['==', ['feature-state', 'zone'], null],
-            ['boolean', !!highlightUnassgned]
+            ['boolean', !!highlightUnassgned],
+            ['!', ['boolean', ['feature-state', 'broken'], false]],
           ]
         ],
         3.5,


### PR DESCRIPTION
I thought this condition was working but small bug got introduce - broken parents need should be able to be highlighted and focused for certain tasks, so the check if their broken needs to be part of the highlight unassigned areas check, not before.


## Reviewers
- Primary: @raphaellaude 