### PR TITLE
Bugfix - remove source

### DIFF
--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -279,6 +279,12 @@ export function removeBlockLayers(map: Map | null) {
   ].forEach(layer => {
     map.getLayer(layer) && map.removeLayer(layer);
   });
+  
+  [
+    BLOCK_SOURCE_ID,
+  ].forEach(source => {
+    map.getSource(source) && map.removeSource(source);
+  });
 }
 
 export {addBlockLayers};

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -260,12 +260,6 @@ const addBlockLayers = (map: Map | null, mapDocument: DocumentObject) => {
   }
   map?.addLayer(getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT));
   useMapStore.getState().setMapRenderingState('loaded');
-
-  // update map bounds based on document extent
-  useMapStore.getState().setMapOptions({
-    bounds: mapDocument.extent as [number, number, number, number],
-    container: useMapStore.getState().mapOptions.container,
-  });
 };
 
 export function removeBlockLayers(map: Map | null) {

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -23,7 +23,11 @@ export const INTERACTIVE_LAYERS = [BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CH
 
 export const PARENT_LAYERS = [BLOCK_LAYER_ID, BLOCK_HOVER_LAYER_ID];
 
-export const CHILD_LAYERS = [BLOCK_LAYER_ID_CHILD, BLOCK_HOVER_LAYER_ID_CHILD, BLOCK_LAYER_ID_HIGHLIGHT_CHILD];
+export const CHILD_LAYERS = [
+  BLOCK_LAYER_ID_CHILD,
+  BLOCK_HOVER_LAYER_ID_CHILD,
+  BLOCK_LAYER_ID_HIGHLIGHT_CHILD,
+];
 
 export const DEFAULT_PAINT_STYLE: ExpressionSpecification = [
   'case',
@@ -66,11 +70,11 @@ export function getLayerFill(
   captiveIds?: Set<string>,
   shatterIds?: Set<string>
 ): DataDrivenPropertyValueSpecification<number> {
-  const innerFillSpec = [
+  const innerFillSpec = ([
     'case',
     // is broken parent
     ['boolean', ['feature-state', 'broken'], false],
-    0, 
+    0,
     // geography is locked
     ['boolean', ['feature-state', 'locked'], false],
     0.35,
@@ -108,7 +112,7 @@ export function getLayerFill(
     ['boolean', ['feature-state', 'hover'], false],
     0.6,
     0.2,
-  ] as unknown as DataDrivenPropertyValueSpecification<number>;
+  ] as unknown) as DataDrivenPropertyValueSpecification<number>;
   if (captiveIds?.size) {
     return [
       'case',
@@ -162,12 +166,13 @@ export function getHighlightLayerSpecification(
           'any',
           ['boolean', ['feature-state', 'focused'], false],
           ['boolean', ['feature-state', 'highlighted'], false],
-          ['all',
+          [
+            'all',
             // @ts-ignore correct logic, wrong types
             ['==', ['feature-state', 'zone'], null],
             ['boolean', !!highlightUnassigned],
             ['!', ['boolean', ['feature-state', 'broken'], false]],
-          ]
+          ],
         ],
         3.5,
         0, // Default width if none of the conditions are met
@@ -278,10 +283,8 @@ export function removeBlockLayers(map: Map | null) {
   ].forEach(layer => {
     map.getLayer(layer) && map.removeLayer(layer);
   });
-  
-  [
-    BLOCK_SOURCE_ID,
-  ].forEach(source => {
+
+  [BLOCK_SOURCE_ID].forEach(source => {
     map.getSource(source) && map.removeSource(source);
   });
 }

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -275,7 +275,6 @@ export function removeBlockLayers(map: Map | null) {
     BLOCK_LAYER_ID_CHILD,
     BLOCK_HOVER_LAYER_ID_CHILD,
     BLOCK_LAYER_ID_HIGHLIGHT_CHILD,
-    BLOCK_SOURCE_ID,
   ].forEach(layer => {
     map.getLayer(layer) && map.removeLayer(layer);
   });

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -358,17 +358,26 @@ export const useMapStore = create(
         setMapViews: mapViews => set({mapViews}),
         mapDocument: null,
         setMapDocument: mapDocument => {
-          const currentMapDocument = get().mapDocument;
+          const {
+            mapDocument: currentMapDocument,
+            setFreshMap,
+            resetZoneAssignments,
+            upsertUserMap,
+            mapOptions
+          } = get();
           if (currentMapDocument?.document_id === mapDocument.document_id) {
             return;
           }
-          get().setFreshMap(true);
-          get().resetZoneAssignments();
-          get().upsertUserMap({
-            mapDocument,
-          });
+          resetZoneAssignments()
+          setFreshMap(true)
+          upsertUserMap({mapDocument})
+          
           set({
             mapDocument: mapDocument,
+            mapOptions: {
+              ...mapOptions,
+              bounds: mapDocument.extent
+            },
             shatterIds: {parents: new Set(), children: new Set()},
           });
         },

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -368,8 +368,8 @@ export const useMapStore = create(
           if (currentMapDocument?.document_id === mapDocument.document_id) {
             return;
           }
-          resetZoneAssignments()
           setFreshMap(true)
+          resetZoneAssignments()
           upsertUserMap({mapDocument})
           
           set({


### PR DESCRIPTION
Bug introduced in refactor that missed removing the maplibre source on remove layers. Current refactor is more readable for future changes.

## Description
- In `removeBlockLayers` adds a second loop for sources that calls `removeSource`
- A future refactor should centralize layer and source manipulations in a single class or store to make it more consistent and ergonomic 

## Reviewers
- Primary: @raphaellaude 

