### PR TITLE
Paint by county with ID instead of features

### DIFF
--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -47,11 +47,11 @@ export const MapComponent: React.FC = () => {
       maxZoom: MAP_OPTIONS.maxZoom,
     });
 
-    map.current.on('data', (event) => {
+    map.current.on('data', (event: any) => {
       const {tiles_s3_path, parent_layer} = useMapStore.getState().mapDocument || {}
-      if (!tiles_s3_path || event.dataType !== 'source' || !event?.source?.url?.includes(tiles_s3_path)) return
+      if (!tiles_s3_path || !parent_layer || event.dataType !== 'source' || !event?.source?.url?.includes(tiles_s3_path)) return
 
-      const tileData = event?.tile?.latestFeatureIndex
+      const tileData = event?.tile?.latestFeatureIndex;
       if (!tileData) return
       
       const index = `${tileData.x}-${tileData.y}-${tileData.z}`
@@ -64,7 +64,7 @@ export const MapComponent: React.FC = () => {
       const featureDataArray = parentLayerData?._values
       parentIdCache.add(index, featureDataArray.slice(-numFeatures,))
     });
-    
+
     fitMapToBounds();
     map.current.scrollZoom.setWheelZoomRate(1 / 300);
     map.current.scrollZoom.setZoomRate(1 / 300);

--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -47,24 +47,6 @@ export const MapComponent: React.FC = () => {
       maxZoom: MAP_OPTIONS.maxZoom,
     });
 
-    map.current.on('data', (event: any) => {
-      const {tiles_s3_path, parent_layer} = useMapStore.getState().mapDocument || {}
-      if (!tiles_s3_path || !parent_layer || event.dataType !== 'source' || !event?.source?.url?.includes(tiles_s3_path)) return
-
-      const tileData = event?.tile?.latestFeatureIndex;
-      if (!tileData) return
-      
-      const index = `${tileData.x}-${tileData.y}-${tileData.z}`
-      if (parentIdCache.hasCached(index)) return
-      
-
-      const vtLayers = tileData.loadVTLayers()
-      const parentLayerData = vtLayers[parent_layer]
-      const numFeatures = parentLayerData?.length
-      const featureDataArray = parentLayerData?._values
-      parentIdCache.add(index, featureDataArray.slice(-numFeatures,))
-    });
-
     fitMapToBounds();
     map.current.scrollZoom.setWheelZoomRate(1 / 300);
     map.current.scrollZoom.setZoomRate(1 / 300);

--- a/app/src/app/components/sidebar/PaintByCounty.tsx
+++ b/app/src/app/components/sidebar/PaintByCounty.tsx
@@ -8,12 +8,15 @@ export default function PaintByCounty() {
   const mapRef = useMapStore(state => state.getMapRef());
   const addVisibleLayerIds = useMapStore(state => state.addVisibleLayerIds);
   const setPaintFunction = useMapStore(state => state.setPaintFunction);
-  const [checked, setChecked] = useState(false);
+  const paintByCounty = useMapStore(state => state.mapOptions.paintByCounty)
+  const setMapOptions = useMapStore(state => state.setMapOptions)
 
-  useEffect(() => {
+  const handleToggle = () => {
     if (!mapRef) return;
-
-    if (checked) {
+    setMapOptions({
+      paintByCounty: !paintByCounty
+    })
+    if (!paintByCounty) {
       COUNTY_LAYER_IDS.forEach(layerId => {
         mapRef.setLayoutProperty(layerId, 'visibility', 'visible');
       });
@@ -22,16 +25,16 @@ export default function PaintByCounty() {
     } else {
       setPaintFunction(getFeaturesInBbox);
     }
-  }, [checked, mapRef, addVisibleLayerIds]);
+  }
 
   return (
     <Box>
       <Text as="label" size="2">
         <Flex gap="2">
           <Checkbox
-            checked={checked}
+            checked={paintByCounty}
             defaultChecked={false}
-            onClick={() => setChecked(prevIsChecked => !prevIsChecked)}
+            onClick={handleToggle}
           />
           Paint by County
         </Flex>

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -23,7 +23,7 @@ export const INTERACTIVE_LAYERS = [BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CH
 export const LINE_LAYERS = [BLOCK_LAYER_ID, BLOCK_LAYER_ID_CHILD] as const
 
 export const PARENT_LAYERS = [BLOCK_LAYER_ID, BLOCK_HOVER_LAYER_ID]; 
-export const COUNTY_LAYERS = ['counties_fill', 'counties_boundary','counties_label']
+export const COUNTY_LAYERS = ['counties_fill', 'counties_boundary','counties_labels']
 
 export const CHILD_LAYERS = [
   BLOCK_LAYER_ID_CHILD,

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -23,6 +23,7 @@ export const INTERACTIVE_LAYERS = [BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CH
 export const LINE_LAYERS = [BLOCK_LAYER_ID, BLOCK_LAYER_ID_CHILD] as const
 
 export const PARENT_LAYERS = [BLOCK_LAYER_ID, BLOCK_HOVER_LAYER_ID]; 
+export const COUNTY_LAYERS = ['counties_fill', 'counties_boundary','counties_label']
 
 export const CHILD_LAYERS = [
   BLOCK_LAYER_ID_CHILD,

--- a/app/src/app/store/idCache.ts
+++ b/app/src/app/store/idCache.ts
@@ -1,0 +1,25 @@
+
+class IdCache {
+  cachedTileIndices: Set<string> = new Set()
+  parentIds: Set<string> = new Set()
+
+  hasCached(index: string){
+    return this.cachedTileIndices.has(index)
+  }
+
+  add(index: string, ids: string[]){
+    this.cachedTileIndices.add(index)
+    ids.forEach(id => this.parentIds.add(id))
+  }
+
+  clear(){
+    this.parentIds.clear()
+    this.cachedTileIndices.clear()
+  }
+
+  getFilteredIds(id: string){
+    return Array.from(this.parentIds).filter(f => f.startsWith(id))
+  }
+}
+
+export const parentIdCache = new IdCache()

--- a/app/src/app/store/idCache.ts
+++ b/app/src/app/store/idCache.ts
@@ -1,4 +1,3 @@
-
 class IdCache {
   cachedTileIndices: Set<string> = new Set()
   parentIds: Set<string> = new Set()
@@ -18,7 +17,8 @@ class IdCache {
   }
 
   getFilteredIds(id: string){
-    return Array.from(this.parentIds).filter(f => f.startsWith(id))
+    const regex = new RegExp(`^${id}`);
+    return Array.from(this.parentIds).filter(f => regex.test(f));
   }
 }
 

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -11,6 +11,7 @@ import {
   BLOCK_LAYER_ID_HIGHLIGHT,
   getHighlightLayerSpecification,
   BLOCK_LAYER_ID_HIGHLIGHT_CHILD,
+  COUNTY_LAYERS,
 } from '../constants/layers';
 import {
   ColorZoneAssignmentsState,
@@ -310,6 +311,18 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       } 
     }
   );
+  
+  const filterCountiesSub = useMapStore.subscribe<[string|undefined, MapStore['getMapRef']]>(state => [state.mapOptions.currentStateFp, state.getMapRef],
+    ([stateFp, getMapRef]) => {
+      const mapRef = getMapRef()
+      if (!mapRef) return
+      const filterExpression = (stateFp ? ["==", "STATEFP", stateFp] : true) as any
+      COUNTY_LAYERS.forEach(layer => {
+        mapRef.setFilter(layer,  ["any", filterExpression])
+      })
+    }
+  )
+  
   return [
     addLayerSubMapDocument,
     _shatterMapSideEffectRender,
@@ -318,5 +331,6 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
     _updateMapCursor,
     _applyFocusFeatureState,
     highlightUnassignedSub,
+    filterCountiesSub
   ];
 };

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -58,7 +58,7 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       // Hide broken parents on parent layer
       // Show broken children on child layer
       layersToFilter.forEach(layerId =>
-        mapRef.setFilter(layerId, getLayerFilter(layerId, shatterIds))
+        mapRef.getLayer(layerId) && mapRef.setFilter(layerId, getLayerFilter(layerId, shatterIds))
       );
       // remove zone from parents
       shatterIds.parents.forEach(id => {

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -15,6 +15,8 @@ import {
 import {
   ColorZoneAssignmentsState,
   colorZoneAssignments,
+  getFeaturesInBbox,
+  getFeaturesIntersectingCounties,
   shallowCompareArray,
 } from '../utils/helpers';
 import {useMapStore as _useMapStore, MapStore} from '@store/mapStore';
@@ -222,16 +224,21 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
     activeTool => {
       const mapRef = useMapStore.getState().getMapRef();
       if (!mapRef) return;
+      const mapOptions = useMapStore.getState().mapOptions
+      const defaultPaintFunction = mapOptions.paintByCounty ? getFeaturesIntersectingCounties : getFeaturesInBbox
       let cursor;
       switch (activeTool) {
         case 'pan':
           cursor = '';
+          useMapStore.getState().setPaintFunction(defaultPaintFunction);
           break;
         case 'brush':
           cursor = 'pointer';
+          useMapStore.getState().setPaintFunction(defaultPaintFunction);
           break;
         case 'eraser':
           cursor = 'pointer';
+          useMapStore.getState().setPaintFunction(defaultPaintFunction);
           break;
         case 'shatter':
           cursor = 'crosshair';

--- a/app/src/app/store/mapRenderSubs.ts
+++ b/app/src/app/store/mapRenderSubs.ts
@@ -318,7 +318,7 @@ export const getRenderSubscriptions = (useMapStore: typeof _useMapStore) => {
       if (!mapRef) return
       const filterExpression = (stateFp ? ["==", "STATEFP", stateFp] : true) as any
       COUNTY_LAYERS.forEach(layer => {
-        mapRef.setFilter(layer,  ["any", filterExpression])
+        mapRef.getLayer(layer) && mapRef.setFilter(layer,  ["any", filterExpression])
       })
     }
   )

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -36,6 +36,7 @@ import {BLOCK_SOURCE_ID} from '../constants/layers';
 import {DistrictrMapOptions} from './types';
 import {onlyUnique} from '../utils/arrays';
 import {queryClient} from '../utils/api/queryClient';
+import { parentIdCache } from './idCache';
 
 const combineSetValues = (setRecord: Record<string, Set<unknown>>, keys?: string[]) => {
   const combinedSet = new Set<unknown>(); // Create a new set to hold combined values
@@ -383,6 +384,7 @@ export const useMapStore = create(
           if (currentMapDocument?.document_id === mapDocument.document_id) {
             return;
           }
+          parentIdCache.clear()
           setFreshMap(true);
           resetZoneAssignments();
           upsertUserMap({mapDocument});

--- a/app/src/app/store/types.ts
+++ b/app/src/app/store/types.ts
@@ -5,4 +5,5 @@ export type DistrictrMapOptions = {
   higlightUnassigned?: boolean;
   lockPaintedAreas: boolean | Array<NullableZone>;
   mode: 'default' | 'break';
+  paintByCounty?: boolean
 };

--- a/app/src/app/store/types.ts
+++ b/app/src/app/store/types.ts
@@ -5,5 +5,6 @@ export type DistrictrMapOptions = {
   higlightUnassigned?: boolean;
   lockPaintedAreas: boolean | Array<NullableZone>;
   mode: 'default' | 'break';
-  paintByCounty?: boolean
+  paintByCounty?: boolean;
+  currentStateFp?: string
 };

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -253,7 +253,11 @@ export const handleIdCache = (
   const parentLayerData = vtLayers[parent_layer]
   const numFeatures = parentLayerData.length
   const featureDataArray = parentLayerData._values
-  parentIdCache.add(index, featureDataArray.slice(-numFeatures,))
+  const idArray = featureDataArray.slice(-numFeatures,)
+  parentIdCache.add(index, idArray)
+  useMapStore.getState().setMapOptions({
+    currentStateFp: idArray[0].replace('vtd:','').slice(0,2)
+  })
 }
 
 export const mapEvents = [

--- a/app/src/app/utils/helpers.ts
+++ b/app/src/app/utils/helpers.ts
@@ -135,7 +135,8 @@ export const getFeaturesIntersectingCounties = (
   if (!countyFeatures?.length) return;
   const fips = countyFeatures[0].properties.STATEFP + countyFeatures[0].properties.COUNTYFP;
   const {mapDocument, shatterIds} = useMapStore.getState();
-  const cachedParentFeatures = parentIdCache.getFilteredIds(`vtd:${fips}`).map(id => ({
+  const filterPrefix = mapDocument?.parent_layer.includes("vtd") ? "vtd:" : ""
+  const cachedParentFeatures = parentIdCache.getFilteredIds(`${filterPrefix}${fips}`).map(id => ({
     id,
     source: BLOCK_SOURCE_ID,
     sourceLayer: mapDocument?.parent_layer,


### PR DESCRIPTION
Instead of painting by county using features, this PRs drafts a method of caching all IDs and then filtering based on those

## Description
- Cache IDs of features on `data` in the map
- When painting by county, search those IDs

## Reviewers
- Primary: @raphaellaude 
- Secondary: @mariogiampieri  
