### PR TITLE
Remove deprecated setZoneAssignments

### DIFF
--- a/app/src/app/components/sidebar/Picker.jsx
+++ b/app/src/app/components/sidebar/Picker.jsx
@@ -5,12 +5,9 @@ import {useMapStore} from '../../store/mapStore';
 export function ZoneTypeSelector() {
   const selectedZone = useMapStore(state => state.selectedZone);
   const setSelectedZone = useMapStore(state => state.setSelectedZone);
-  const setZoneAssignments = useMapStore(state => state.setZoneAssignments);
   const accumulatedGeoids = useMapStore(state => state.accumulatedGeoids);
 
   const handlePickerValueChange = value => {
-    console.log('setting accumulated geoids to old zone', selectedZone, 'new zone is', value);
-    setZoneAssignments(selectedZone, accumulatedGeoids);
     setSelectedZone(value);
   };
 

--- a/app/src/app/components/sidebar/ZonePicker.tsx
+++ b/app/src/app/components/sidebar/ZonePicker.tsx
@@ -10,7 +10,6 @@ import {ColorPicker} from './ColorPicker';
 export function ZonePicker() {
   const selectedZone = useMapStore(state => state.selectedZone);
   const setSelectedZone = useMapStore(state => state.setSelectedZone);
-  const setZoneAssignments = useMapStore(state => state.setZoneAssignments);
   const accumulatedGeoids = useMapStore(state => state.accumulatedGeoids);
   const resetAccumulatedBlockPopulations = useMapStore(
     state => state.resetAccumulatedBlockPopulations
@@ -18,8 +17,6 @@ export function ZonePicker() {
 
   const handleRadioChange = (index: number, _color: string) => {
     const value = index + 1;
-    console.log('setting accumulated geoids to old zone', selectedZone, 'new zone is', value);
-    // setZoneAssignments(selectedZone, accumulatedGeoids);
     setSelectedZone(value);
     // resetAccumulatedBlockPopulations();
   };

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -242,7 +242,6 @@ export interface MapStore {
   accumulatedBlockPopulations: Map<string, number>;
   resetAccumulatedBlockPopulations: () => void;
   zoneAssignments: Map<string, NullableZone>; // geoid -> zone
-  setZoneAssignments: (zone: NullableZone, gdbPaths: Set<GDBPath>) => void;
   assignmentsHash: string;
   setAssignmentsHash: (hash: string) => void;
   loadZoneAssignments: (assigments: Assignment[]) => void;
@@ -830,17 +829,6 @@ export const useMapStore = create(
         setAssignmentsHash: hash => set({assignmentsHash: hash}),
         accumulatedGeoids: new Set<string>(),
         setAccumulatedGeoids: accumulatedGeoids => set({accumulatedGeoids}),
-        setZoneAssignments: (zone, geoids) => {
-          const zoneAssignments = get().zoneAssignments;
-          const newZoneAssignments = new Map(zoneAssignments);
-          geoids.forEach(geoid => {
-            newZoneAssignments.set(geoid, zone);
-          });
-          set({
-            zoneAssignments: newZoneAssignments,
-            accumulatedGeoids: new Set<string>(),
-          });
-        },
         loadZoneAssignments: assignments => {
           const zoneAssignments = new Map<string, number>();
           const shatterIds = {


### PR DESCRIPTION
Mentioned this on Slack - now that we moved to an event listener, `setZoneAssignments` is only called by the zone picker. We don't think this is necessary anymore now that the mouse exiting the map should apply the changes.

The calls were added to the picker in this commit and PR:
https://github.com/districtr/districtr-v2/commit/8dc9328f2d7d926b497b8b0adf52d84d74f4fcc2
https://github.com/districtr/districtr-v2/pull/129 (likely copying the Picker)