### PR TITLE
Zoom to unassigned tool

### DIFF
--- a/app/src/app/components/sidebar/MapModeSelector.jsx
+++ b/app/src/app/components/sidebar/MapModeSelector.jsx
@@ -9,17 +9,15 @@ import {
   HandIcon,
   LockOpen1Icon,
   ViewGridIcon,
+  MagnifyingGlassIcon,
 } from '@radix-ui/react-icons';
 import {RecentMapsModal} from '@components/sidebar/RecentMapsModal';
-import GeometryWorker from '@/app/utils/GeometryWorker';
 
 export function MapModeSelector() {
   const activeTool = useMapStore(state => state.activeTool);
   const setActiveTool = useMapStore(state => state.setActiveTool);
   const mapDocument = useMapStore(state => state.mapDocument);
-  const [unassignedFeatures, setUnassignedFeatures] = React.useState([]);
 
-  const mapRef = useMapStore(state => state.getMapRef());
   if (!activeTool) return null;
   const activeTools = [
     {mode: 'pan', disabled: false, label: 'Pan', icon: <HandIcon />},
@@ -36,6 +34,12 @@ export function MapModeSelector() {
       disabled: false,
       label: 'Lock',
       icon: <LockOpen1Icon />,
+    },
+    {
+      mode: 'zoomToUnassigned',
+      disabled: !mapDocument?.parent_layer,
+      label: 'Zoom To Unassigned',
+      icon: <MagnifyingGlassIcon />,
     },
   ];
 
@@ -59,32 +63,8 @@ export function MapModeSelector() {
             </RadioCards.Item>
           </Flex>
         ))}
-          <Flex>
-            <RadioCards.Item value={null} id={'unassigned'} onClick={() => {
-              GeometryWorker.updateProps(Array.from(useMapStore.getState().zoneAssignments.entries())).then(
-                () => GeometryWorker.getUnassignedGeometries().then(
-                  geometries => setUnassignedFeatures(geometries)
-                )
-              )
-            }}>
-              Zoom to unassigned
-            </RadioCards.Item>
-          </Flex>
         <RecentMapsModal />
       </RadioCards.Root>
-      {unassignedFeatures.length > 0 && (
-        <Box>
-          <h3>Unassigned Features</h3>
-          <ul>
-            {unassignedFeatures.map((feature, index) => (
-              <button key={index} 
-                className="btn p-4"
-              onClick={() => {
-                mapRef?.fitBounds(feature.properties.bbox);
-              }}>{index}</button>))}
-          </ul>
-        </Box>
-      )}
     </Box>
   );
 }

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import {ExitBlockViewButtons} from './ExitBlockViewButtons';
 import {ZonePicker} from './ZonePicker';
 import {ZoneLockPicker} from './ZoneLockPicker';
 import {MobileColorPicker} from './MobileColorPicker';
+import { ZoomToUnassigned } from './ZoomToUnassigned';
 
 export default function SidebarComponent() {
   const activeTool = useMapStore(state => state.activeTool);
@@ -61,6 +62,9 @@ export default function SidebarComponent() {
             <ZoneLockPicker />
           </div>
         ) : null}
+        {!!(activeTool === "zoomToUnassigned") && (
+          <ZoomToUnassigned />
+        )}
         <ResetMapButton />
         <ExitBlockViewButtons />
 

--- a/app/src/app/components/sidebar/ZoomToUnassigned.tsx
+++ b/app/src/app/components/sidebar/ZoomToUnassigned.tsx
@@ -31,12 +31,12 @@ export const ZoomToUnassigned = () => {
     <div>
       {unassignedFeatures.length > 0 && (
         <Box>
-          <Heading as="h3" size="3" my="2">
+          <Heading as="h3" size="3" mt="2">
             Found {unassignedFeatures.length} unassigned area
-            {unassignedFeatures.length > 1 ? 's' : ''}.
+            {unassignedFeatures.length > 1 ? 's' : ''}
           </Heading>
-          <Flex direction="row" align={'center'} gapX="2" mb="2">
-            <Text>Zoom to area{unassignedFeatures.length > 1 ? 's' : ''}:</Text>
+          <Text>Zoom to unassigned area{unassignedFeatures.length > 1 ? 's' : ''}</Text>
+          <Flex direction="row" align={'center'} gapX="2" gapY="2" my="2" wrap="wrap">
             {unassignedFeatures.map((feature, index) => (
               <Button
                 key={index}

--- a/app/src/app/components/sidebar/ZoomToUnassigned.tsx
+++ b/app/src/app/components/sidebar/ZoomToUnassigned.tsx
@@ -1,0 +1,58 @@
+import {useMapStore} from '@/app/store/mapStore';
+import GeometryWorker from '@/app/utils/GeometryWorker';
+import {Box, Button, Flex, Heading, Text} from '@radix-ui/themes';
+import { LngLatBoundsLike } from 'maplibre-gl';
+import React, {useEffect} from 'react';
+
+export const ZoomToUnassigned = () => {
+  const [unassignedFeatures, setUnassignedFeatures] = React.useState<GeoJSON.Feature[]>([]);
+  const mapRef = useMapStore(state => state.getMapRef());
+  const zoneAssignments = useMapStore(state => state.zoneAssignments);
+
+  const updateUnassignedFeatures = () => {
+    if (!GeometryWorker || !mapRef) return;
+    GeometryWorker.updateProps(Array.from(zoneAssignments.entries())).then(() =>
+      GeometryWorker!.getUnassignedGeometries().then(geometries => {
+        const {overall, dissolved} = geometries;
+        mapRef?.fitBounds(overall as LngLatBoundsLike);
+        if (dissolved.features.length) {
+          setUnassignedFeatures(dissolved.features);
+        } else {
+          setUnassignedFeatures([]);
+        }
+      })
+    );
+  };
+  useEffect(() => {
+    updateUnassignedFeatures();
+  }, []);
+
+  return (
+    <div>
+      {unassignedFeatures.length > 0 && (
+        <Box>
+          <Heading as="h3" size="3" my="2">
+            Found {unassignedFeatures.length} unassigned area
+            {unassignedFeatures.length > 1 ? 's' : ''}.
+          </Heading>
+          <Flex direction="row" align={'center'} gapX="2" mb="2">
+            <Text>Zoom to area{unassignedFeatures.length > 1 ? 's' : ''}:</Text>
+            {unassignedFeatures.map((feature, index) => (
+              <Button
+                key={index}
+                variant="surface"
+                color="ruby"
+                className="btn p-4"
+                onClick={() => {
+                  feature.properties?.bbox && mapRef?.fitBounds(feature.properties.bbox);
+                }}
+              >
+                {index + 1}
+              </Button>
+            ))}
+          </Flex>
+        </Box>
+      )}
+    </div>
+  );
+};

--- a/app/src/app/constants/types.ts
+++ b/app/src/app/constants/types.ts
@@ -9,7 +9,7 @@ export type GDBPath = string;
 
 export type ZoneDict = Map<GEOID, Zone>;
 
-export type ActiveTool = 'pan' | 'brush' | 'eraser' | 'shatter' | 'lock'; // others?
+export type ActiveTool = 'pan' | 'brush' | 'eraser' | 'shatter' | 'lock' | 'zoomToUnassigned'; // others?
 
 export type SpatialUnit = 'county' | 'tract' | 'block' | 'block_group' | 'voting_district'; // others?
 

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -2,11 +2,12 @@ import {expose} from 'comlink';
 import {area} from '@turf/area';
 import dissolve from '@turf/dissolve';
 import centerOfMass from '@turf/center-of-mass';
-import {GeometryWorkerClass} from './geometryWorker.types';
+import {GeometryWorkerClass, MinGeoJSONFeature} from './geometryWorker.types';
 import bboxClip from '@turf/bbox-clip';
 import pointOnFeature from '@turf/point-on-feature';
 import pointsWithinPolygon from '@turf/points-within-polygon';
 import {MapGeoJSONFeature} from 'maplibre-gl';
+import bbox from '@turf/bbox';
 
 const GeometryWorker: GeometryWorkerClass = {
   geometries: {},
@@ -59,7 +60,6 @@ const GeometryWorker: GeometryWorkerClass = {
       }
     );
     let largestDissolvedFeatures: Record<number, {feature: GeoJSON.Feature; area: number}> = {};
-
     dissolved.features.forEach(feature => {
       const zone = feature.properties?.zone;
       if (!zone) return;
@@ -112,6 +112,35 @@ const GeometryWorker: GeometryWorkerClass = {
     const {dissolved, centroids} = this.dissolveGeometry(clippedFeatures as MapGeoJSONFeature[]);
     return {dissolved, centroids};
   },
+  getUnassignedGeometries() {
+    const geomsToDissolve = []
+    const unassignedOtherGeoms = []
+    for (const id in this.geometries) {
+      const geom = this.geometries[id]
+      if (geom.properties?.zone == null) {
+        if (geom.geometry.type === 'Polygon') {
+          geomsToDissolve.push(geom)
+        } else {
+          this.geometries[id].properties.bbox = bbox(geom.geometry)
+          unassignedOtherGeoms.push(geom)
+        }
+      }
+    }
+    const dissolved = dissolve({
+      type: 'FeatureCollection',
+      features: geomsToDissolve as GeoJSON.Feature<GeoJSON.Polygon>[],
+    }).features.map(f => ({
+      ...f,
+      properties: {
+        ...f.properties,
+        bbox: bbox(f.geometry),
+      },
+    } as MinGeoJSONFeature))
+    return [
+      ...dissolved,
+      ...unassignedOtherGeoms,
+    ]
+  }
 };
 
 expose(GeometryWorker);

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -53,6 +53,11 @@ export type GeometryWorkerClass = {
   ) => CentroidReturn;
 
   /**
+   * Retrieves a collection of geometries without a zone assignment.
+   * @returns The collection of unassigned geometries.
+   */
+  getUnassignedGeometries: () => MinGeoJSONFeature[];
+  /**
    * Retrieves the collection of geometries.
    * @returns The collection of geometries.
    */

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -56,7 +56,10 @@ export type GeometryWorkerClass = {
    * Retrieves a collection of geometries without a zone assignment.
    * @returns The collection of unassigned geometries.
    */
-  getUnassignedGeometries: () => MinGeoJSONFeature[];
+  getUnassignedGeometries: () => {
+    dissolved: GeoJSON.FeatureCollection;
+    overall: GeoJSON.BBox;
+  }
   /**
    * Retrieves the collection of geometries.
    * @returns The collection of geometries.

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -109,7 +109,7 @@ export const handleMapMouseDown = (
   const mapStore = useMapStore.getState();
   const activeTool = mapStore.activeTool;
 
-  if (activeTool === 'pan') {
+  if (activeTool === 'pan' || activeTool === 'zoomToUnassigned') {
     // enable drag pan
     map?.dragPan.enable();
   } else if (activeTool === 'brush' || activeTool === 'eraser') {


### PR DESCRIPTION
Adds a tool to help users find unassigned areas. Closes #98 

## Description
- Add a tool to find unassigned areas
- Zooms to clusters of assigned areas
- Uses geometry worker

## Reviewers
- Primary: @raphaellaude 
- Secondary: @mariogiampieri 

## Checklist
- [ ] Track assignments in geometry worker
- [ ] Filter features by assignment and dissolve unassigned
- [ ] Return Bbox to zoom to
- [ ] UI to find unassigned and navigate
- [ ] Bug testing and edge cases
