### PR TITLE
Hovered features should reset after mouse leaves the map

### DIFF
--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -7,7 +7,7 @@ import React, {useEffect, useRef} from 'react';
 import {MAP_OPTIONS} from '../constants/configuration';
 import {handleWheelOrPinch, mapContainerEvents, mapEvents} from '../utils/events/mapEvents';
 import {INTERACTIVE_LAYERS} from '../constants/layers';
-import {useMapStore} from '../store/mapStore';
+import {useHoverStore, useMapStore} from '../store/mapStore';
 import {MapTooltip} from './MapTooltip';
 
 export const MapComponent: React.FC = () => {
@@ -16,6 +16,7 @@ export const MapComponent: React.FC = () => {
   const mapLock = useMapStore(state => state.mapLock);
   const setMapRef = useMapStore(state => state.setMapRef);
   const mapOptions = useMapStore(state => state.mapOptions);
+  const setHoverFeatures = useHoverStore(state => state.setHoverFeatures);
 
   useEffect(() => {
     let protocol = new Protocol();
@@ -35,6 +36,12 @@ export const MapComponent: React.FC = () => {
     }
   };
   useEffect(fitMapToBounds, [mapOptions.bounds]);
+
+  useEffect(() => {
+    map.current?.on('mouseout', () => {
+      setTimeout(() => setHoverFeatures([]), 250);  
+    });
+  }, [setHoverFeatures]);
 
   useEffect(() => {
     if (map.current || !mapContainer.current) return;

--- a/app/src/app/components/Map.tsx
+++ b/app/src/app/components/Map.tsx
@@ -7,7 +7,7 @@ import React, {useEffect, useRef} from 'react';
 import {MAP_OPTIONS} from '../constants/configuration';
 import {handleWheelOrPinch, mapContainerEvents, mapEvents} from '../utils/events/mapEvents';
 import {INTERACTIVE_LAYERS} from '../constants/layers';
-import {useHoverStore, useMapStore} from '../store/mapStore';
+import {useMapStore} from '../store/mapStore';
 import {MapTooltip} from './MapTooltip';
 
 export const MapComponent: React.FC = () => {
@@ -16,7 +16,6 @@ export const MapComponent: React.FC = () => {
   const mapLock = useMapStore(state => state.mapLock);
   const setMapRef = useMapStore(state => state.setMapRef);
   const mapOptions = useMapStore(state => state.mapOptions);
-  const setHoverFeatures = useHoverStore(state => state.setHoverFeatures);
 
   useEffect(() => {
     let protocol = new Protocol();
@@ -36,12 +35,6 @@ export const MapComponent: React.FC = () => {
     }
   };
   useEffect(fitMapToBounds, [mapOptions.bounds]);
-
-  useEffect(() => {
-    map.current?.on('mouseout', () => {
-      setTimeout(() => setHoverFeatures([]), 250);  
-    });
-  }, [setHoverFeatures]);
 
   useEffect(() => {
     if (map.current || !mapContainer.current) return;

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -141,7 +141,7 @@ export const handleMapMouseLeave = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
-  setTimeout(useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
+  setTimeout(() => useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
   useTooltipStore.getState().setTooltip(null);
   useMapStore.getState().setIsPainting(false);
 };
@@ -150,7 +150,7 @@ export const handleMapMouseOut = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
-  setTimeout(useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
+  setTimeout(() => useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
   useTooltipStore.getState().setTooltip(null);
   useMapStore.getState().setIsPainting(false);
 };

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -141,7 +141,7 @@ export const handleMapMouseLeave = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
-  useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY);
+  setTimeout(useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
   useTooltipStore.getState().setTooltip(null);
   useMapStore.getState().setIsPainting(false);
 };
@@ -150,7 +150,7 @@ export const handleMapMouseOut = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
-  useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY);
+  setTimeout(useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
   useTooltipStore.getState().setTooltip(null);
   useMapStore.getState().setIsPainting(false);
 };
@@ -276,7 +276,7 @@ export const handleIdCache = (
 ) => {
   const e = _e as any
   const {tiles_s3_path, parent_layer} = useMapStore.getState().mapDocument || {}
-  
+
   if (
     !tiles_s3_path ||
     !parent_layer ||
@@ -289,7 +289,7 @@ export const handleIdCache = (
   const tileData = e.tile.latestFeatureIndex;
 
   if (!tileData) return
-  
+
   const index = `${tileData.x}-${tileData.y}-${tileData.z}`
   if (parentIdCache.hasCached(index)) return
   const featureArray: MinGeoJSONFeature[] = []


### PR DESCRIPTION
Bug was repeatable: having the cursor leave the map while painting leaves that area shaded until you resume painting, this can be a longer time if you change to the move cursor

<img width="444" alt="Screenshot 2024-12-28 at 11 34 13 PM" src="https://github.com/user-attachments/assets/b9619621-a037-4828-a2cb-f69741d4d65b" />

This might have caused a colors issue here:
<img src="https://github.com/user-attachments/assets/ef42a1b9-9e97-41f2-9601-d79a485d3538" width="444"/>

Proposed solution: `useHoverStore` gives us a function to clear the hover features; this requires a short timeout to avoid the map re-selecting these features