### PR TITLE
Better FE request management 

### DIFF
--- a/app/src/app/store/mapEditSubs.ts
+++ b/app/src/app/store/mapEditSubs.ts
@@ -4,17 +4,17 @@ import {patchUpdates} from '../utils/api/mutations';
 import {useMapStore as _useMapStore, MapStore} from './mapStore';
 import {shallowCompareArray} from '../utils/helpers';
 import {updateAssignments} from '../utils/api/queries';
-import {queryClient} from '../utils/api/queryClient';
 
 const zoneUpdates = ({getMapRef, zoneAssignments, appLoadingState}: Partial<MapStore>) => {
-  const isMutating = queryClient.isMutating();
-  if (!isMutating && getMapRef?.() && zoneAssignments?.size && appLoadingState === 'loaded') {
+  // locked during break or heal
+  const mapIsLocked = _useMapStore.getState().mapLock;
+  if (!mapIsLocked && getMapRef?.() && zoneAssignments?.size && appLoadingState === 'loaded') {
     const assignments = FormatAssignments();
     patchUpdates.mutate(assignments);
   }
 };
 
-const debouncedZoneUpdate = debounce(zoneUpdates, 25);
+const debouncedZoneUpdate = debounce(zoneUpdates, 1000);
 
 export const getMapEditSubs = (useMapStore: typeof _useMapStore) => {
   const sendZoneUpdatesOnUpdate = useMapStore.subscribe<

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -816,7 +816,7 @@ export const useMapStore = create(
         setSelectedZone: zone => set({selectedZone: zone}),
         zoneAssignments: new Map(),
         assignmentsHash: '',
-        lastUpdatedHash: '',
+        lastUpdatedHash: Date.now().toString(),
         setAssignmentsHash: hash => set({assignmentsHash: hash}),
         accumulatedGeoids: new Set<string>(),
         setAccumulatedGeoids: accumulatedGeoids => set({accumulatedGeoids}),

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -232,6 +232,7 @@ export interface MapStore {
   zoneAssignments: Map<string, NullableZone>; // geoid -> zone
   setZoneAssignments: (zone: NullableZone, gdbPaths: Set<GDBPath>) => void;
   assignmentsHash: string;
+  lastUpdatedHash: string;
   setAssignmentsHash: (hash: string) => void;
   loadZoneAssignments: (assigments: Assignment[]) => void;
   resetZoneAssignments: () => void;
@@ -375,6 +376,9 @@ export const useMapStore = create(
           });
 
           useChartStore.getState().updateMetrics(popChanges);
+          set({
+            assignmentsHash: Date.now().toString(),
+          })
         },
         mapViews: {isPending: true},
         setMapViews: mapViews => set({mapViews}),
@@ -812,6 +816,7 @@ export const useMapStore = create(
         setSelectedZone: zone => set({selectedZone: zone}),
         zoneAssignments: new Map(),
         assignmentsHash: '',
+        lastUpdatedHash: '',
         setAssignmentsHash: hash => set({assignmentsHash: hash}),
         accumulatedGeoids: new Set<string>(),
         setAccumulatedGeoids: accumulatedGeoids => set({accumulatedGeoids}),
@@ -863,9 +868,21 @@ export const useMapStore = create(
         isPainting: false,
         setIsPainting: isPainting => {
           if (!isPainting) {
-            const {setZoneAssignments, accumulatedGeoids, selectedZone, activeTool} = get();
-            const zone = activeTool === 'eraser' ? null : selectedZone;
-            setZoneAssignments(zone, accumulatedGeoids);
+            const {
+              setZoneAssignments,
+              accumulatedGeoids,
+              selectedZone,
+              activeTool,
+              assignmentsHash,
+              lastUpdatedHash,
+            } = get();
+            if (assignmentsHash !== lastUpdatedHash) {
+              const zone = activeTool === 'eraser' ? null : selectedZone;
+              setZoneAssignments(zone, accumulatedGeoids);
+              set({
+                lastUpdatedHash: assignmentsHash,
+              });
+            }
           }
           set({isPainting});
         },

--- a/app/src/app/utils/api/apiHandlers.ts
+++ b/app/src/app/utils/api/apiHandlers.ts
@@ -146,15 +146,13 @@ export let currentHash: string = '';
 export const getZonePopulations: (
   mapDocument: DocumentObject
 ) => Promise<ZonePopulation[]> = async mapDocument => {
-  if (populationAbortController) {
-    populationAbortController && populationAbortController?.abort();
-  }
+  populationAbortController?.abort();
+  populationAbortController = new AbortController();
   const assignmentHash = `${useMapStore.getState().assignmentsHash}`;
   if (currentHash !== assignmentHash) {
-    // return stale data
+    // return stale data if map already changed
     return useChartStore.getState().mapMetrics?.data || []
   }
-  populationAbortController = new AbortController();
   if (mapDocument) {
     return await axios
       .get(`${process.env.NEXT_PUBLIC_API_URL}/api/document/${mapDocument.document_id}/total_pop`, {

--- a/app/src/app/utils/api/apiHandlers.ts
+++ b/app/src/app/utils/api/apiHandlers.ts
@@ -133,7 +133,8 @@ export interface ZonePopulation {
   total_pop: number;
 }
 
-
+// TODO: Tanstack has a built in abort controller, we should use that
+// https://tanstack.com/query/v5/docs/framework/react/guides/query-cancellation
 export let populationAbortController: AbortController | null = null;
 export let updateAbortController: AbortController | null = null;
 export let currentHash: string = '';

--- a/app/src/app/utils/api/mutations.ts
+++ b/app/src/app/utils/api/mutations.ts
@@ -4,10 +4,13 @@ import {
   AssignmentsCreate,
   AssignmentsReset,
   createMapDocument,
+  currentHash,
   patchShatterParents,
   patchUnShatterParents,
   patchUpdateAssignments,
   patchUpdateReset,
+  populationAbortController,
+  updateAbortController,
 } from '@/app/utils/api/apiHandlers';
 import {useMapStore} from '@/app/store/mapStore';
 import {mapMetrics} from './queries';
@@ -28,7 +31,7 @@ export const patchShatter = new MutationObserver(queryClient, {
   },
   onSuccess: data => {
     console.log(`Successfully shattered parents into ${data.children.length} children`);
-    useMapStore.getState().setAssignmentsHash(performance.now().toString());
+    useMapStore.getState().setAssignmentsHash(Date.now().toString());
     return data;
   },
 });
@@ -55,16 +58,16 @@ export const patchUnShatter = new MutationObserver(queryClient, {
 export const patchUpdates = new MutationObserver(queryClient, {
   mutationFn: patchUpdateAssignments,
   onMutate: () => {
-    console.log('Updating assignments');
+    populationAbortController?.abort();
+    updateAbortController?.abort();
   },
   onError: error => {
     console.log('Error updating assignments: ', error);
   },
   onSuccess: (data: AssignmentsCreate) => {
     console.log(`Successfully upserted ${data.assignments_upserted} assignments`);
-    const {setAssignmentsHash, isPainting} = useMapStore.getState();
+    const {isPainting} = useMapStore.getState();
     const {mapMetrics: _mapMetrics} = useChartStore.getState();
-    setAssignmentsHash(performance.now().toString());
     if (!isPainting || !_mapMetrics?.data) {
       mapMetrics.refetch();
     }
@@ -103,7 +106,7 @@ export const document = new MutationObserver(queryClient, {
   },
   onSuccess: data => {
     useMapStore.getState().setMapDocument(data);
-    useMapStore.getState().setAssignmentsHash(performance.now().toString());
+    useMapStore.getState().setAssignmentsHash(Date.now().toString());
     useMapStore.getState().setAppLoadingState('loaded');
     const documentUrl = new URL(window.location.toString());
     documentUrl.searchParams.set('document_id', data.document_id);

--- a/app/src/app/utils/api/mutations.ts
+++ b/app/src/app/utils/api/mutations.ts
@@ -58,6 +58,7 @@ export const patchUnShatter = new MutationObserver(queryClient, {
 export const patchUpdates = new MutationObserver(queryClient, {
   mutationFn: patchUpdateAssignments,
   onMutate: () => {
+    console.log('Updating assignments');
     populationAbortController?.abort();
     updateAbortController?.abort();
   },

--- a/app/src/app/utils/api/queries.ts
+++ b/app/src/app/utils/api/queries.ts
@@ -57,7 +57,6 @@ export const getQueriesResultsSubs = (_useMapStore: typeof useMapStore) => {
   });
   fetchTotPop.subscribe(response => {
     if (response?.data?.results) {
-      // console.log(response?.data?.results);
       useMapStore.getState().setSummaryStat('totpop', {data: response.data.results});
       useMapStore.getState().setSummaryStat('idealpop', {
         data:

--- a/app/src/app/utils/api/queries.ts
+++ b/app/src/app/utils/api/queries.ts
@@ -57,7 +57,7 @@ export const getQueriesResultsSubs = (_useMapStore: typeof useMapStore) => {
   });
   fetchTotPop.subscribe(response => {
     if (response?.data?.results) {
-      console.log(response?.data?.results);
+      // console.log(response?.data?.results);
       useMapStore.getState().setSummaryStat('totpop', {data: response.data.results});
       useMapStore.getState().setSummaryStat('idealpop', {
         data:


### PR DESCRIPTION
We get in some weird states where the async nature of the population and updates can get out of sync with the frontend. This shows as population bars jumping around when the server is under load. 

## Description
- Adds abort controllers to update and zone population queries
- Increase debounce on zone updates
- Track last zone updates with a hash to eliminate duplicate zone updates (eg. on mouse out, painting stops and a zone update is triggered even if no features have been updated)


## Reviewers
- Primary: @raphaellaude 
- Secondary:

## Checklist
- [ ] Abort controllers work under normal circumstances
- [ ] Abort controllers work under heavy load
- [ ] Population bars do not jump around substantially
- [ ] No work is lost under normal and heavy loads

## Screenshots (if applicable):
