### PR TITLE
Qol organization changes

### DIFF
--- a/app/src/app/components/sidebar/DataPanels.tsx
+++ b/app/src/app/components/sidebar/DataPanels.tsx
@@ -4,6 +4,7 @@ import PopulationPanel from '@components/sidebar/PopulationPanel';
 import {Tabs} from '@radix-ui/themes';
 import Layers from './Layers';
 import React from 'react';
+import {useMapStore} from '@/app/store/mapStore';
 
 interface DataPanelSpec {
   title: string;
@@ -13,7 +14,6 @@ interface DataPanelSpec {
 }
 
 interface DataPanelsProps {
-  defaultPanel?: string;
   panels?: DataPanelSpec[];
 }
 
@@ -36,14 +36,19 @@ const defaultPanels: DataPanelSpec[] = [
 ];
 
 const DataPanels: React.FC<DataPanelsProps> = ({
-  defaultPanel = defaultPanels[0].title,
   panels = defaultPanels,
 }) => {
+  const sidebarPanel = useMapStore(state => state.sidebarPanel);
+  const setSidebarPanel = useMapStore(state => state.setSidebarPanel);
   return (
-    <Tabs.Root defaultValue={defaultPanel}>
+    <Tabs.Root value={sidebarPanel}>
       <Tabs.List>
         {panels.map(panel => (
-          <Tabs.Trigger key={panel.title} value={panel.title}>
+          <Tabs.Trigger
+            key={panel.title}
+            value={panel.title}
+            onClick={_ => setSidebarPanel(panel.title as any)}
+          >
             {panel.label}
           </Tabs.Trigger>
         ))}

--- a/app/src/app/components/sidebar/Layers.tsx
+++ b/app/src/app/components/sidebar/Layers.tsx
@@ -46,8 +46,6 @@ export default function Layers() {
           mapOptions.showZoneNumbers ? '2' : '',
           parentsAreBroken && mapOptions.showBrokenDistricts ? '3' : '',
           mapOptions.lockPaintedAreas === true ? '4' : '',
-          mapOptions.higlightUnassigned === true ? 'higlightUnassigned' : '',
-          mapOptions.showPopulationTooltip === true ? 'showPopulationTooltip' : '',
         ]}
       >
         <CheckboxGroup.Item
@@ -75,26 +73,6 @@ export default function Layers() {
           onClick={() => toggleHighlightBrokenDistricts()}
         >
           Highlight broken precincts
-        </CheckboxGroup.Item>
-        <CheckboxGroup.Item
-          value="higlightUnassigned"
-          onClick={() =>
-            setMapOptions({
-              higlightUnassigned: !mapOptions.higlightUnassigned,
-            })
-          }
-        >
-          Highlight unassigned units
-        </CheckboxGroup.Item>
-        <CheckboxGroup.Item
-          value="showPopulationTooltip"
-          onClick={() =>
-            setMapOptions({
-              showPopulationTooltip: !mapOptions.showPopulationTooltip,
-            })
-          }
-        >
-          Show population tooltip
         </CheckboxGroup.Item>
       </CheckboxGroup.Root>
       <Heading as="h3" weight="bold" size="3">

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationChart.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationChart.tsx
@@ -195,6 +195,7 @@ export const PopulationChart: React.FC<{
                   yScale,
                   entry,
                   maxPop,
+                  idealPopulation,
                   index,
                   barHeight,
                   isHovered,

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationLabels.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationLabels.tsx
@@ -7,6 +7,7 @@ export const PopulationLabels: React.FC<{
   yScale: (value: number) => number;
   entry: {zone: number; total_pop: number};
   maxPop: number;
+  idealPopulation?: number;
   index: number;
   barHeight: number;
   isHovered: boolean;
@@ -18,6 +19,7 @@ export const PopulationLabels: React.FC<{
   yScale,
   entry,
   maxPop,
+  idealPopulation,
   index,
   barHeight,
   isHovered,
@@ -25,7 +27,7 @@ export const PopulationLabels: React.FC<{
   showTopBottomDeviation,
   width,
 }) => {
-  const popDiffLabel = formatNumber(entry.total_pop - maxPop, 'string');
+  const popDiffLabel = formatNumber(entry.total_pop - (idealPopulation || 0), 'string');
   const popLabel = formatNumber(entry.total_pop, 'string');
   if (!popDiffLabel || !popLabel) return null;
   const [left, top] = [xScale(entry.total_pop), yScale(index) + barHeight];

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationTooltip.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationTooltip.tsx
@@ -3,7 +3,7 @@ import {colorScheme} from '@/app/constants/colors';
 import {formatNumber} from '@/app/utils/numbers';
 import {Card, Text} from '@radix-ui/themes';
 
-export const PopulationCustomTooltip = ({y, pop, index, idealPopulation, maxPop}: TooltipInput) => {
+export const PopulationCustomTooltip = ({y, pop, index, idealPopulation}: TooltipInput) => {
   const deviationFromIdeal = idealPopulation ? (idealPopulation - pop) * -1 : 0;
   const deviationDir = deviationFromIdeal > 0 ? '+' : '';
   const deviationPercent = idealPopulation

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationTooltip.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationTooltip.tsx
@@ -9,10 +9,10 @@ export const PopulationCustomTooltip = ({y, pop, index, idealPopulation, maxPop}
   const deviationPercent = idealPopulation
     ? formatNumber(deviationFromIdeal / idealPopulation, 'percent')
     : '';
-  const deviationFromMax = maxPop ? (maxPop - pop) * -1 : 0;
-  const deviationFromMaxDir = deviationFromMax > 0 ? '+' : '';
-  const deviationFromMaxPercent = maxPop ? formatNumber(deviationFromMax / maxPop, 'percent') : '';
-  const isMax = pop === maxPop;
+  // const deviationFromMax = maxPop ? (maxPop - pop) * -1 : 0;
+  // const deviationFromMaxDir = deviationFromMax > 0 ? '+' : '';
+  // const deviationFromMaxPercent = maxPop ? formatNumber(deviationFromMax / maxPop, 'percent') : '';
+  // const isMax = pop === maxPop;
   return (
     <foreignObject x="20" y={y + 10} width="300" height="120" style={{pointerEvents: 'none'}}>
       <Card size="1" style={{padding: '.25rem .375rem'}}>
@@ -30,12 +30,12 @@ export const PopulationCustomTooltip = ({y, pop, index, idealPopulation, maxPop}
         <span>
           Zone {index + 1}: {formatNumber(pop, 'string')}
         </span>
-        <br />
+        {/* <br />
         <Text>
           {idealPopulation && isMax
             ? `Deviation from max: 0`
             : `Deviation from max: ${deviationFromMaxDir}${deviationFromMaxPercent} (${deviationFromMaxDir}${formatNumber(deviationFromMax, 'string')})`}
-        </Text>
+        </Text> */}
         <br />
         <Text>
           {idealPopulation &&

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationTooltip.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationTooltip.tsx
@@ -9,10 +9,6 @@ export const PopulationCustomTooltip = ({y, pop, index, idealPopulation, maxPop}
   const deviationPercent = idealPopulation
     ? formatNumber(deviationFromIdeal / idealPopulation, 'percent')
     : '';
-  // const deviationFromMax = maxPop ? (maxPop - pop) * -1 : 0;
-  // const deviationFromMaxDir = deviationFromMax > 0 ? '+' : '';
-  // const deviationFromMaxPercent = maxPop ? formatNumber(deviationFromMax / maxPop, 'percent') : '';
-  // const isMax = pop === maxPop;
   return (
     <foreignObject x="20" y={y + 10} width="300" height="120" style={{pointerEvents: 'none'}}>
       <Card size="1" style={{padding: '.25rem .375rem'}}>
@@ -30,12 +26,6 @@ export const PopulationCustomTooltip = ({y, pop, index, idealPopulation, maxPop}
         <span>
           Zone {index + 1}: {formatNumber(pop, 'string')}
         </span>
-        {/* <br />
-        <Text>
-          {idealPopulation && isMax
-            ? `Deviation from max: 0`
-            : `Deviation from max: ${deviationFromMaxDir}${deviationFromMaxPercent} (${deviationFromMaxDir}${formatNumber(deviationFromMax, 'string')})`}
-        </Text> */}
         <br />
         <Text>
           {idealPopulation &&

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -71,7 +71,9 @@ export const PopulationPanel = () => {
         <Heading as="h3" size="3">
           Total population by district
         </Heading>
-        <PopulationPanelOptions chartOptions={chartOptions} setChartOptions={setChartOptions} />
+        <PopulationPanelOptions chartOptions={chartOptions} setChartOptions={setChartOptions} 
+          idealPopulation={idealPopulation}
+        />
       </Flex>
       <ParentSize
         style={{
@@ -108,68 +110,6 @@ export const PopulationPanel = () => {
               ' will appear when all districts are started'
             )}{' '}
           </Text>
-        </Flex>
-      )}
-      {!!idealPopulation && (
-        <Flex direction="row" align="start" gapX="2" pt="2">
-          <Text>
-            Target deviation from ideal
-            <InfoTip tips="maxDeviation" />
-          </Text>
-          <Flex direction="row" align="center" gapX="2" flexGrow={'1'}>
-            <Flex direction="column" flexGrow={'1'}>
-              <TextField.Root
-                placeholder="% Deviation"
-                type="number"
-                max={100}
-                step={0.1}
-                value={chartOptions.popTargetPopDeviationPct || undefined}
-                onChange={e => {
-                  if (e.target.value === '') {
-                    setChartOptions({
-                      popTargetPopDeviation: undefined,
-                      popTargetPopDeviationPct: undefined,
-                    });
-                  } else {
-                    const value = Math.max(0, +e.target.value);
-                    setChartOptions({
-                      popTargetPopDeviation: Math.round((value / 100) * idealPopulation),
-                      popTargetPopDeviationPct: value,
-                    });
-                  }
-                }}
-              >
-                <TextField.Slot side="right">
-                  <IconButton size="1" variant="ghost">
-                    %
-                  </IconButton>
-                </TextField.Slot>
-              </TextField.Root>
-              <Text size="1">Percent</Text>
-            </Flex>
-            <Flex direction="column" flexGrow={'1'}>
-              <TextField.Root
-                placeholder="Pop Deviation"
-                type="number"
-                value={chartOptions.popTargetPopDeviation || undefined}
-                onChange={e => {
-                  if (e.target.value === '') {
-                    setChartOptions({
-                      popTargetPopDeviation: undefined,
-                      popTargetPopDeviationPct: undefined,
-                    });
-                  } else {
-                    const value = Math.max(0, +e.target.value);
-                    setChartOptions({
-                      popTargetPopDeviation: value,
-                      popTargetPopDeviationPct: Math.round((value / idealPopulation) * 10000) / 100,
-                    });
-                  }
-                }}
-              ></TextField.Root>
-              <Text size="1">Population</Text>
-            </Flex>
-          </Flex>
         </Flex>
       )}
     </Flex>

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -88,7 +88,7 @@ export const PopulationPanel = () => {
       </Flex>
       <ParentSize
         style={{
-          minHeight: chartData.length ? `${chartData.length * 40 + 80}px` : '200px',
+          minHeight: chartData.length ? `${chartData.length * 40 + 40}px` : '200px',
           width: '100%',
         }}
       >

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -1,4 +1,4 @@
-import {Flex, Heading, IconButton, Text, TextField} from '@radix-ui/themes';
+import {CheckboxGroup, Flex, Heading, IconButton, Text, TextField} from '@radix-ui/themes';
 import React, {useMemo} from 'react';
 import {formatNumber} from '@utils/numbers';
 import {ParentSize} from '@visx/responsive'; // Import ParentSize
@@ -17,6 +17,9 @@ export const PopulationPanel = () => {
   const lockPaintedAreas = useMapStore(state => state.mapOptions.lockPaintedAreas);
   const chartOptions = useChartStore(state => state.chartOptions);
   const setChartOptions = useChartStore(state => state.setChartOptions);
+  const mapOptions = useMapStore(state => state.mapOptions);
+  const setMapOptions = useMapStore(state => state.setMapOptions);
+
   const maxNumberOrderedBars = 40; // max number of zones to consider while keeping blank spaces for missing zones
   const {chartData, stats} = useMemo(() => {
     if (mapMetrics && mapMetrics.data && numDistricts) {
@@ -66,12 +69,14 @@ export const PopulationPanel = () => {
   }
 
   return (
-    <Flex gap="3" direction="column">
+    <Flex gap="0" direction="column">
       <Flex direction="row" gap={'2'} align="center">
         <Heading as="h3" size="3">
           Total population by district
         </Heading>
-        <PopulationPanelOptions chartOptions={chartOptions} setChartOptions={setChartOptions} 
+        <PopulationPanelOptions
+          chartOptions={chartOptions}
+          setChartOptions={setChartOptions}
           idealPopulation={idealPopulation}
         />
       </Flex>
@@ -112,6 +117,39 @@ export const PopulationPanel = () => {
           </Text>
         </Flex>
       )}
+      <CheckboxGroup.Root
+        defaultValue={[]}
+        name="districts"
+        value={[
+          mapOptions.higlightUnassigned === true ? 'higlightUnassigned' : '',
+          mapOptions.showPopulationTooltip === true ? 'showPopulationTooltip' : '',
+        ]}
+      >
+        <hr className="my-2"/>
+      <Heading as="h3" weight="bold" size="3">
+        Map Options
+      </Heading>
+        <CheckboxGroup.Item
+          value="higlightUnassigned"
+          onClick={() =>
+            setMapOptions({
+              higlightUnassigned: !mapOptions.higlightUnassigned,
+            })
+          }
+        >
+          Highlight unassigned units
+        </CheckboxGroup.Item>
+        <CheckboxGroup.Item
+          value="showPopulationTooltip"
+          onClick={() =>
+            setMapOptions({
+              showPopulationTooltip: !mapOptions.showPopulationTooltip,
+            })
+          }
+        >
+          Show population tooltip
+        </CheckboxGroup.Item>
+      </CheckboxGroup.Root>
     </Flex>
   );
 };

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
@@ -46,7 +46,7 @@ export const PopulationPanelOptions: React.FC<{
             }
             className="cursor-pointer"
           >
-            Show top-to-bottom deviation numbers
+            Show distance from ideal population
           </CheckboxGroup.Item>
           <CheckboxGroup.Item
             value="numbers"

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
@@ -1,4 +1,4 @@
-import {CheckboxGroup, Flex, IconButton, Radio, Text} from '@radix-ui/themes';
+import {CheckboxGroup, Flex, IconButton, Radio, Text, TextField} from '@radix-ui/themes';
 import React from 'react'; // Import ParentSize
 import {Popover} from '@radix-ui/themes';
 import {GearIcon} from '@radix-ui/react-icons';
@@ -8,7 +8,8 @@ import {ChartStore} from '@store/chartStore';
 export const PopulationPanelOptions: React.FC<{
   chartOptions: ChartStore['chartOptions'];
   setChartOptions: ChartStore['setChartOptions'];
-}> = ({chartOptions, setChartOptions}) => {
+  idealPopulation?: number;
+}> = ({chartOptions, setChartOptions, idealPopulation}) => {
   return (
     <Popover.Root>
       <Popover.Trigger>
@@ -94,6 +95,69 @@ export const PopulationPanelOptions: React.FC<{
             />
             <Text size={'2'}>Scale bars to current zone population range</Text>
           </Flex>
+
+      {!!idealPopulation && (
+        <Flex direction="column" align="start" gapX="2" pt="2">
+          <Text className="py-2">
+            Target deviation from ideal
+            <InfoTip tips="maxDeviation" />
+          </Text>
+          <Flex direction="row" align="center" gapX="2" flexGrow={'1'}>
+            <Flex direction="column" flexGrow={'1'}>
+              <TextField.Root
+                placeholder="% Deviation"
+                type="number"
+                max={100}
+                step={0.1}
+                value={chartOptions.popTargetPopDeviationPct || undefined}
+                onChange={e => {
+                  if (e.target.value === '') {
+                    setChartOptions({
+                      popTargetPopDeviation: undefined,
+                      popTargetPopDeviationPct: undefined,
+                    });
+                  } else {
+                    const value = Math.max(0, +e.target.value);
+                    setChartOptions({
+                      popTargetPopDeviation: Math.round((value / 100) * idealPopulation),
+                      popTargetPopDeviationPct: value,
+                    });
+                  }
+                }}
+              >
+                <TextField.Slot side="right">
+                  <IconButton size="1" variant="ghost">
+                    %
+                  </IconButton>
+                </TextField.Slot>
+              </TextField.Root>
+              <Text size="1">Percent</Text>
+            </Flex>
+            <Flex direction="column" flexGrow={'1'}>
+              <TextField.Root
+                placeholder="Pop Deviation"
+                type="number"
+                value={chartOptions.popTargetPopDeviation || undefined}
+                onChange={e => {
+                  if (e.target.value === '') {
+                    setChartOptions({
+                      popTargetPopDeviation: undefined,
+                      popTargetPopDeviationPct: undefined,
+                    });
+                  } else {
+                    const value = Math.max(0, +e.target.value);
+                    setChartOptions({
+                      popTargetPopDeviation: value,
+                      popTargetPopDeviationPct: Math.round((value / idealPopulation) * 10000) / 100,
+                    });
+                  }
+                }}
+              ></TextField.Root>
+              <Text size="1">Population</Text>
+            </Flex>
+          </Flex>
+        </Flex>
+      )}
         </Flex>
       </Popover.Content>
     </Popover.Root>

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -70,7 +70,7 @@ export default function SidebarComponent() {
             md: 'inline',
           }}
         >
-          <DataPanels defaultPanel="layers" />
+          <DataPanels />
         </Box>
       </Flex>
     </Box>

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -221,6 +221,8 @@ export interface MapStore {
   focusFeatures: Array<MapFeatureInfo>;
   mapOptions: MapOptions & DistrictrMapOptions;
   setMapOptions: (options: Partial<MapStore['mapOptions']>) => void;
+  sidebarPanel: 'layers' | 'population' | 'evaluation';
+  setSidebarPanel: (panel: MapStore['sidebarPanel']) => void;
   // HIGHLIGHT
   toggleHighlightBrokenDistricts: (ids?: Set<string> | string[], _higlighted?: boolean) => void;
   activeTool: ActiveTool;
@@ -416,6 +418,7 @@ export const useMapStore = create(
               ...initialMapOptions,
               bounds: mapDocument.extent,
             },
+            sidebarPanel: 'population',
             shatterIds: {parents: new Set(), children: new Set()},
           });
         },
@@ -763,6 +766,8 @@ export const useMapStore = create(
           lockPaintedAreas: false,
         },
         setMapOptions: options => set({mapOptions: {...get().mapOptions, ...options}}),
+        sidebarPanel: 'layers',
+        setSidebarPanel: sidebarPanel => set({sidebarPanel}),
         toggleHighlightBrokenDistricts: (_ids, _higlighted) => {
           const {shatterIds, mapOptions, getMapRef, mapDocument} = get();
           const mapRef = getMapRef();

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -389,11 +389,11 @@ export const useMapStore = create(
             setFreshMap,
             resetZoneAssignments,
             upsertUserMap,
-            mapOptions,
           } = get();
           if (currentMapDocument?.document_id === mapDocument.document_id) {
             return;
           }
+          const initialMapOptions = useMapStore.getInitialState().mapOptions;
           parentIdCache.clear();
           setFreshMap(true);
           resetZoneAssignments();
@@ -413,7 +413,7 @@ export const useMapStore = create(
           set({
             mapDocument: mapDocument,
             mapOptions: {
-              ...mapOptions,
+              ...initialMapOptions,
               bounds: mapDocument.extent,
             },
             shatterIds: {parents: new Set(), children: new Set()},

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -141,8 +141,10 @@ export const handleMapMouseLeave = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
-  setTimeout(() => useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
-  useTooltipStore.getState().setTooltip(null);
+  setTimeout(() => {
+    useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY)
+    useTooltipStore.getState().setTooltip(null);
+  }, 250);
   useMapStore.getState().setIsPainting(false);
 };
 
@@ -150,8 +152,10 @@ export const handleMapMouseOut = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
-  setTimeout(() => useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY), 250);
-  useTooltipStore.getState().setTooltip(null);
+  setTimeout(() => {
+    useHoverStore.getState().setHoverFeatures(EMPTY_FEATURE_ARRAY)
+    useTooltipStore.getState().setTooltip(null);
+  }, 250);
   useMapStore.getState().setIsPainting(false);
 };
 


### PR DESCRIPTION
Various requested organization and quality of life enhancements

## Description
This PR integrates the following feedback from Moon:
- move "Highlight unassigned units" and "Show population tooltip" out of data layers -- makes more sense in the population tab
- add a counter for unassigned population
- the hover-over on the population bars would be fine with just distance to ideal, doesn't need distance to max
- stash the "target deviation from ideal" feature in the gear drop-down, i.e., treat it as an advanced feature
- the user should start in the population tab when they pick a geography.  (Now I think it starts in data layers.)
- the tool remembers a lot of settings from your last map when you start a new map, such as whether the tooltip is on, whether you're in zoom mode on population bars, what your target percent is -- I don't think this stuff should be remembered, but rather should start again at defaults with a new map

Tech description:
- Mostly just code reorganization
- Moves data panels to state and makes the tab component controlled

## Reviewers
- Primary: @mariogiampieri 
- Secondary: @mapmeld 

