### PR TITLE
[bugfix] Stale loaded map ID on new document

### DIFF
--- a/app/src/app/utils/api/mutations.ts
+++ b/app/src/app/utils/api/mutations.ts
@@ -106,9 +106,11 @@ export const document = new MutationObserver(queryClient, {
     console.error('Error creating map document: ', error);
   },
   onSuccess: data => {
-    useMapStore.getState().setMapDocument(data);
-    useMapStore.getState().setAssignmentsHash(Date.now().toString());
-    useMapStore.getState().setAppLoadingState('loaded');
+    const {setMapDocument, setLoadedMapId, setAssignmentsHash, setAppLoadingState} = useMapStore.getState();
+    setMapDocument(data);
+    setLoadedMapId(data.document_id);
+    setAssignmentsHash(Date.now().toString());
+    setAppLoadingState('loaded');
     const documentUrl = new URL(window.location.toString());
     documentUrl.searchParams.set('document_id', data.document_id);
     history.pushState({}, '', documentUrl.toString());


### PR DESCRIPTION
We are now using a slightly redundant 'loadedMapId' piece of state to avoid re-running certain subscriptions and functions, especially when tabbing in and out.

A small bug occurs when you create a new map, then return to the immediately previous map via Recents. This PR makes the new document create mutation change the loadedMapId in the state, which resolves the issue