### PR TITLE
Update fallback for null num_districts [fixes #205]

### DIFF
--- a/app/src/app/components/sidebar/ColorPicker.tsx
+++ b/app/src/app/components/sidebar/ColorPicker.tsx
@@ -45,7 +45,7 @@ export const ColorPicker = <T extends boolean>({
           }}
         >
           {!!mapDocument &&
-            colorArray.slice(0, mapDocument.num_districts ?? 0).map((color, i) => (
+            colorArray.slice(0, mapDocument.num_districts ?? 4).map((color, i) => (
               <CheckboxGroupItem
                 key={i}
                 // @ts-ignore Correct behavior, global CSS variables need to be extended
@@ -71,7 +71,7 @@ export const ColorPicker = <T extends boolean>({
         defaultValue={colorArray[defaultValue]}
       >
         {!!mapDocument &&
-          colorArray.slice(0, mapDocument.num_districts ?? 0).map((color, i) => (
+          colorArray.slice(0, mapDocument.num_districts ?? 4).map((color, i) => (
             <RadioGroupItem key={i} style={{backgroundColor: color}} value={color}>
               <RadioGroupIndicator />
             </RadioGroupItem>


### PR DESCRIPTION
I noticed the same bug as #205 some time ago. If I remember right, it was when we added `num_districts` to the DB, so older maps had `null ?? 0` districts. This updates the null count fallback to be 4 districts.