### PR TITLE
Population bars while painting bug fixes (part 1)

### DIFF
--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -9,6 +9,7 @@ import {calculateMinMaxRange} from '@utils/zone-helpers';
 import {PopulationChart} from './PopulationChart/PopulationChart';
 import {PopulationPanelOptions} from './PopulationPanelOptions';
 import { getEntryTotal } from '@/app/utils/summaryStats';
+import { fetchTotPop } from '@/app/utils/api/queries';
 
 export const PopulationPanel = () => {
   const mapMetrics = useChartStore(state => state.mapMetrics);
@@ -20,12 +21,13 @@ export const PopulationPanel = () => {
   const setChartOptions = useChartStore(state => state.setChartOptions);
   const mapOptions = useMapStore(state => state.mapOptions);
   const setMapOptions = useMapStore(state => state.setMapOptions);
-  const totPop = useMapStore(state => getEntryTotal(state.summaryStats.totpop?.data || {}));
+  const totalPopData = useMapStore(state => state.summaryStats.totpop?.data);
+  const totPop = getEntryTotal(totalPopData || {})
 
   const maxNumberOrderedBars = 40; // max number of zones to consider while keeping blank spaces for missing zones
   const {chartData, stats, unassigned} = useMemo(() => {
-    let unassigned = totPop
-    if (mapMetrics && mapMetrics.data && numDistricts) {
+    let unassigned = structuredClone(totPop)
+    if (mapMetrics && mapMetrics.data && numDistricts && totPop) {
       const chartData = Array.from({length: numDistricts}, (_, i) => i + 1).reduce(
         (acc, district) => {
           const totalPop = mapMetrics.data.reduce((acc, entry) => {
@@ -50,9 +52,9 @@ export const PopulationPanel = () => {
         unassigned:0
       };
     }
-  }, [mapMetrics]);
+  }, [mapMetrics, totalPopData, numDistricts]);
 
-  if (mapMetrics?.isPending) {
+  if (mapMetrics?.isPending || !totalPopData) {
     return <div>Loading...</div>;
   }
 

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -9,7 +9,6 @@ import {calculateMinMaxRange} from '@utils/zone-helpers';
 import {PopulationChart} from './PopulationChart/PopulationChart';
 import {PopulationPanelOptions} from './PopulationPanelOptions';
 import { getEntryTotal } from '@/app/utils/summaryStats';
-import { fetchTotPop } from '@/app/utils/api/queries';
 
 export const PopulationPanel = () => {
   const mapMetrics = useChartStore(state => state.mapMetrics);

--- a/app/src/app/store/mapEditSubs.ts
+++ b/app/src/app/store/mapEditSubs.ts
@@ -15,7 +15,9 @@ const zoneUpdates = ({getMapRef, zoneAssignments, appLoadingState}: Partial<MapS
   const mapIsLocked = _useMapStore.getState().mapLock;
   if (!mapIsLocked && getMapRef?.() && zoneAssignments?.size && appLoadingState === 'loaded') {
     const assignments = FormatAssignments();
-    patchUpdates.mutate(assignments);
+    if (assignments.length) {
+      patchUpdates.mutate(assignments);
+    }
   }
 };
 

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -595,7 +595,7 @@ export const useMapStore = createWithMiddlewares<MapStore>(
             // TODO: Should this be true instead?
             // Is there a way to clean up the state history during
             // break / shatter?
-            isTemporalAction: true,
+            isTemporalAction: false,
             mapLock: false,
             captiveIds: newChildren,
             lockedFeatures: newLockedFeatures,

--- a/app/src/app/utils/api/queries.ts
+++ b/app/src/app/utils/api/queries.ts
@@ -149,6 +149,7 @@ fetchAssignments.subscribe(assignments => {
         loadedMapId
       );
     } else {
+      fetchTotPop.refetch();
       loadZoneAssignments(assignments.data);
       useMapStore.temporal.getState().clear();
     }

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -52,7 +52,7 @@ function getLayerIdsToPaint(child_layer: string | undefined | null, activeTool: 
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
  * @param map - Map | null, the maplibre map instance
  */
-export const handleMapClick = (
+export const handleMapClick = throttle((
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   map: MapLibreMap | null
 ) => {
@@ -87,7 +87,7 @@ export const handleMapClick = (
   } else {
     // tbd, for pan mode - is there an info mode on click?
   }
-};
+}, 25);
 
 export const handleMapMouseUp = (
   e: MapLayerMouseEvent | MapLayerTouchEvent,


### PR DESCRIPTION
There are a few bugs with population while painting that make it feel unreliable.

## Description
- Changes break/healing to be a non-temporal action so that population properly incorporates
- Adds a throttle to map click events to prevent double paint events at the block level

## Reviewers
- Primary: @mapmeld 
- Secondary: @raphaellaude 

## Checklist
- [ ] Population bars are stable when breaking/healing
- [ ] Population bars are stable when painting at the block level

