### PR TITLE
Toggle a BVAP layer

### DIFF
--- a/app/src/app/components/sidebar/Evaluation.css
+++ b/app/src/app/components/sidebar/Evaluation.css
@@ -1,0 +1,27 @@
+.color-legend {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 10px;
+  font-size: 80%;
+}
+.color-legend .gradientbar {
+  width: 191px;
+  height: 24px;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(0, 0, 139, 0.81));
+  display: inline-block;
+  border: 1px solid #ddd;
+  border-left: none;
+  border-right: none;
+}
+.color-legend .notch {
+  width: 35px;
+  display: inline-block;
+  font-size: 10px;
+  height: 10px;
+}
+.color-legend .square {
+  width: 35px;
+  height: 24px;
+  display: inline-block;
+}

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -21,6 +21,7 @@ export const BLOCK_LAYER_ID_HIGHLIGHT_CHILD = BLOCK_LAYER_ID + '-highlight-child
 export const BLOCK_LAYER_ID_CHILD = 'blocks-child';
 export const BLOCK_HOVER_LAYER_ID = `${BLOCK_LAYER_ID}-hover`;
 export const BLOCK_HOVER_LAYER_ID_CHILD = `${BLOCK_LAYER_ID_CHILD}-hover`;
+const DEMO_LAYER = 'demo-layer';
 
 export const INTERACTIVE_LAYERS = [BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CHILD];
 export const LINE_LAYERS = [BLOCK_LAYER_ID, BLOCK_LAYER_ID_CHILD] as const;
@@ -45,7 +46,7 @@ export const COUNTY_LAYER_IDS: string[] = ['counties_boundary', 'counties_labels
 
 export const LABELS_BREAK_LAYER_ID = 'places_subplace';
 
-const vap_choropleths: Record<string, boolean> = {
+export const VAP_CHOROPLETHS: Record<string, boolean> = {
   co_vtd_p1_view: true,
   co_block_p1_view: true,
   co_p1_view: true,
@@ -311,7 +312,9 @@ const addBlockLayers = (map: Map | null, mapDocument: DocumentObject) => {
       LABELS_BREAK_LAYER_ID
     );
   }
-  if (mapDocument.gerrydb_table in vap_choropleths) {
+  map?.addLayer(getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT));
+
+  if (mapDocument.gerrydb_table in VAP_CHOROPLETHS) {
     const demoLayerSpec: LayerSpecification = {
       id: DEMO_LAYER,
       source: BLOCK_SOURCE_ID,
@@ -321,7 +324,7 @@ const addBlockLayers = (map: Map | null, mapDocument: DocumentObject) => {
         visibility: 'visible',
       },
       paint: {
-        'fill-opacity': 0.8,
+        'fill-opacity': 0,
         'fill-color': [
           'rgba',
           0,
@@ -329,16 +332,16 @@ const addBlockLayers = (map: Map | null, mapDocument: DocumentObject) => {
           139,
           [
             'case',
-            ['==', ['get', 'total_pop'], 0],
+            ['==', ['get', 'total_pop'], '0'],
             0, // if VAP is 0, return 0 opacity
             ['/', ['to-number', ['get', 'black_pop']], ['to-number', ['get', 'total_pop']]], // opacity is %bvap
           ],
         ],
       },
     };
-    map?.addLayer(demoLayerSpec);
+    map.addLayer(demoLayerSpec);
   }
-  map?.addLayer(getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT));
+
   useMapStore.getState().setMapRenderingState('loaded');
 };
 
@@ -362,6 +365,14 @@ export function removeBlockLayers(map: Map | null) {
   [BLOCK_SOURCE_ID].forEach(source => {
     map.getSource(source) && map.removeSource(source);
   });
+}
+
+export function showVAPlayer(map: Map | null) {
+  map?.setPaintProperty(DEMO_LAYER, 'fill-opacity', 0.8);
+}
+
+export function hideVAPlayer(map: Map | null) {
+  map?.setPaintProperty(DEMO_LAYER, 'fill-opacity', 0);
 }
 
 const getDissolved = async () => {

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -45,6 +45,12 @@ export const COUNTY_LAYER_IDS: string[] = ['counties_boundary', 'counties_labels
 
 export const LABELS_BREAK_LAYER_ID = 'places_subplace';
 
+const vap_choropleths: Record<string, boolean> = {
+  co_vtd_p1_view: true,
+  co_block_p1_view: true,
+  co_p1_view: true,
+};
+
 const colorStyleBaseline: any[] = ['case'];
 
 export const ZONE_ASSIGNMENT_STYLE_DYNAMIC = colorScheme.reduce((val, color, i) => {
@@ -305,6 +311,33 @@ const addBlockLayers = (map: Map | null, mapDocument: DocumentObject) => {
       LABELS_BREAK_LAYER_ID
     );
   }
+  if (mapDocument.gerrydb_table in vap_choropleths) {
+    const demoLayerSpec: LayerSpecification = {
+      id: DEMO_LAYER,
+      source: BLOCK_SOURCE_ID,
+      'source-layer': mapDocument.parent_layer,
+      type: 'fill',
+      layout: {
+        visibility: 'visible',
+      },
+      paint: {
+        'fill-opacity': 0.8,
+        'fill-color': [
+          'rgba',
+          0,
+          0,
+          139,
+          [
+            'case',
+            ['==', ['get', 'total_pop'], 0],
+            0, // if VAP is 0, return 0 opacity
+            ['/', ['to-number', ['get', 'black_pop']], ['to-number', ['get', 'total_pop']]], // opacity is %bvap
+          ],
+        ],
+      },
+    };
+    map?.addLayer(demoLayerSpec);
+  }
   map?.addLayer(getHighlightLayerSpecification(mapDocument.parent_layer, BLOCK_LAYER_ID_HIGHLIGHT));
   useMapStore.getState().setMapRenderingState('loaded');
 };
@@ -321,6 +354,7 @@ export function removeBlockLayers(map: Map | null) {
     BLOCK_LAYER_ID_CHILD,
     BLOCK_HOVER_LAYER_ID_CHILD,
     BLOCK_LAYER_ID_HIGHLIGHT_CHILD,
+    DEMO_LAYER,
   ].forEach(layer => {
     map.getLayer(layer) && map.removeLayer(layer);
   });


### PR DESCRIPTION
Draft/demo of BVAP toggle on Colorado maps, trying to show a proof-of-concept so we can figure out a good UI

<img width="417" alt="Screenshot 2025-02-05 at 10 48 02 PM" src="https://github.com/user-attachments/assets/1d868e3d-225d-4e04-ab49-6136b67b1e91" />

<img width="879" alt="Screenshot 2025-01-28 at 10 25 25 PM" src="https://github.com/user-attachments/assets/6a4369f7-db08-45c4-926a-5b90512ecb05" />

Feedback
- can we update the population layer upload process so that populations are uploaded as integers and not strings? I don't know how it affects storage or overhead, and it is manageable in the map styling code, just wanted to mention it
- I think that this data might be showing % Black, and not the % BVAP

Questions:
- should the layer be in Evaluation, in its own sidebar accordion section, or added to the map toolbar?
- should the map key be over the map or in the same section as the toolbar?
- currently hardcoding which maps have population data. Should this / is this on the DB record?