### PR TITLE
Transition to separate parent and child tilesets

### DIFF
--- a/app/src/app/components/Map/DemographicLayer.tsx
+++ b/app/src/app/components/Map/DemographicLayer.tsx
@@ -3,7 +3,6 @@ import {
   BLOCK_HOVER_LAYER_ID_CHILD,
   BLOCK_LAYER_ID,
   BLOCK_LAYER_ID_CHILD,
-  BLOCK_SOURCE_ID,
   LABELS_BREAK_LAYER_ID,
   OVERLAY_OPACITY,
 } from '@/app/constants/layers';
@@ -35,7 +34,7 @@ export const DemographicLayer: React.FC<{
     
     <Layer
       id={`${child ? BLOCK_HOVER_LAYER_ID_CHILD : BLOCK_HOVER_LAYER_ID}${isOverlay ? '_overlay' : ''}`}
-      source={BLOCK_SOURCE_ID}
+      source={id}
       source-layer={id}
       filter={child ? layerFilter : ['literal', true]}
       beforeId={LABELS_BREAK_LAYER_ID}
@@ -57,7 +56,7 @@ export const DemographicLayer: React.FC<{
 
           <Layer
             id={child ? BLOCK_LAYER_ID_CHILD : BLOCK_LAYER_ID}
-            source={BLOCK_SOURCE_ID}
+            source={id}
             source-layer={id}
             filter={layerFilter}
             beforeId={LABELS_BREAK_LAYER_ID}

--- a/app/src/app/components/Map/HighlightOverlayLayerGroup.tsx
+++ b/app/src/app/components/Map/HighlightOverlayLayerGroup.tsx
@@ -1,7 +1,6 @@
 import {
   BLOCK_HOVER_LAYER_ID,
   BLOCK_HOVER_LAYER_ID_CHILD,
-  BLOCK_SOURCE_ID,
   LABELS_BREAK_LAYER_ID,
 } from '@/app/constants/layers';
 import {useMapStore} from '@/app/store/mapStore';
@@ -33,7 +32,7 @@ export const HighlightOverlayerLayerGroup: React.FC<{
     <>
       <Layer
         id={(child ? BLOCK_HOVER_LAYER_ID_CHILD : BLOCK_HOVER_LAYER_ID) + '_demography_hover'}
-        source={BLOCK_SOURCE_ID}
+        source={id}
         source-layer={id}
         filter={child ? layerFilter : ['literal', true]}
         beforeId={LABELS_BREAK_LAYER_ID}
@@ -48,7 +47,7 @@ export const HighlightOverlayerLayerGroup: React.FC<{
       />
       <Layer
         id={(child ? BLOCK_HOVER_LAYER_ID_CHILD : BLOCK_HOVER_LAYER_ID) + '_line'}
-        source={BLOCK_SOURCE_ID}
+        source={id}
         source-layer={id}
         filter={child ? layerFilter : ['literal', true]}
         beforeId={LABELS_BREAK_LAYER_ID}

--- a/app/src/app/components/Map/ZoneLayerGroup.tsx
+++ b/app/src/app/components/Map/ZoneLayerGroup.tsx
@@ -5,7 +5,6 @@ import {
   BLOCK_LAYER_ID_CHILD,
   BLOCK_LAYER_ID_HIGHLIGHT,
   BLOCK_LAYER_ID_HIGHLIGHT_CHILD,
-  BLOCK_SOURCE_ID,
   getLayerFill,
   LABELS_BREAK_LAYER_ID,
   ZONE_ASSIGNMENT_STYLE,
@@ -52,7 +51,7 @@ export const ZoneLayerGroup: React.FC<{
     <>
       <Layer
         id={child ? BLOCK_LAYER_ID_CHILD : BLOCK_LAYER_ID}
-        source={BLOCK_SOURCE_ID}
+        source={id}
         source-layer={id}
         filter={layerFilter}
         beforeId={LABELS_BREAK_LAYER_ID}
@@ -89,7 +88,7 @@ export const ZoneLayerGroup: React.FC<{
       />
       <Layer
         id={child ? BLOCK_HOVER_LAYER_ID_CHILD : BLOCK_HOVER_LAYER_ID}
-        source={BLOCK_SOURCE_ID}
+        source={id}
         source-layer={id}
         filter={child ? layerFilter : ['literal', true]}
         beforeId={LABELS_BREAK_LAYER_ID}
@@ -104,7 +103,7 @@ export const ZoneLayerGroup: React.FC<{
       />
       <Layer
         id={child ? BLOCK_LAYER_ID_HIGHLIGHT_CHILD : BLOCK_LAYER_ID_HIGHLIGHT}
-        source={BLOCK_SOURCE_ID}
+        source={id}
         source-layer={id}
         filter={child ? layerFilter : ['literal', true]}
         type="line"

--- a/app/src/app/utils/demography/demographyCache.ts
+++ b/app/src/app/utils/demography/demographyCache.ts
@@ -2,7 +2,7 @@
 import {op, table, escape} from 'arquero';
 import type {ColumnTable} from 'arquero';
 import {DocumentObject} from '../api/apiHandlers';
-import {BLOCK_SOURCE_ID, FALLBACK_NUM_DISTRICTS} from '../../constants/layers';
+import {FALLBACK_NUM_DISTRICTS} from '../../constants/layers';
 import {MapGeoJSONFeature} from 'maplibre-gl';
 import {MapStore, useMapStore} from '../../store/mapStore';
 import {useChartStore} from '../../store/chartStore';
@@ -206,7 +206,7 @@ class DemographyCache {
       .map((properties: TableRow) => ({
         id: properties.path,
         sourceLayer: properties.sourceLayer,
-        source: BLOCK_SOURCE_ID,
+        source: properties.sourceLayer,
         properties,
       })) as MapGeoJSONFeature[];
     return ids;
@@ -383,7 +383,7 @@ class DemographyCache {
 
       mapRef.setFeatureState(
         {
-          source: BLOCK_SOURCE_ID,
+          source: row.sourceLayer,
           sourceLayer: row.sourceLayer,
           id,
         },
@@ -422,7 +422,7 @@ class DemographyCache {
   }) {
     if (!this.table) return;
     const quantiles = this.calculateQuantiles(variable, numberOfBins);
-    const dataSoureExists = mapRef.getSource(BLOCK_SOURCE_ID);
+    const dataSoureExists = mapDocument?.parent_layer && mapRef.getSource(mapDocument.parent_layer);
     if (!mapRef || !mapDocument || !dataSoureExists || !quantiles) return;
     const mapMode = useMapStore.getState().mapOptions.showDemographicMap;
     const defaultColor =

--- a/app/src/app/utils/events/handlers.ts
+++ b/app/src/app/utils/events/handlers.ts
@@ -1,4 +1,3 @@
-import {BLOCK_SOURCE_ID} from '@/app/constants/layers';
 import {MapGeoJSONFeature} from 'maplibre-gl';
 import {MapRef} from 'react-map-gl/maplibre';
 import {MapStore} from '@/app/store/mapStore';
@@ -22,7 +21,7 @@ export const ResetMapSelectState = (
 ) => {
   if (map && Object.keys(mapStoreRef.zoneAssignments).length) {
     map.removeFeatureState({
-      source: BLOCK_SOURCE_ID,
+      source: sourceLayer,
       sourceLayer: sourceLayer,
     });
 

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -242,7 +242,8 @@ export const handleMapContextMenu = (e: MapLayerMouseEvent | MapLayerTouchEvent)
 export const handleDataLoad = (e: MapSourceDataEvent) => {
   const {mapDocument, shatterMappings} = useMapStore.getState();
   const {tiles_s3_path, parent_layer, child_layer} = mapDocument || {};
-  if (!tiles_s3_path || !parent_layer || !(e?.source as any)?.url?.includes(tiles_s3_path)) return;
+  const isParentOCchild = (e?.source as any)?.url?.includes(parent_layer) || (e?.source as any)?.url?.includes(child_layer);
+  if (!tiles_s3_path || !parent_layer || !isParentOCchild) return;
   const tileData = e?.tile?.latestFeatureIndex;
   if (!tileData) return;
   if (!tileData.vtLayers) {

--- a/app/src/app/utils/helpers.ts
+++ b/app/src/app/utils/helpers.ts
@@ -9,7 +9,6 @@ import {
 import {
   BLOCK_HOVER_LAYER_ID,
   BLOCK_HOVER_LAYER_ID_CHILD,
-  BLOCK_SOURCE_ID,
 } from '@/app/constants/layers';
 import {MapStore, useMapStore} from '../store/mapStore';
 import {NullableZone} from '../constants/types';
@@ -202,7 +201,6 @@ export const getMap = (_getMapRef?: MapStore['getMapRef']) => {
  * @returns {void}
  *
  * @requires useMapStore
- * @requires BLOCK_SOURCE_ID
  *
  * @description
  * This function does the following:
@@ -238,22 +236,20 @@ export const colorZoneAssignments = (
   ) {
     return;
   }
-  const featureStateCache = mapRef.style.sourceCaches?.[BLOCK_SOURCE_ID]?._state?.state;
-  const featureStateChangesCache = mapRef.style.sourceCaches?.[BLOCK_SOURCE_ID]?._state?.stateChanges;
-  if (!featureStateCache) return;
 
   zoneAssignments.forEach((zone, id) => {
     if (!id) return;
     const isChild = currentShatterIds.children.has(id);
     const sourceLayer = isChild ? mapDocument.child_layer : mapDocument.parent_layer;
     if (!sourceLayer) return;
-    const featureState = featureStateCache?.[sourceLayer]?.[id];
-    const futureState = featureStateChangesCache?.[sourceLayer]?.[id];
+    
+    const featureState = mapRef.style.sourceCaches?.[sourceLayer]?._state?.state?.[sourceLayer]?.[id];
+    const futureState = mapRef.style.sourceCaches?.[sourceLayer]?._state?.stateChanges?.[sourceLayer]?.[id];
     if (!isInitialRender && (featureState?.zone === zone || futureState?.zone === zone)) return;
 
     mapRef?.setFeatureState(
       {
-        source: BLOCK_SOURCE_ID,
+        source: sourceLayer,
         id,
         sourceLayer,
       },
@@ -271,7 +267,7 @@ export const colorZoneAssignments = (
     if (!sourceLayer) return;
     mapRef?.setFeatureState(
       {
-        source: BLOCK_SOURCE_ID,
+        source: sourceLayer,
         id,
         sourceLayer,
       },
@@ -326,7 +322,7 @@ export const resetZoneColors = ({
     const sourceLayer = getSourceLayer(id);
     mapRef?.setFeatureState(
       {
-        source: BLOCK_SOURCE_ID,
+        source: sourceLayer,
         id,
         sourceLayer,
       },

--- a/app/src/app/utils/map/mapRenderSubs.ts
+++ b/app/src/app/utils/map/mapRenderSubs.ts
@@ -1,4 +1,4 @@
-import {PARENT_LAYERS, CHILD_LAYERS, getLayerFill, BLOCK_SOURCE_ID} from '@constants/layers';
+import {PARENT_LAYERS, CHILD_LAYERS, getLayerFill} from '@constants/layers';
 import {
   ColorZoneAssignmentsState,
   colorZoneAssignments,
@@ -52,7 +52,7 @@ export class MapRenderSubscriber {
     shatterIds.parents.forEach(id => {
       this.mapRef.setFeatureState(
         {
-          source: BLOCK_SOURCE_ID,
+          source: mapDocument?.parent_layer,
           id,
           sourceLayer: mapDocument?.parent_layer,
         },
@@ -68,7 +68,7 @@ export class MapRenderSubscriber {
         this.mapRef.setFeatureState(
           {
             id: parentId,
-            source: BLOCK_SOURCE_ID,
+            source: mapDocument.parent_layer,
             sourceLayer: mapDocument.parent_layer,
           },
           {


### PR DESCRIPTION
Due to performance reasons, we need to separate out the parent and child tilesets. 

## Description
- This will optimize rendering and selection speed.
- Ideally we can migrate with as minimal changes as possible
- Rest of the API should remain the same

## Reviewers
- Primary: @mariogiampieri 
- Secondary: @raphaellaude 

## Checklist
- [ ] Change FE layer configs
- [ ] Probably rename layers and sources, sanely 
- [ ] Update map events and interactions as needed
- [ ] Upload required data
- [ ] Update tilesets pipeline
- [ ] Drop tilesets column ?
