### PR TITLE
Better zone number labels

### DIFF
--- a/app/src/app/components/Cms/ContentEditor/ContentEditor.tsx
+++ b/app/src/app/components/Cms/ContentEditor/ContentEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import {useCmsFormStore} from '@/app/store/cmsFormStore';
 import {LANG_MAPPING} from '@/app/utils/language';
 import {Box, Button, Flex, Grid, Heading, Select, Text, TextField} from '@radix-ui/themes';
@@ -20,21 +20,29 @@ export const ContentEditor: React.FC = () => {
   const [contentHasChanged, setContentHasChanged] = useState(false);
 
   useEffect(() => {
-    if (!editingContent && formData?.content.slug && formData?.content.language && formData?.content.title) {
+    if (
+      !editingContent &&
+      formData?.content.slug &&
+      formData?.content.language &&
+      formData?.content.title
+    ) {
       setContentHasChanged(true);
     } else if (editingContent) {
-      const currentEditContent = editingContent.content.draft_content || editingContent.content.published_content;
+      const currentEditContent =
+        editingContent.content.draft_content || editingContent.content.published_content;
       if (!currentEditContent) {
         setContentHasChanged(false);
       } else {
-        const contentChanged = JSON.stringify({title: currentEditContent.title, body: currentEditContent.body}) !== JSON.stringify({title: formData?.content.title, body: formData?.content.body});
+        const contentChanged =
+          JSON.stringify({title: currentEditContent.title, body: currentEditContent.body}) !==
+          JSON.stringify({title: formData?.content.title, body: formData?.content.body});
         setContentHasChanged(contentChanged);
       }
     } else {
       setContentHasChanged(false);
     }
   }, [editingContent, formData]);
-  
+
   return (
     <Flex direction="column" gapY="4" p="6" className="bg-white shadow rounded-lg">
       <Heading as="h2" className="text-xl font-semibold">

--- a/app/src/app/components/Map/HighlightOverlayLayerGroup.tsx
+++ b/app/src/app/components/Map/HighlightOverlayLayerGroup.tsx
@@ -4,7 +4,7 @@ import {
   BLOCK_SOURCE_ID,
   LABELS_BREAK_LAYER_ID,
 } from '@/app/constants/layers';
-import { useLayerFilter } from '@/app/hooks/useLayerFilter';
+import {useLayerFilter} from '@/app/hooks/useLayerFilter';
 import {useMapStore} from '@/app/store/mapStore';
 import {FilterSpecification} from 'maplibre-gl';
 import {useMemo} from 'react';
@@ -16,7 +16,7 @@ export const HighlightOverlayerLayerGroup: React.FC<{
   const mapDocument = useMapStore(state => state.mapDocument);
   const id = child ? mapDocument?.child_layer : mapDocument?.parent_layer;
   const isOverlay = useMapStore(state => state.mapOptions.showDemographicMap) === 'overlay';
-  const layerFilter = useLayerFilter(child)
+  const layerFilter = useLayerFilter(child);
   const fillOpacity = isOverlay ? 0.3 : 0.1;
 
   if (!id || !mapDocument) return null;

--- a/app/src/app/components/Map/MetaLayers.tsx
+++ b/app/src/app/components/Map/MetaLayers.tsx
@@ -143,9 +143,12 @@ const ZoneNumbersLayer = () => {
             'interpolate',
             ['linear'],
             ['zoom'],
-            5, 10,   // At zoom level 5, radius is 10 (increased from 8)
-            10, 15,  // At zoom level 10, radius is 15 (increased from 12)
-            15, 18   // At zoom level 15 and above, radius is 18 (increased from 15)
+            5,
+            10, // At zoom level 5, radius is 10 (increased from 8)
+            10,
+            15, // At zoom level 10, radius is 15 (increased from 12)
+            15,
+            18, // At zoom level 15 and above, radius is 18 (increased from 15)
           ],
           'circle-opacity': 0.8,
           'circle-stroke-color': ZONE_LABEL_STYLE(colorScheme) || '#000',
@@ -153,8 +156,10 @@ const ZoneNumbersLayer = () => {
             'interpolate',
             ['linear'],
             ['zoom'],
-            5, 1.5,  // At zoom level 5, stroke width is 1.5 (increased from 1)
-            15, 2.5  // At zoom level 15 and above, stroke width is 2.5 (increased from 2)
+            5,
+            1.5, // At zoom level 5, stroke width is 1.5 (increased from 1)
+            15,
+            2.5, // At zoom level 15 and above, stroke width is 2.5 (increased from 2)
           ],
         }}
       ></Layer>
@@ -170,9 +175,12 @@ const ZoneNumbersLayer = () => {
             'interpolate',
             ['linear'],
             ['zoom'],
-            5, 12,   // At zoom level 5, text size is 12 (increased from 10)
-            10, 16,  // At zoom level 10, text size is 16 (increased from 14)
-            15, 20   // At zoom level 15 and above, text size is 20 (increased from 18)
+            5,
+            12, // At zoom level 5, text size is 12 (increased from 10)
+            10,
+            16, // At zoom level 10, text size is 16 (increased from 14)
+            15,
+            20, // At zoom level 15 and above, text size is 20 (increased from 18)
           ],
           'text-anchor': 'center',
           'text-offset': [0, 0],
@@ -197,9 +205,12 @@ const ZoneNumbersLayer = () => {
             'interpolate',
             ['linear'],
             ['zoom'],
-            5, 0.8,   // At zoom level 5, icon size is 0.8 (increased from 0.6)
-            10, 1.0,  // At zoom level 10, icon size is 1.0 (increased from 0.8)
-            15, 1.2   // At zoom level 15 and above, icon size is 1.2 (increased from 1)
+            5,
+            0.8, // At zoom level 5, icon size is 0.8 (increased from 0.6)
+            10,
+            1.0, // At zoom level 10, icon size is 1.0 (increased from 0.8)
+            15,
+            1.2, // At zoom level 15 and above, icon size is 1.2 (increased from 1)
           ],
           'icon-allow-overlap': true,
         }}

--- a/app/src/app/components/Map/MetaLayers.tsx
+++ b/app/src/app/components/Map/MetaLayers.tsx
@@ -139,10 +139,23 @@ const ZoneNumbersLayer = () => {
         }}
         paint={{
           'circle-color': '#fff',
-          'circle-radius': 15,
+          'circle-radius': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            5, 10,   // At zoom level 5, radius is 10 (increased from 8)
+            10, 15,  // At zoom level 10, radius is 15 (increased from 12)
+            15, 18   // At zoom level 15 and above, radius is 18 (increased from 15)
+          ],
           'circle-opacity': 0.8,
           'circle-stroke-color': ZONE_LABEL_STYLE(colorScheme) || '#000',
-          'circle-stroke-width': 2,
+          'circle-stroke-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            5, 1.5,  // At zoom level 5, stroke width is 1.5 (increased from 1)
+            15, 2.5  // At zoom level 15 and above, stroke width is 2.5 (increased from 2)
+          ],
         }}
       ></Layer>
       <Layer
@@ -153,7 +166,14 @@ const ZoneNumbersLayer = () => {
           visibility: shouldHide ? 'none' : 'visible',
           'text-field': ['get', 'zone'],
           'text-font': ['Barlow Bold'],
-          'text-size': 18,
+          'text-size': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            5, 12,   // At zoom level 5, text size is 12 (increased from 10)
+            10, 16,  // At zoom level 10, text size is 16 (increased from 14)
+            15, 20   // At zoom level 15 and above, text size is 20 (increased from 18)
+          ],
           'text-anchor': 'center',
           'text-offset': [0, 0],
           'text-allow-overlap': true,
@@ -173,7 +193,14 @@ const ZoneNumbersLayer = () => {
         layout={{
           visibility: shouldHide ? 'none' : 'visible',
           'icon-image': 'lock',
-          'icon-size': 1,
+          'icon-size': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            5, 0.8,   // At zoom level 5, icon size is 0.8 (increased from 0.6)
+            10, 1.0,  // At zoom level 10, icon size is 1.0 (increased from 0.8)
+            15, 1.2   // At zoom level 15 and above, icon size is 1.2 (increased from 1)
+          ],
           'icon-allow-overlap': true,
         }}
         filter={

--- a/app/src/app/components/Map/MetaLayers.tsx
+++ b/app/src/app/components/Map/MetaLayers.tsx
@@ -156,6 +156,7 @@ const ZoneNumbersLayer = () => {
           'text-size': 18,
           'text-anchor': 'center',
           'text-offset': [0, 0],
+          'text-allow-overlap': true,
         }}
         paint={{
           'text-color': '#000',
@@ -173,6 +174,7 @@ const ZoneNumbersLayer = () => {
           visibility: shouldHide ? 'none' : 'visible',
           'icon-image': 'lock',
           'icon-size': 1,
+          'icon-allow-overlap': true,
         }}
         filter={
           // get zone not in lockedAreas

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -128,7 +128,7 @@ const getDissolved = async () => {
       currentView.getNorth(),
     ],
     activeZones,
-    strategy: 'non-colliding-centroids',
+    strategy: 'center-of-mass',
     minBuffer: bufferInKm,
   });
   return {centroids, dissolved};

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -228,7 +228,9 @@ const GeometryWorker: GeometryWorkerClass = {
     const validPixels = [];
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
+        // Each pixel takes 4 int array values (R, G, B, A), so we multiply by 4.
         const i = (y * width + x) * 4;
+        // Check if the red channel is 255 as a shorthand to see if painted
         if (imageData[i] === 255) {
           sumX += x;
           sumY += y;

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -38,7 +38,7 @@ const computeCenterOfMass = async (
   const ctx = canvas.getContext('2d', {willReadFrequently: true});
 
   // Calculate bounds for rendering
-  const [minX, minY, maxX, maxY] = bounds
+  const [minX, minY, maxX, maxY] = bounds;
   const scaleX = width / (maxX - minX);
   const scaleY = height / (maxY - minY);
   if (!ctx) return null;
@@ -74,9 +74,7 @@ const computeCenterOfMass = async (
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const i = (y * width + x) * 4;
-      if (
-        imageData[i] === 255
-      ) {
+      if (imageData[i] === 255) {
         sumX += x;
         sumY += y;
         count++;
@@ -91,7 +89,7 @@ const computeCenterOfMass = async (
   let centerY = sumY / count;
 
   const idx = (Math.floor(centerY) * width + Math.floor(centerX)) * 4;
-  const isValidCenter = imageData[idx] === 255
+  const isValidCenter = imageData[idx] === 255;
 
   // Fallback: choose a random pixel inside the district
   if (!isValidCenter) {
@@ -103,7 +101,7 @@ const computeCenterOfMass = async (
   const lng = minX + centerX / scaleX;
   const lat = maxY - centerY / scaleY;
 
-  return [lng, lat]
+  return [lng, lat];
 };
 
 const GeometryWorker: GeometryWorkerClass = {
@@ -289,7 +287,7 @@ const GeometryWorker: GeometryWorkerClass = {
     });
     const centers = await Promise.all(
       Object.entries(clippedFeatures).map(async ([_zone, features]) => {
-        const zone = +_zone
+        const zone = +_zone;
         const center = await computeCenterOfMass(
           {
             type: 'FeatureCollection',
@@ -299,13 +297,13 @@ const GeometryWorker: GeometryWorkerClass = {
         );
         if (!center) return null;
         return {
-            type: 'Feature',
-            properties: {zone},
-            geometry: {
-              type: 'Point',
-              coordinates: center,
-            },
-          } as GeoJSON.Feature<GeoJSON.Point>
+          type: 'Feature',
+          properties: {zone},
+          geometry: {
+            type: 'Point',
+            coordinates: center,
+          },
+        } as GeoJSON.Feature<GeoJSON.Point>;
       })
     );
 

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -191,12 +191,12 @@ const GeometryWorker: GeometryWorkerClass = {
   ){
     const canvas = new OffscreenCanvas(width, height);
     const ctx = canvas.getContext('2d', {willReadFrequently: true});
+    if (!ctx) return null;
   
     // Calculate bounds for rendering
     const [minX, minY, maxX, maxY] = bounds;
     const scaleX = width / (maxX - minX);
     const scaleY = height / (maxY - minY);
-    if (!ctx) return null;
     ctx.imageSmoothingEnabled = false;
     ctx.fillStyle = `rgb(255,0,0)`;
     ctx.strokeStyle = `rgb(255,0,0)`;

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -268,7 +268,7 @@ const GeometryWorker: GeometryWorkerClass = {
 
     return [lng, lat];
   },
-  async getCentersOfMass(bounds, activeZones) {
+  async getCentersOfMass(bounds, activeZones, canvasWidth, canvasHeight) {
     const {centroids, dissolved} = this.getCentroidBoilerplate(bounds);
     if (!activeZones.length) {
       return {
@@ -299,7 +299,9 @@ const GeometryWorker: GeometryWorkerClass = {
             type: 'FeatureCollection',
             features: features as GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>[],
           },
-          bounds
+          bounds,
+          canvasWidth,
+          canvasHeight
         );
         if (!center) return null;
         return {
@@ -405,10 +407,12 @@ const GeometryWorker: GeometryWorkerClass = {
     activeZones,
     strategy = 'non-colliding-centroids',
     minBuffer,
+    canvasWidth = 256,
+    canvasHeight = 256,
   }) {
     switch (strategy) {
       case 'center-of-mass':
-        return await this.getCentersOfMass(bounds, activeZones);
+        return await this.getCentersOfMass(bounds, activeZones, canvasWidth, canvasHeight);
       case 'non-colliding-centroids':
         return await this.getNonCollidingRandomCentroids(bounds, activeZones, minBuffer);
       default:

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -91,7 +91,9 @@ export type GeometryWorkerClass = {
    */
   getCentersOfMass: (
     bounds: [number, number, number, number],
-    activeZones: number[]
+    activeZones: number[],
+    canvasWidth?: number,
+    canvasHeight?: number
   ) => Promise<CentroidReturn>;
   /**
    * Strategy for finding centroids choosing random centroids that do not intersect with each other
@@ -119,6 +121,8 @@ export type GeometryWorkerClass = {
     activeZones: number[];
     strategy: 'center-of-mass' | 'non-colliding-centroids';
     minBuffer?: number;
+    canvasWidth?: number;
+    canvasHeight?: number;
   }) => Promise<CentroidReturn>;
   getPropertiesCentroids: (ids: string[]) => GeoJSON.FeatureCollection<GeoJSON.Point>;
   /**

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -69,7 +69,7 @@ export type GeometryWorkerClass = {
   };
   /**
    * Calculate the center of mass for a set of polygons
-   * 
+   *
    * @param geojson Set of polygons to calculate the center of mass for
    * @param bounds Bounds of the view
    * @param width Width of the subcanvas to render the polygons on. A higher number will result in a more accurate center of mass.

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -56,13 +56,6 @@ export type GeometryWorkerClass = {
   clear: () => void;
   resetZones: () => void;
   /**
-   * Parses geometries and returns their centroids.
-   * @param features - The features to parse.
-   * @returns The centroids and dissolved outlines of the parsed features.
-   */
-  dissolveGeometry: (features: MinGeoJSONFeature[]) => CentroidReturn;
-
-  /**
    * Convenience method for DRY of getCentroidsFromView
    * @param bounds number[] the view bounds
    * @returns CentroidReturn

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -84,7 +84,7 @@ export type GeometryWorkerClass = {
   getCentersOfMass: (
     bounds: [number, number, number, number],
     activeZones: number[]
-  ) => CentroidReturn;
+  ) => Promise<CentroidReturn>;
   /**
    * Strategy for finding centroids choosing random centroids that do not intersect with each other
    * @param bounds number[] the view bounds
@@ -97,7 +97,7 @@ export type GeometryWorkerClass = {
     bounds: [number, number, number, number],
     activeZones: number[],
     minBuffer?: number
-  ) => CentroidReturn;
+  ) => Promise<CentroidReturn>;
   /**
    * Parses geometries within a specified view and returns their centroids.
    * @param minLon - The minimum longitude of the view.
@@ -111,7 +111,7 @@ export type GeometryWorkerClass = {
     activeZones: number[];
     strategy: 'center-of-mass' | 'non-colliding-centroids';
     minBuffer?: number;
-  }) => CentroidReturn;
+  }) => Promise<CentroidReturn>;
   getPropertiesCentroids: (ids: string[]) => GeoJSON.FeatureCollection<GeoJSON.Point>;
   /**
    * Retrieves a collection of geometries without a zone assignment.

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -68,6 +68,21 @@ export type GeometryWorkerClass = {
     bboxGeom: GeoJSON.Polygon;
   };
   /**
+   * Calculate the center of mass for a set of polygons
+   * 
+   * @param geojson Set of polygons to calculate the center of mass for
+   * @param bounds Bounds of the view
+   * @param width Width of the subcanvas to render the polygons on. A higher number will result in a more accurate center of mass.
+   * @param height Height of the subcanvas to render the polygons on. A higher number will result in a more accurate center of mass.
+   * @returns [lng, lat] of the center of mass
+   */
+  computeCenterOfMass: (
+    geojson: GeoJSON.FeatureCollection<GeoJSON.Polygon | GeoJSON.MultiPolygon>,
+    bounds: [number, number, number, number],
+    width?: number,
+    height?: number
+  ) => Promise<[number, number] | null>;
+  /**
    * Strategy for finding centroids by dissolving the zone geometries and finding the center of mass.
    * @param bounds number[] the view bounds
    * @param activeZones list of current drawn zones

--- a/backend/app/cms/main.py
+++ b/backend/app/cms/main.py
@@ -15,7 +15,7 @@ from app.cms.models import (
     CMSContentTypesEnum,
     AllCMSContentPublic,
     ContentUpdateResponse,
-    LANGUAGE_MAP
+    LANGUAGE_MAP,
 )
 
 router = APIRouter(prefix="/api/cms", tags=["cms"])

--- a/backend/app/cms/models.py
+++ b/backend/app/cms/models.py
@@ -25,6 +25,7 @@ class LanguageEnum(str, Enum):
     HAITIAN = "ht"
     PORTUGUESE = "pt"
 
+
 LANGUAGE_MAP = {
     "en": "English",
     "es": "Spanish",
@@ -33,6 +34,8 @@ LANGUAGE_MAP = {
     "ht": "Haitian",
     "pt": "Portuguese",
 }
+
+
 class TagsCMSContent(TimeStampMixin, SQLModel, table=True):
     __tablename__ = "tags_content"
     metadata = MetaData(schema=CMS_SCHEMA)


### PR DESCRIPTION
This PR improves the zone label positioning.

## Description
- Previous work to position zone labels used geometric dissolves / unions and centroids, which was slow (2000-3000ms), but pretty good
- To optimize this, we started using random points (~20-100ms), but that was kind of annoying when points on or near the edges were selected
- This approach instead compromises by making a low res raster of the map and choosing a valid point based on the raster image; this is pretty much as good as the first method, but much faster (~30-60ms)

## Reviewers
- Primary: @raphaellaude 
- Secondary:

## Checklist
- [x] Add raster shenanigans to the web worker
- [x] Fallback to random point
- [x] Remove dead code

## Screenshots (if applicable):
