### PR TITLE
Contiguity tool loads custom colorScheme

### DIFF
--- a/app/src/app/components/sidebar/MapValidation/Contiguity.tsx
+++ b/app/src/app/components/sidebar/MapValidation/Contiguity.tsx
@@ -5,7 +5,6 @@ import {useQuery} from '@tanstack/react-query';
 import {queryClient} from '@utils/api/queryClient';
 import {useEffect, useMemo, useState} from 'react';
 import {CheckCircledIcon, DashIcon} from '@radix-ui/react-icons';
-import {colorScheme} from '@/app/constants/colors';
 import {FALLBACK_NUM_DISTRICTS} from '@/app/constants/layers';
 import {isAxiosError} from 'axios';
 import {RefreshButton, TimestampDisplay} from '@/app/components/Time/TimestampDisplay';
@@ -13,6 +12,7 @@ import ZoomToConnectedComponents from './ZoomToConnectedComponents';
 
 export const Contiguity = () => {
   const mapDocument = useMapStore(store => store.mapDocument);
+  const colorScheme = useMapStore(store => store.colorScheme);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const {data, error, isLoading, isFetched, refetch} = useQuery(
     {

--- a/app/src/app/components/sidebar/MapValidation/Contiguity.tsx
+++ b/app/src/app/components/sidebar/MapValidation/Contiguity.tsx
@@ -89,7 +89,7 @@ export const Contiguity = () => {
                     style={{
                       width: '15px',
                       height: '15px',
-                      backgroundColor: colorScheme[(row.zone % colorScheme.length) - 1],
+                      backgroundColor: colorScheme[(row.zone - 1) % colorScheme.length],
                       borderRadius: '4px',
                     }}
                   />


### PR DESCRIPTION
Fixes #313
Loads colorScheme from mapStore to allow custom colors

I did a `git grep` to check if other files still use `colorScheme` from `constants/colors `, and others already have been updated to `import {colorScheme as DefaultColorScheme}`