### PR TITLE
Use maps metadata in title/description

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -4,7 +4,6 @@ import './globals.css';
 import {Theme} from '@radix-ui/themes';
 import '@radix-ui/themes/styles.css';
 import {getDocument} from '@/app/utils/api/apiHandlers/getDocument';
-import {isArray} from 'lodash';
 
 const inter = Inter({subsets: ['latin']});
 
@@ -23,7 +22,7 @@ const DISTRICTR_LOGO = [
 export async function generateMetadata({searchParams}: MetadataProps): Promise<Metadata> {
   const resolvedParams = await searchParams;
   const document_id = resolvedParams?.document_id ?? '';
-  const singularDocumentId = isArray(document_id) ? document_id[0] : document_id;
+  const singularDocumentId = Array.isArray(document_id) ? document_id[0] : document_id;
   if (!singularDocumentId) {
     return {
       title: 'Districtr 2.0',

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -3,13 +3,54 @@ import {Inter} from 'next/font/google';
 import './globals.css';
 import {Theme} from '@radix-ui/themes';
 import '@radix-ui/themes/styles.css';
+import {getDocument} from '@/app/utils/api/apiHandlers/getDocument';
+import {isArray} from 'lodash';
 
 const inter = Inter({subsets: ['latin']});
 
-export const metadata: Metadata = {
-  title: 'Districtr 2.0',
-  description: 'Districtr reboot',
+type MetadataProps = {
+  searchParams: Promise<{document_id?: string | string[] | undefined}>;
 };
+
+const DISTRICTR_LOGO = [
+  {
+    url: 'https://districtr-v2-frontend.fly.dev/_next/image?url=%2Fdistrictr_logo.jpg&w=1920&q=75',
+    width: 1136,
+    height: 423,
+  },
+];
+
+export async function generateMetadata({searchParams}: MetadataProps): Promise<Metadata> {
+  const resolvedParams = await searchParams;
+  const document_id = resolvedParams?.document_id ?? '';
+  const singularDocumentId = isArray(document_id) ? document_id[0] : document_id;
+  if (!singularDocumentId) {
+    return {
+      title: 'Districtr 2.0',
+      description: 'Create districting maps',
+      openGraph: {
+        title: 'Get Started',
+        description: 'Create districting maps',
+        siteName: 'Districtr 2.0',
+        images: DISTRICTR_LOGO,
+      },
+    };
+  }
+
+  const mapDocument = await getDocument(singularDocumentId);
+  const districtCount = mapDocument?.num_districts ? `${mapDocument.num_districts} districts` : '';
+  return {
+    title: 'Districtr 2.0',
+    openGraph: {
+      title: districtCount
+        ? `${districtCount} - ${mapDocument?.map_metadata?.name ?? 'Shared Map'}`
+        : (mapDocument?.map_metadata?.name ?? 'Get Started'),
+      description: mapDocument?.map_metadata?.description ?? 'Create districting maps',
+      siteName: 'Districtr 2.0',
+      images: DISTRICTR_LOGO,
+    },
+  };
+}
 
 export default function RootLayout({
   children,

--- a/app/src/app/utils/api/apiHandlers/types.ts
+++ b/app/src/app/utils/api/apiHandlers/types.ts
@@ -1,20 +1,6 @@
 import {NullableZone} from '@constants/types';
 import {SummaryTypes} from '../summaryStats';
 
-export interface DocumentObject {
-  document_id: string;
-  gerrydb_table: string;
-  parent_layer: string;
-  child_layer: string | null;
-  tiles_s3_path: string | null;
-  num_districts: number | null;
-  created_at: string;
-  updated_at: string | null;
-  extent: [number, number, number, number]; // [minx, miny, maxx, maxy]
-  available_summary_stats: Array<SummaryTypes>;
-  color_scheme: string[] | null;
-}
-
 export interface Assignment {
   document_id: string;
   geo_id: string;


### PR DESCRIPTION
This replaces NextJS's static metadata feature with its `generateMetadata` async function, allowing the title and description of the page and its social media / opengraph preview to use a map's name, description, and number of districts.

- I suggest the Districtr paintbrush logo as the social media image until we add #314 to make individual thumbnail URLs
- Replaces description "Districtr reboot" with "Create districting maps"
- On OpenGraph where we already have siteName "Districtr 2.0" and the Districtr logo, the title can be "Get Started" on general pages like the homepage or /map
- On individual maps the title would be "3 districts - NAME" or "3 districts - Shared Map"
- On individual maps the description would be from map metadata or "Create districting maps"

Notes:
- removes a duplicate type definition for `MapDocument`
- very open to reworking how we use name / num_districts and other phrasing, this is mostly to make better metadata
- uses `num_districts` and not the number of districts drawn by the user
- I didn't decide how to get the state name from layer names