### PR TITLE
Bugfix: load data

### DIFF
--- a/backend/management/load_data.py
+++ b/backend/management/load_data.py
@@ -65,6 +65,8 @@ def import_gerrydb_view(
         logger.error("ogr2ogr failed. Got %s", result)
         raise ValueError(f"ogr2ogr failed with return code {result.returncode}")
 
+    # Commit before trying to build index
+    session.commit()
     logger.info(f"GerryDB view {table_name} imported successfully")
 
     if rm:
@@ -296,6 +298,8 @@ def load_sample_data(
         )
 
         if view.child_layer is not None:
+            # Commit districtr views
+            session.commit()
             _create_parent_child_edges(session=session, districtr_map_uuid=str(u))
 
         session.commit()


### PR DESCRIPTION
From a fresh install, the load data script had a couple breaking errors:

1. When making gerrydb views, the views not committed before building which cause the geo index to fail and mess up other stuff down the line
2. When makign the districtrmap view, the view was not committed before trying to make parent child edges