### PR TITLE
Maps can be organized into groups

### DIFF
--- a/backend/app/alembic/versions/dc0216fef023_create_map_groups.py
+++ b/backend/app/alembic/versions/dc0216fef023_create_map_groups.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
             ["districtrmap.uuid"],
         ),
     )
-    op.execute(sa.text("INSERT INTO map_group (id, name, slug) VALUES (1, 'States', 'states')"))
+    op.execute(sa.text("INSERT INTO map_group (name, slug) VALUES ('States', 'states')"))
     op.execute(sa.text("INSERT INTO districtrmaps_to_groups (group_id, districtrmap_uuid) SELECT 1, uuid from districtrmap"))
 
 def downgrade() -> None:

--- a/backend/app/alembic/versions/dc0216fef023_create_map_groups.py
+++ b/backend/app/alembic/versions/dc0216fef023_create_map_groups.py
@@ -1,0 +1,45 @@
+"""create map groups
+
+Revision ID: dc0216fef023
+Revises: d38d0f766dc5
+Create Date: 2025-04-29 15:50:59.583224
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'dc0216fef023'
+down_revision: Union[str, None] = 'd38d0f766dc5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('map_group',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('name', sa.String(), unique=True, nullable=False),
+        sa.Column('slug', sa.String(), unique=True, nullable=False),
+    )
+    op.create_table('districtrmaps_to_groups',
+        sa.Column('group_id', sa.Integer(), nullable=False),
+        sa.Column('districtrmap_uuid', sa.Uuid(), nullable=False),
+        sa.PrimaryKeyConstraint("group_id", "districtrmap_uuid", name="group_map_unique"),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["map_group.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["districtrmap_uuid"],
+            ["districtrmap.uuid"],
+        ),
+    )
+    op.execute(sa.text("INSERT INTO map_group (id, name, slug) VALUES (1, 'States', 'states')"))
+    op.execute(sa.text("INSERT INTO districtrmaps_to_groups (group_id, districtrmap_uuid) SELECT 1, uuid from districtrmap"))
+
+def downgrade() -> None:
+    op.drop_table('districtrmaps_to_groups')
+    op.drop_table('map_group')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from app.models import (
     AssignmentsResponse,
     ColorsSetResult,
     DistrictrMap,
+    DistrictrMapsToGroups,
     Document,
     DocumentCreate,
     DocumentPublic,
@@ -952,11 +953,17 @@ async def update_districtrmap_metadata(
 async def get_projects(
     *,
     session: Session = Depends(get_session),
+    group: int = Query(default=1),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=100, le=100),
 ):
     gerrydb_views = session.exec(
         select(DistrictrMap)
+        .join(
+            DistrictrMapsToGroups,
+            DistrictrMapsToGroups.districtrmap_uuid == DistrictrMap.uuid
+        )
+        .filter(DistrictrMapsToGroups.group_id == group)
         .filter(DistrictrMap.visible == true())  # pyright: ignore
         .order_by(DistrictrMap.created_at.asc())  # pyright: ignore
         .offset(offset)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -300,3 +300,9 @@ class ShatterResult(BaseModel):
 
 class ColorsSetResult(BaseModel):
     colors: list[str]
+
+
+class DistrictrMapsToGroups(SQLModel, table=True):
+    __tablename__ = "districtrmaps_to_groups"
+    districtrmap_uuid: str = Field(primary_key=True, foreign_key="districtrmap.uuid")
+    group_id: int = Field(primary_key=True, foreign_key="map_groups.id")

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -35,6 +35,7 @@ def create_districtr_map(
     gerrydb_table_name: str | None = None,
     num_districts: int | None = None,
     tiles_s3_path: str | None = None,
+    group_slug: str = "states",
     visibility: bool = True,
 ) -> str:
     """
@@ -46,6 +47,7 @@ def create_districtr_map(
         districtr_map_slug: The slug of the districtr map.
         parent_layer_name: The name of the parent layer.
         child_layer_name: The name of the child layer.
+        group_slug: The slug of the map group.
         gerrydb_table_name: The name of the gerrydb table.
         num_districts: The number of districts.
         tiles_s3_path: The S3 path to the tiles.
@@ -89,6 +91,17 @@ def create_districtr_map(
             "parent_layer_name": parent_layer,
             "child_layer_name": child_layer,
             "visibility": visibility,
+        },
+    )
+    group_stmt = text("""
+        INSERT INTO districtrmaps_to_groups (group_id, districtrmap_uuid)
+        SELECT id, :uuid FROM map_group
+        WHERE slug = :slug"""
+    )
+    session.execute(group_stmt,
+        {
+            "uuid": inserted_map_uuid[0],
+            "slug": group_slug,
         },
     )
     return inserted_map_uuid[0]  # pyright: ignore

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -128,6 +128,7 @@ def delete_parent_child_edges(session: Session, districtr_map: str):
 @click.option("--parent-layer-name", help="Parent gerrydb layer name", required=True)
 @click.option("--districtr-map-slug", help="Slug of the districtr map", required=True)
 @click.option("--child-layer-name", help="Child gerrydb layer name", required=False)
+@click.option("--group-slug", help="Map group slug", required=False)
 @click.option("--gerrydb-table-name", help="Name of the GerryDB table", required=True)
 @click.option("--num-districts", help="Number of districts", required=False)
 @click.option("--tiles-s3-path", help="S3 path to the tileset", required=False)
@@ -155,6 +156,7 @@ def create_districtr_map(
     tiles_s3_path: str | None,
     no_extent: bool = False,
     bounds: list[float] | None = None,
+    group_slug: str = "states",
 ):
     logger.info("Creating districtr map...")
     districtr_map_uuid = _create_districtr_map(
@@ -163,6 +165,7 @@ def create_districtr_map(
         parent_layer=parent_layer_name,
         child_layer=child_layer_name,
         districtr_map_slug=districtr_map_slug,
+        group_slug=group_slug,
         gerrydb_table_name=gerrydb_table_name,
         num_districts=num_districts,
         tiles_s3_path=tiles_s3_path,


### PR DESCRIPTION
As discussed on the Slack, we want a MapGroup table to organize DistrictrMaps. The current homepage DistrictrMaps all fall into a States group.

Other maps will be browseable in the future by group - for example an organization wants to organize their DistrictrMaps across one or more states. With a many-to-many table, maps can be part of multiple groups.

I confirmed that `cli.py create-districtr-map` without any changes will put the map in the States group, and adding `--group-slug` put it somewhere else

Note:
- Auto-increment gets messed up if I INSERTing the first group row with a set ID in the migration. I could maybe set it to 0 or -1?
- Delete/cascade not being set in the migration - I wasn't sure the right way to make the join table dependent
- There is no warning if the `--group-slug` doesn't exist; the DistrictrMap is created without a row in the join table
- You can browse a group by ID, like `/api/gerrydb/views?group=10`, but this isn't readily accessible if we are using the slug
- Unclear how we will create groups (from CLI?)