### PR TITLE
Extend color palette

### DIFF
--- a/app/src/app/components/Toolbar/ColorPicker.tsx
+++ b/app/src/app/components/Toolbar/ColorPicker.tsx
@@ -60,10 +60,12 @@ export const ColorPicker = <T extends boolean>({
       // if key is digit, set selected zone to that digit
       if (!event.code.includes('Digit')) return;
       let value = event.key;
+      const numDistricts = useMapStore.getState().mapDocument?.num_districts ?? FALLBACK_NUM_DISTRICTS;
+      const numDigits = numDistricts.toString().length;
       if (numDistricts >= 10) {
         hotkeyRef.current = (hotkeyRef.current || '') + value;
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        if (hotkeyRef?.current?.length === 2) {
+        if (hotkeyRef?.current?.length === numDigits) {
           handleKeyPressSubmit();
         } else {
           timeoutRef.current = setTimeout(() => {

--- a/app/src/app/components/Toolbar/ColorPicker.tsx
+++ b/app/src/app/components/Toolbar/ColorPicker.tsx
@@ -1,7 +1,5 @@
 import React, {useEffect, useRef} from 'react';
-import {Button, CheckboxGroup, Flex, Text} from '@radix-ui/themes';
 import {useMapStore} from '@/app/store/mapStore';
-import {extendColorArray} from '@/app/utils/colors';
 import {NullableZone} from '@/app/constants/types';
 import {FALLBACK_NUM_DISTRICTS} from '@/app/constants/layers';
 import {ColorRadioGroup} from './ColorRadioGroup';
@@ -37,8 +35,6 @@ export const ColorPicker = <T extends boolean>({
   const hotkeyRef = useRef<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const numDistricts = mapDocument?.num_districts ?? FALLBACK_NUM_DISTRICTS;
-  const colorArray =
-    numDistricts > colorScheme.length ? extendColorArray(colorScheme, numDistricts) : colorScheme;
 
   const handleKeyPressSubmit = () => {
     if (!hotkeyRef.current) return;

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -38,6 +38,7 @@ import {useUnassignFeaturesStore} from './unassignedFeatures';
 import {demographyCache} from '../utils/demography/demographyCache';
 import {useDemographyStore} from './demography/demographyStore';
 import {CheckboxGroupIndicator} from '@radix-ui/themes/dist/esm/components/checkbox-group.primitive.js';
+import {extendColorArray} from '../utils/colors';
 
 const combineSetValues = (setRecord: Record<string, Set<unknown>>, keys?: string[]) => {
   const combinedSet = new Set<unknown>(); // Create a new set to hold combined values
@@ -480,7 +481,10 @@ export var useMapStore = createWithMiddlewares<MapStore>((set, get) => ({
         password: mapDocument.password,
       },
       activeTool: mapDocument.access === 'edit' ? currentActiveTool : undefined,
-      colorScheme: mapDocument.color_scheme ?? DefaultColorScheme,
+      colorScheme: extendColorArray(
+        mapDocument.color_scheme ?? DefaultColorScheme,
+        mapDocument.num_districts ?? FALLBACK_NUM_DISTRICTS
+      ),
       sidebarPanels: ['population'],
       appLoadingState: mapDocument?.genesis === 'copied' ? 'loaded' : 'initializing',
       mapRenderingState:

--- a/app/src/app/utils/colors.ts
+++ b/app/src/app/utils/colors.ts
@@ -1,9 +1,13 @@
 export const extendColorArray = (colorArray: string[], numDistricts: number) => {
   let newColorArray = [...colorArray];
   while (newColorArray.length < numDistricts) {
-    newColorArray = newColorArray.concat(newColorArray);
+    const newColors = colorArray.map(color => hexshift(color));
+    newColorArray = newColorArray.concat(...newColors);
+    newColorArray = newColorArray.filter(
+      (color, index, array) => array.findIndex(c => c === color) === index
+    );
   }
-  return newColorArray;
+  return newColorArray.slice(0, numDistricts);
 };
 
 function hexshift(color: string): string {

--- a/app/src/app/utils/colors.ts
+++ b/app/src/app/utils/colors.ts
@@ -1,11 +1,9 @@
 export const extendColorArray = (colorArray: string[], numDistricts: number) => {
   let newColorArray = [...colorArray];
   while (newColorArray.length < numDistricts) {
-    const newColors = colorArray.map(color => hexshift(color));
-    newColorArray = newColorArray.concat(...newColors);
-    newColorArray = newColorArray.filter(
-      (color, index, array) => array.findIndex(c => c === color) === index
-    );
+    newColorArray = newColorArray
+      .concat(...colorArray.map(hexshift))
+      .filter((color, index, array) => array.findIndex(c => c === color) === index);
   }
   return newColorArray.slice(0, numDistricts);
 };


### PR DESCRIPTION
## Description
- #376 
- Extends the map document color palette or default color palette on load
- Uses Peters procedural color generation strategy

## Reviewers
- Primary: @raphaellaude 
- Secondary:

## Checklist
- [ ] Colors are procedurally generated as needed
- [ ] Colors update everywhere they should
- [ ] Colors are not repeated
- [ ] Colors can be edited
- [ ] Colors are updated in the DB if edited 

## Screenshots (if applicable):
