### PR TITLE
Enable population numbers for all geometries

### DIFF
--- a/app/src/app/components/Map/MetaLayers.tsx
+++ b/app/src/app/components/Map/MetaLayers.tsx
@@ -28,7 +28,8 @@ const PopulationTextLayer = () => {
   const demographyHash = useDemographyStore(state => state.dataHash);
 
   useEffect(() => {
-    if ((!showPopulationNumbers && !showBlockPopulationNumbers) || (showBlockPopulationNumbers && !captiveIds.size)) {
+    const shouldShow = (showPopulationNumbers || showBlockPopulationNumbers) || (showBlockPopulationNumbers && captiveIds.size)
+    if (!shouldShow) {
       setPointFeatureCollection(EMPTY_FT_COLLECTION);
       return;
     }
@@ -36,6 +37,7 @@ const PopulationTextLayer = () => {
     const idSet: Set<string> = showPopulationNumbers 
       ? new Set(demographyCache.table?.dedupe('path').column('path') ?? []) 
       : captiveIds;
+
     const currIds = new Set(pointFeatureCollection.features.map(f => f.properties?.path))
     const missingIds = Array.from(idSet).filter(id => !currIds.has(id))
     if (!missingIds.length) {

--- a/app/src/app/components/Map/MetaLayers.tsx
+++ b/app/src/app/components/Map/MetaLayers.tsx
@@ -41,7 +41,7 @@ const PopulationTextLayer = () => {
     if (!missingIds.length) {
       return;
     }
-    GeometryWorker?.getPropertiesCentroids(missingIds).then(data => {
+    GeometryWorker?.getCentroidsByIds(missingIds).then(data => {
       setPointFeatureCollection(prev => ({
         type: 'FeatureCollection',
         // Filter out old, irrelevant features (eg broken parents)

--- a/app/src/app/components/Map/MetaLayers.tsx
+++ b/app/src/app/components/Map/MetaLayers.tsx
@@ -54,13 +54,24 @@ const PopulationTextLayer = () => {
         layout={{
           'text-field': ['get', 'total_pop_20'],
           'text-font': ['Barlow Bold'],
-          'text-size': 14,
+          'text-size': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            0,
+            0,
+            10,
+            8, // At zoom level 10, text size is 10
+            14,
+            10, // At zoom level 14, text size is 14
+            18,
+            18, // At zoom level 18, text size is 18
+          ],
           'text-anchor': 'center',
           'text-offset': [0, 0],
           // padding
           'text-padding': 1,
           'text-allow-overlap': true,
-
         }}
         paint={{
           'text-color': '#000',

--- a/app/src/app/components/Toolbar/Settings.tsx
+++ b/app/src/app/components/Toolbar/Settings.tsx
@@ -53,7 +53,8 @@ export const ToolSettings: React.FC = () => {
             mapOptions.showPaintedDistricts === true ? 'showPaintedDistricts' : '',
             mapOptions.higlightUnassigned === true ? 'higlightUnassigned' : '',
             mapOptions.showPopulationTooltip === true ? 'showPopulationTooltip' : '',
-            mapOptions.showBlockPopulationNumbers === true ? 'showBlockPopulationNumbers' : '',
+            mapDocument?.child_layer && mapOptions.showBlockPopulationNumbers === true ? 'showBlockPopulationNumbers' : '',
+            mapOptions.showPopulationNumbers === true ? 'showPopulationNumbers' : '',
             mapOptions.lockPaintedAreas.length ===
             (mapDocument?.num_districts ?? FALLBACK_NUM_DISTRICTS)
               ? 'lockAll'
@@ -80,12 +81,23 @@ export const ToolSettings: React.FC = () => {
             Show population tooltip
           </CheckboxGroup.Item>
           <CheckboxGroup.Item
+            value="showPopulationNumbers"
+            onClick={() =>
+              setMapOptions({
+                showPopulationNumbers: !mapOptions.showPopulationNumbers,
+              })
+            }
+          >
+            Show total population labels on all geometries
+          </CheckboxGroup.Item>
+          <CheckboxGroup.Item
             value="showBlockPopulationNumbers"
             onClick={() =>
               setMapOptions({
                 showBlockPopulationNumbers: !mapOptions.showBlockPopulationNumbers,
               })
             }
+            disabled={!mapDocument?.child_layer}
           >
             Show total population labels on blocks
           </CheckboxGroup.Item>

--- a/app/src/app/components/Topbar.tsx
+++ b/app/src/app/components/Topbar.tsx
@@ -141,7 +141,7 @@ export const Topbar: React.FC = () => {
                       </a>
                     </Tooltip>
                   </DropdownMenu.Item>
-                  <DropdownMenu.Item disabled={!mapDocument?.child_layer}>
+                  <DropdownMenu.Item>
                     <Tooltip content="Download a CSV of Census Block GEOIDs and zone IDs">
                       <a
                         href={`${process.env.NEXT_PUBLIC_API_URL}/api/document/${mapDocument?.document_id}/export?format=CSV&export_type=BlockZoneAssignments`}

--- a/app/src/app/components/Topbar.tsx
+++ b/app/src/app/components/Topbar.tsx
@@ -141,7 +141,7 @@ export const Topbar: React.FC = () => {
                       </a>
                     </Tooltip>
                   </DropdownMenu.Item>
-                  <DropdownMenu.Item>
+                  <DropdownMenu.Item disabled={!mapDocument?.child_layer}>
                     <Tooltip content="Download a CSV of Census Block GEOIDs and zone IDs">
                       <a
                         href={`${process.env.NEXT_PUBLIC_API_URL}/api/document/${mapDocument?.document_id}/export?format=CSV&export_type=BlockZoneAssignments`}

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -237,8 +237,10 @@ export interface MapStore {
    */
   zonesLastUpdated: Map<Zone, string>;
   assignmentsHash: string;
-  lastUpdatedHash: string;
   setAssignmentsHash: (hash: string) => void;
+  lastUpdatedHash: string;
+  workerUpdateHash: string;
+  setWorkerUpdateHash: (hash: string) => void;
   loadZoneAssignments: (assignmentsData: RemoteAssignmentsResponse) => void;
   resetZoneAssignments: () => void;
   zonePopulations: Map<Zone, number>;
@@ -962,8 +964,10 @@ export var useMapStore = createWithMiddlewares<MapStore>((set, get) => ({
   zoneAssignments: new Map(),
   zonesLastUpdated: new Map(),
   assignmentsHash: '',
-  lastUpdatedHash: new Date().toISOString(),
   setAssignmentsHash: hash => set({assignmentsHash: hash}),
+  lastUpdatedHash: new Date().toISOString(),
+  workerUpdateHash: new Date().toISOString(),
+  setWorkerUpdateHash: hash => set({workerUpdateHash: hash}),
   accumulatedGeoids: new Set<string>(),
   setAccumulatedGeoids: accumulatedGeoids => set({accumulatedGeoids}),
   allPainted: new Set<string>(),

--- a/app/src/app/store/types.ts
+++ b/app/src/app/store/types.ts
@@ -17,6 +17,7 @@ export type DistrictrMapOptions = {
   prominentCountyNames?: boolean;
   showCountyBoundaries?: boolean;
   showBlockPopulationNumbers?: boolean;
+  showPopulationNumbers?: boolean;
   showDemographicMap?: undefined | 'side-by-side' | 'overlay';
   showPaintedDistricts?: boolean;
   overlayOpacity: number;

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -30,6 +30,7 @@ const GeometryWorker: GeometryWorkerClass = {
   geometries: {},
   activeGeometries: {},
   zoneAssignments: {},
+  cachedCentroids: {},
   shatterIds: {
     parents: [],
     children: [],
@@ -96,6 +97,7 @@ const GeometryWorker: GeometryWorkerClass = {
     this.geometries = {};
     this.activeGeometries = {};
     this.previousCentroids = {};
+    this.cachedCentroids = {};
     this.shatterIds = {
       parents: [],
       children: [],
@@ -438,15 +440,19 @@ const GeometryWorker: GeometryWorkerClass = {
         return await this.getNonCollidingRandomCentroids(bounds, activeZones);
     }
   },
-  getPropertiesCentroids(ids) {
+  getCentroidsByIds(ids) {
     const features: GeoJSON.Feature<GeoJSON.Point>[] = [];
-
     ids.forEach(id => {
       const f = this.geometries[id];
       if (f) {
-        let center = centerOfMass(f);
-        center.properties = f.properties;
-        features.push(center);
+        if (this.cachedCentroids[id]) {
+          features.push(this.cachedCentroids[id]);
+        } else {
+          let center = centerOfMass(f);
+          center.properties = f.properties;
+          features.push(center);
+          this.cachedCentroids[id] = center;
+        }
       } else {
         console.log('Could not find geography', id);
       }

--- a/app/src/app/utils/GeometryWorker/geometryWorker.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.ts
@@ -442,6 +442,7 @@ const GeometryWorker: GeometryWorkerClass = {
   },
   getCentroidsByIds(ids) {
     const features: GeoJSON.Feature<GeoJSON.Point>[] = [];
+    let missingIds = [];
     ids.forEach(id => {
       const f = this.geometries[id];
       if (f) {
@@ -454,10 +455,10 @@ const GeometryWorker: GeometryWorkerClass = {
           this.cachedCentroids[id] = center;
         }
       } else {
-        console.log('Could not find geography', id);
+        missingIds.push(id);
       }
     });
-
+    console.log(`Missing ${missingIds.length} geometries for centroid labels.`);
     return {
       type: 'FeatureCollection',
       features,

--- a/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
+++ b/app/src/app/utils/GeometryWorker/geometryWorker.types.ts
@@ -129,7 +129,16 @@ export type GeometryWorkerClass = {
     canvasWidth?: number;
     canvasHeight?: number;
   }) => Promise<CentroidReturn>;
-  getPropertiesCentroids: (ids: string[]) => GeoJSON.FeatureCollection<GeoJSON.Point>;
+  /**
+   * Retrieves the centroids of the geometries with the given IDs.
+   * @param ids - The IDs of the geometries to retrieve.
+   * @returns The centroids of the geometries.
+   */
+  getCentroidsByIds: (ids: string[]) => GeoJSON.FeatureCollection<GeoJSON.Point>;
+  /**
+   * The cached centroids of the geometries.
+   */
+  cachedCentroids: Record<string, GeoJSON.Feature<GeoJSON.Point>>;
   /**
    * Retrieves a collection of geometries without a zone assignment.
    * @returns The collection of unassigned geometries.

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -196,9 +196,7 @@ export const handleMapIdle = (e: MapEvent) => {
   }
 };
 
-export const handleMapMoveEnd = e => {
-  console.log(e.target.getZoom());
-};
+export const handleMapMoveEnd = () => {};
 
 export const handleMapZoomEnd = (e: ViewStateChangeEvent) => {};
 

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -196,7 +196,9 @@ export const handleMapIdle = (e: MapEvent) => {
   }
 };
 
-export const handleMapMoveEnd = () => {};
+export const handleMapMoveEnd = e => {
+  console.log(e.target.getZoom());
+};
 
 export const handleMapZoomEnd = (e: ViewStateChangeEvent) => {};
 
@@ -247,9 +249,9 @@ export const handleMapContextMenu = (e: MapLayerMouseEvent | MapLayerTouchEvent)
 };
 
 export const handleDataLoad = (e: MapSourceDataEvent) => {
-  const {mapDocument, shatterMappings, setMapOptions, setMapRenderingState} =
+  const {mapDocument, setMapOptions, setMapRenderingState, setWorkerUpdateHash} =
     useMapStore.getState();
-  const {tiles_s3_path, parent_layer, child_layer} = mapDocument || {};
+  const {tiles_s3_path, parent_layer} = mapDocument || {};
   if (!tiles_s3_path || !parent_layer || !(e?.source as any)?.url?.includes(tiles_s3_path)) return;
   const tileData = e?.tile?.latestFeatureIndex;
   if (!tileData) return;
@@ -267,6 +269,7 @@ export const handleDataLoad = (e: MapSourceDataEvent) => {
       mapDocument,
       idProp: 'path',
     });
+    setWorkerUpdateHash(new Date().toISOString());
   }
 };
 


### PR DESCRIPTION
There are a couple issues with maps that are only parent geographies with no child layer. This 

## Description
- Allow showing population numbers (eg. #325)

## Reviewers
- Primary: @raphaellaude 
- Secondary: @mapmeld 

## Checklist
- [x] Population numbers work for all geos
- [x] Perf
