### PR TITLE
Bugfix: stale document

### DIFF
--- a/app/src/app/utils/api/queries.ts
+++ b/app/src/app/utils/api/queries.ts
@@ -53,6 +53,8 @@ const getDocumentFunction = (documentId?: string) => {
 const updateDocumentFromId = new QueryObserver<DocumentObject | null>(queryClient, {
   queryKey: ['mapDocument', undefined],
   queryFn: getDocumentFunction(),
+  staleTime: 0,
+  placeholderData: _ => null,
 });
 
 updateDocumentFromId.subscribe(mapDocument => {


### PR DESCRIPTION
There is an edge case where upon returning to tab that has slept, the subscription re-subscribes and loads stale data. There is never a case where we want stale document data to load in temporarily, since it has `updated_at` and `access`/`edit` state attached to it, which can change on re-focus

## Description
- Remove stale time from map document query
- Remove placeholder data from map document query

## Reviewers
- Primary: @raphaellaude 
- Secondary:

