### PR TITLE
On group page, DistrictrMaps have thumbnails

### DIFF
--- a/app/src/app/(static)/group/[slug]/page.tsx
+++ b/app/src/app/(static)/group/[slug]/page.tsx
@@ -39,13 +39,14 @@ export default async function Page({params}: {params: Promise<{slug: string}>}) 
         {Boolean(availableMaps) && (
           <>
             {availableMaps!.map((view, i) => (
-              <Flex key={i} className="items-center" direction="column" gapY="4" py="4">
+              <Flex key={i} className="items-center capitalize" direction="column" gapY="4" py="4">
                 <object
                   type="image/png"
                   data={`https://tilesets1.cdn.districtr.org/thumbnails/${view.districtr_map_slug}.png`}
                   width="150"
                   height="150"
                   aria-label="Preview with map outline"
+                  style={{borderRadius: 10}}
                 >
                   <Image src={placeImages[i % 3]} alt="Fallback image" width="150" height="150" />
                 </object>

--- a/app/src/app/(static)/group/[slug]/page.tsx
+++ b/app/src/app/(static)/group/[slug]/page.tsx
@@ -42,7 +42,7 @@ export default async function Page({params}: {params: Promise<{slug: string}>}) 
               <Flex key={i} className="items-center" direction="column" gapY="4" py="4">
                 <object
                   type="image/png"
-                  data="https://tilesets1.cdn.districtr.org/thumbnails/null.png"
+                  data={`https://tilesets1.cdn.districtr.org/thumbnails/${view.districtr_map_slug}.png`}
                   width="150"
                   height="150"
                   aria-label="Preview with map outline"

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -4,6 +4,7 @@ import io
 import logging
 import math
 import matplotlib.pyplot as plt
+import random
 from sqlalchemy import text
 from sqlmodel import Session
 from app.core.config import settings
@@ -146,7 +147,6 @@ def generate_thumbnail(
         WHERE zone IS NOT NULL
         GROUP BY zone)"""
 
-    session.connection
     conn = session.connection().connection
     gdf = geopandas.read_postgis(sql=sql, con=conn).to_crs(epsg=3857)  # pyright: ignore
     gdf["color"] = gdf.apply(lambda row: coloration(row), axis=1)
@@ -200,3 +200,84 @@ async def make_thumbnail(
         out_directory=THUMBNAIL_BUCKET,
     )
     return {"message": "Generating thumbnail in background task"}
+
+
+def generate_blank(
+    session: Session, districtr_map_slug: str, out_directory: str | None
+) -> str:
+    """
+    Generate a preview image of a blank DistrictrMap using GeoPandas.
+
+    Args:
+        session: The database session.
+        districtr_map_slug: The ID for the base map
+        out_directory: Directory to which the thumbnail should be written.
+
+    Returns:
+        Path to thumbnail file.
+    """
+    stmt = text("""
+        SELECT parent_layer
+        FROM districtrmap
+        WHERE districtr_map_slug = :districtr_map_slug
+    """)
+    results = session.execute(stmt, {"districtr_map_slug": districtr_map_slug})
+    [parent_layer] = results.one()
+
+    sql = f"""
+    SELECT geometry AS geom
+    FROM gerrydb.{parent_layer}
+    """
+
+    conn = session.connection().connection
+    gdf = geopandas.read_postgis(sql=sql, con=conn).to_crs(epsg=3857)  # pyright: ignore
+
+    # faint background coloring
+    bg_colors = [
+        (0.8, 0.8, 0.8, 0.5),  # light gray
+        (0.8, 0.8, 1.0, 0.5),  # light blue
+        (0.75, 1.0, 0.9, 0.5),  # light green
+        (0.75, 0.85, 1.0, 0.5),  # lavender
+    ]
+    bg_color = random.choice(bg_colors)
+
+    _, ax = plt.subplots(figsize=(5.6, 5.6), facecolor=bg_color)
+    geoplt = gdf.plot(
+        ax=ax, figsize=(5.6, 5.6), color="#fbeeac", linewidth=0.5, edgecolor="#444444"
+    )
+    geoplt.set_axis_off()
+    pic_IObytes = io.BytesIO()
+    geoplt.figure.savefig(pic_IObytes, format="png")
+    plt.close(geoplt.figure)
+    pic_IObytes.seek(0)
+
+    out_file = get_document_thumbnail_file_path(districtr_map_slug)
+    try:
+        write_image(out_file, pic_IObytes)
+    except (ValueError, S3UploadFailedError) as e:
+        logger.error(f"Could not upload blank map thumbnail for {districtr_map_slug}")
+        raise e
+    finally:
+        pic_IObytes.close()
+        logger.info(f"Thumbnail uploaded for {districtr_map_slug}")
+
+    return out_file
+
+
+@router.post(
+    "/api/gerrydb/{districtr_map_slug}/thumbnail", status_code=status.HTTP_200_OK
+)
+async def make_districtrmap_thumbnail(
+    *,
+    districtr_map_slug: str,
+    background_tasks: BackgroundTasks,
+    session: Session = Depends(get_session),
+    auth_result: dict = Security(auth.verify, scopes=[TokenScope.create_content]),
+):
+    background_tasks.add_task(
+        generate_blank,
+        session=session,
+        districtr_map_slug=districtr_map_slug,
+        out_directory=THUMBNAIL_BUCKET,
+    )
+    return {"message": "Generating blank map thumbnail in background task"}

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -234,10 +234,10 @@ def generate_blank(
 
     # faint background coloring
     bg_colors = [
-        (0.8, 0.8, 0.8, 0.5),  # light gray
-        (0.8, 0.8, 1.0, 0.5),  # light blue
-        (0.75, 1.0, 0.9, 0.5),  # light green
-        (0.75, 0.85, 1.0, 0.5),  # lavender
+        (0.8, 0.8, 0.8, 0.4),  # light gray
+        (0.7, 0.7, 1.0, 0.4),  # light blue
+        (0.75, 1.0, 0.75, 0.4),  # light green
+        (0.75, 0.85, 1.0, 0.4),  # lavender
     ]
     bg_color = random.choice(bg_colors)
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -842,7 +842,7 @@ def test_group_data(client, session: Session):
     response = client.get(f"/api/group/{group_slug}")
     assert response.json().get("name") == "Map Group Two"
 
-    
+
 def test_new_document_from_block_assignments(client, simple_shatterable_districtr_map):
     response = client.post(
         "/api/create_document",

--- a/backend/tests/test_thumbnails.py
+++ b/backend/tests/test_thumbnails.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from tests.constants import FIXTURES_PATH, USER_ID
+from tests.constants import FIXTURES_PATH, USER_ID, GERRY_DB_FIXTURE_NAME
 from unittest.mock import patch
 
 
@@ -54,6 +54,34 @@ def test_thumbnail_generator(client, document_id_with_assignments):
         assert response.status_code == 200
         assert (
             response.json().get("message") == "Generating thumbnail in background task"
+        )
+
+        mock_generate_thumbnail.assert_called_once()
+        assert os.path.exists(out_path)
+        assert os.stat(out_path).st_size > 0
+        os.remove(out_path)
+
+
+def test_blank_thumbnail_generator(client, document_id):
+    payload = {
+        "user_id": USER_ID,
+        "gerrydb_table": GERRY_DB_FIXTURE_NAME,
+    }
+    response = client.post(f"/api/document/{document_id}", json=payload)
+    districtrmap_slug = response.json().get("districtr_map_slug")
+    with patch(
+        "app.thumbnails.main.get_document_thumbnail_file_path"
+    ) as mock_generate_thumbnail:
+        out_path = f"{FIXTURES_PATH}/{districtrmap_slug}.png"
+        mock_generate_thumbnail.return_value = out_path
+
+        response = client.post(
+            f"/api/gerrydb/{districtrmap_slug}/thumbnail",
+        )
+        assert response.status_code == 200
+        assert (
+            response.json().get("message")
+            == "Generating blank map thumbnail in background task"
         )
 
         mock_generate_thumbnail.assert_called_once()


### PR DESCRIPTION
A DistrictrMap can now have a preview / thumbnail image which shows the blocks which make up a blank map:

<img width="960" alt="Screenshot 2025-05-21 at 12 23 12 PM" src="https://github.com/user-attachments/assets/667c8597-d809-4e3e-a5fc-741bf073b783" />

- Backend adds a variant of the thumbnail-generator function, this works without a Document, makes a larger image, and prints yellow-tan blocks on top of a light color background
- Frontend has an updated thumbnail image path, same fallback images
- Includes test
- CSS fixes my data import / scripting mistake where places such as Tell City were showing up as "Tell city, IN"

I had the light color background be a random selection of light blue, green, grey, or purple; I would consider different colors, or printing a transparent background so the background color could be done in CSS. Without colors, I worry this would be too monotonous to have every map looking the same, and we shouldn't color in the blocks to suggest districts.

Other concerns:
- I don't know if the larger image helps much here
- updating thumbnail-generator page now or in the future (I can upload Indiana thumbnails while UI is pending)
- loading too many images / caching when loading a group page