### PR TITLE
List public Documents made with a specific DistrictrMap

### DIFF
--- a/app/src/app/(static)/plans/[slug]/page.tsx
+++ b/app/src/app/(static)/plans/[slug]/page.tsx
@@ -1,0 +1,47 @@
+import {ContentSection} from '@/app/components/Static/ContentSection';
+import {getPublicPlans} from '@/app/utils/api/apiHandlers/getPublicPlans';
+import {getCMSContent} from '@/app/utils/api/cms';
+import {Box, Card, Flex, Grid, Heading, Link, Text} from '@radix-ui/themes';
+import {cookies} from 'next/headers';
+
+export const revalidate = 3600;
+
+export default async function Page({params}: {params: Promise<{slug: string}>}) {
+  const [{slug}, userCookies] = await Promise.all([params, cookies()]);
+  const language = userCookies.get('language')?.value ?? 'en';
+  const [cmsData, publicPlans] = await Promise.all([
+    getCMSContent(slug, language, 'places'),
+    getPublicPlans(slug),
+  ]).catch(() => [null, null]);
+
+  return (
+    <Flex direction="column" width="100%">
+      <Heading as="h1" size="6" mb="4">
+        Public Plans for {slug}
+      </Heading>
+      <ContentSection title="Open an existing plan">
+        <Grid
+          gap="2"
+          columns={{
+            initial: '1',
+            md: '2',
+            lg: '4',
+          }}
+        >
+          {publicPlans!.map(plan => (
+            <Card key={plan.document_id}>
+              <Heading>
+                <Link href={`/map?document_id=${plan.document_id}`}>
+                  {plan.map_metadata?.name ?? plan.document_id}
+                </Link>
+              </Heading>
+              <Text>
+                Created {plan.created_at}, updated {plan.updated_at}
+              </Text>
+            </Card>
+          ))}
+        </Grid>
+      </ContentSection>
+    </Flex>
+  );
+}

--- a/app/src/app/utils/api/apiHandlers/getPublicPlans.ts
+++ b/app/src/app/utils/api/apiHandlers/getPublicPlans.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import {DocumentObject} from './types';
+import {API_URL} from '../constants';
+
+export const getPublicPlans = async (districtr_map_slug: string): Promise<DocumentObject[]> => {
+  return await axios.get(`${API_URL}/api/documents/${districtr_map_slug}`).then(res => {
+    return res.data;
+  });
+};

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1210,3 +1210,35 @@ async def get_group(
         "name": group[0].name,
         "slug": group[0].slug,
     }
+
+
+@app.get(
+    "/api/documents/{districtr_map_slug}",
+    response_model=list[DocumentPublic],
+)
+async def get_public_documents(
+    districtr_map_slug: str, session: Session = Depends(get_session)
+):
+    stmt = (
+        select(
+            Document.document_id,
+            Document.created_at,
+            Document.districtr_map_slug,
+            Document.gerrydb_table,
+            Document.updated_at,
+            Document.map_metadata,
+            DistrictrMap.map_type,
+            DistrictrMap.parent_layer,
+            DistrictrMap.child_layer,
+        )  # pyright: ignore
+        .where(Document.districtr_map_slug == districtr_map_slug)
+        .order_by(text("created_at DESC"))
+        .join(
+            DistrictrMap, Document.districtr_map_slug == DistrictrMap.districtr_map_slug
+        )
+        .where(DistrictrMap.visible == true())
+        .limit(30)
+    )
+
+    results = session.exec(stmt).all()
+    return results


### PR DESCRIPTION
Adds an API endpoint and a page to browse recent `Document`s for a given `DistrictrMap` slug

The API endpoint limits results to members of a public DistrictrMap (i.e. if NYC hasn't been published yet, the API won't return any results)

TODO: I think that the API endpoint should also limit results to `shared = True` and `access = 'read'`, but I don't understand how these are represented in queries

2nd todo: thumbnails?