### PR TITLE
[HiGH] Ensure path is deduped on table updates

### DIFF
--- a/app/src/app/utils/demography/demographyCache.ts
+++ b/app/src/app/utils/demography/demographyCache.ts
@@ -91,7 +91,7 @@ class DemographyCache {
   update(columns: AllTabularColumns[number][], data: ColumnarTableData, hash: string): void {
     if (hash === this.hash) return;
     this.availableColumns = columns;
-    this.table = table(data).derive(getColumnDerives(columns));
+    this.table = table(data).derive(getColumnDerives(columns)).dedupe('path');
     const zoneAssignments = useMapStore.getState().zoneAssignments;
     const popsOk = this.updatePopulations(zoneAssignments);
     if (!popsOk) return;


### PR DESCRIPTION
Adds an additional check to make sure demography table contains no duplicate entries