### PR TITLE
Point selection fallback strategy

### DIFF
--- a/app/src/app/components/Map/PointSelectionLayer.tsx
+++ b/app/src/app/components/Map/PointSelectionLayer.tsx
@@ -1,0 +1,81 @@
+import {BLOCK_LAYER_ID, BLOCK_LAYER_ID_CHILD, BLOCK_POINTS_LAYER_ID, BLOCK_POINTS_LAYER_ID_CHILD} from '@/app/constants/layers';
+import {useLayerFilter} from '@/app/hooks/useLayerFilter';
+import {useMapStore} from '@/app/store/mapStore';
+import { asyncBufferFromUrl, parquetReadObjects } from 'hyparquet';
+import React, {useEffect, useRef, useState} from 'react';
+import {Layer, Source} from 'react-map-gl/dist/esm/exports-maplibre';
+
+const generateGeojson = (pointData: any[], mapDocument: MapDocument, child: boolean) => {
+  const source = child ? BLOCK_LAYER_ID_CHILD : BLOCK_LAYER_ID;
+  const sourceLayer = child ? mapDocument?.child_layer : mapDocument?.parent_layer;
+  return {
+    type: 'FeatureCollection',
+    features: pointData.map((d: any) => ({
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [d.x, d.y]},
+      properties: {
+        path: d.path,
+        total_pop_20: parseInt(d.total_pop_20),
+        __source: source,
+        __sourceLayer: sourceLayer,
+      },
+    })),
+  } as GeoJSON.FeatureCollection<GeoJSON.Point>;
+};
+
+export const PointSelectionLayer: React.FC<{child?: boolean}> = ({child = false}) => {
+  const fullData = useRef<any[] | null>(null);
+  const data = useRef<GeoJSON.FeatureCollection<GeoJSON.Point> | null>(null);
+  const mapDocument = useMapStore(state => state.mapDocument);
+  const brokenChildIds = useMapStore(state => state.shatterIds.children);
+  const layerFilter = useLayerFilter(child);
+  const sourceID = 'SELECTION_POINTS' + (child ? '_child' : '');
+  const [dataHash, setDataHash] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+    const layer = child ? mapDocument?.child_layer : mapDocument?.parent_layer;
+    if (layer) {
+      const url = `${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/dev/${layer}_points.parquet`;
+      const file = await asyncBufferFromUrl({ url }) // wrap url for async fetching
+      const parquetData = await parquetReadObjects({
+        file,
+        columns: ['path', 'x', 'y', 'total_pop_20'],
+      }) as any;
+      if (child) {
+        fullData.current = parquetData;
+        setDataHash(new Date().toISOString());
+      } else {
+        data.current = generateGeojson(parquetData, mapDocument, child);
+        setDataHash(new Date().toISOString());
+      }
+    }
+    };
+    fetchData();
+  }, [child ? mapDocument?.child_layer : mapDocument?.parent_layer]);
+
+  useEffect(() => {
+    if (child && brokenChildIds.size > 0 && data.current?.features?.length !== brokenChildIds.size) {
+      const newData = fullData.current?.filter((d: any) => brokenChildIds.has(d.path));
+      if (newData) {
+        data.current = generateGeojson(newData, mapDocument, child);
+        setDataHash(new Date().toISOString());
+      }
+    }
+  }, [child, brokenChildIds, dataHash]);
+
+  return (
+    <Source id={sourceID} type="geojson" promoteId="path" data={data.current || undefined}>
+      <Layer
+        id={child ? BLOCK_POINTS_LAYER_ID_CHILD : BLOCK_POINTS_LAYER_ID}
+        source={sourceID}
+        filter={layerFilter}
+        type="circle"
+        paint={{
+          'circle-radius': 1,
+          'circle-color': '#000000',
+        }}
+      />
+    </Source>
+  );
+};

--- a/app/src/app/components/Map/VtdBlockLayers.tsx
+++ b/app/src/app/components/Map/VtdBlockLayers.tsx
@@ -9,6 +9,7 @@ import {DemographicLayer} from './DemographicLayer';
 import {HighlightOverlayerLayerGroup} from './HighlightOverlayLayerGroup';
 import {demographyCache} from '@/app/utils/demography/demographyCache';
 import {useClearMap} from '@/app/hooks/useClearMap';
+import { PointSelectionLayer } from './PointSelectionLayer';
 
 export const VtdBlockLayers: React.FC<{
   isDemographicMap?: boolean;
@@ -106,6 +107,8 @@ export const VtdBlockLayers: React.FC<{
         <HighlightOverlayerLayerGroup />
         <HighlightOverlayerLayerGroup child />
       </Source>
+      <PointSelectionLayer />
+      <PointSelectionLayer child />
     </>
   );
 };

--- a/app/src/app/constants/layers.ts
+++ b/app/src/app/constants/layers.ts
@@ -7,9 +7,11 @@ import {demographyCache} from '../utils/demography/demographyCache';
 export const FALLBACK_NUM_DISTRICTS = 4;
 export const BLOCK_SOURCE_ID = 'blocks';
 export const BLOCK_LAYER_ID = 'blocks';
+export const BLOCK_POINTS_LAYER_ID = 'blocks-points';
 export const BLOCK_LAYER_ID_HIGHLIGHT = BLOCK_LAYER_ID + '-highlight';
 export const BLOCK_LAYER_ID_HIGHLIGHT_CHILD = BLOCK_LAYER_ID + '-highlight-child';
 export const BLOCK_LAYER_ID_CHILD = 'blocks-child';
+export const BLOCK_POINTS_LAYER_ID_CHILD = 'blocks-points-child';
 export const BLOCK_HOVER_LAYER_ID = `${BLOCK_LAYER_ID}-hover`;
 export const BLOCK_HOVER_LAYER_ID_CHILD = `${BLOCK_LAYER_ID_CHILD}-hover`;
 

--- a/app/src/app/store/hoverFeatures.ts
+++ b/app/src/app/store/hoverFeatures.ts
@@ -22,12 +22,11 @@ export var useHoverStore = create(
       setHoverFeatures: _features => {
         const hoverFeatures = _features
           ? _features.map(f => ({
-              source: f.source,
-              sourceLayer: f.sourceLayer,
+              source: f.properties.__source || f.source,
+              sourceLayer: f.properties.__sourceLayer || f.sourceLayer,
               id: f.id,
             }))
           : [];
-
         set({hoverFeatures});
       },
     })),

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -375,9 +375,10 @@ export var useMapStore = createWithMiddlewares<MapStore>((set, get) => ({
     }
     features?.forEach(feature => {
       const id = feature?.id?.toString() ?? undefined;
-      if (!id || !feature.sourceLayer) return;
-      const state = featureStateCache[feature.sourceLayer]?.[id];
-      const stateChanges = featureStateChangesCache?.[feature.sourceLayer]?.[id];
+      const sourceLayer = feature.properties.__sourceLayer || feature.sourceLayer;
+      if (!id || !sourceLayer) return;
+      const state = featureStateCache[sourceLayer]?.[id];
+      const stateChanges = featureStateChangesCache?.[sourceLayer]?.[id];
 
       const prevAssignment = stateChanges?.zone || state?.zone || false;
 
@@ -401,7 +402,7 @@ export var useMapStore = createWithMiddlewares<MapStore>((set, get) => ({
         {
           source: BLOCK_SOURCE_ID,
           id,
-          sourceLayer: feature.sourceLayer,
+          sourceLayer,
         },
         {selected: true, zone: selectedZone}
       );

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -18,6 +18,8 @@ import {useMapStore} from '@/app/store/mapStore';
 import {
   BLOCK_HOVER_LAYER_ID,
   BLOCK_HOVER_LAYER_ID_CHILD,
+  BLOCK_POINTS_LAYER_ID,
+  BLOCK_POINTS_LAYER_ID_CHILD,
   INTERACTIVE_LAYERS,
 } from '@/app/constants/layers';
 import {ResetMapSelectState} from '@utils/events/handlers';
@@ -47,7 +49,13 @@ function getLayerIdsToPaint(child_layer: string | undefined | null, activeTool: 
     return [BLOCK_HOVER_LAYER_ID];
   }
 
-  return child_layer ? [BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CHILD] : [BLOCK_HOVER_LAYER_ID];
+  return child_layer
+    ? [
+        BLOCK_POINTS_LAYER_ID,
+        BLOCK_POINTS_LAYER_ID_CHILD,
+        // BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CHILD,
+      ]
+    : [BLOCK_POINTS_LAYER_ID, BLOCK_HOVER_LAYER_ID];
 }
 
 /**

--- a/app/src/app/utils/helpers.ts
+++ b/app/src/app/utils/helpers.ts
@@ -15,6 +15,7 @@ import {MapStore, useMapStore} from '../store/mapStore';
 import {NullableZone} from '../constants/types';
 import {demographyCache} from './demography/demographyCache';
 import {DocumentMetadata} from '@utils/api/apiHandlers/types';
+import {onlyUniqueProperty} from './arrays';
 
 /**
  * PaintEventHandler
@@ -94,10 +95,9 @@ export const getFeaturesInBbox = (
     : captiveIds.size
       ? [BLOCK_HOVER_LAYER_ID, BLOCK_HOVER_LAYER_ID_CHILD]
       : [BLOCK_HOVER_LAYER_ID];
-
   let features = map?.queryRenderedFeatures(bbox, {layers}) || [];
-
-  return filterFeatures(features, filterLocked);
+  const filtered = filterFeatures(features, filterLocked);
+  return filtered;
 };
 
 /**
@@ -429,11 +429,13 @@ export const checkIfSameZone = (
  * The function returns an array of features that pass all the filtering criteria.
  */
 const filterFeatures = (
-  features: MapGeoJSONFeature[],
+  _features: MapGeoJSONFeature[],
   filterLocked: boolean = true,
   additionalFilters: Array<(f: MapGeoJSONFeature) => boolean> = [],
   allowOutsideCaptiveIds: boolean = false
 ) => {
+  // // first, dedupe
+  const features = _features;
   const {
     activeTool,
     captiveIds,


### PR DESCRIPTION
When selecting small geographies from an outer zoom, often they get missed. We've played around with a handful of strategies, but a possible solution is to simply have representative points for all geographies always present; or at least all parent geos and child geos as needed.

## Description
- [Temp] Pulls out the point data from gpkgs for a test case (Kansas)
- Uses a point layer as an additional selection layer

## Reviewers
- Primary: WIP
- Secondary:

## Checklist
- [ ] Add point selection layers
- [ ]Tweak existing selection logic
- [ ] Test performance
- [ ] Update pipeline

## Screenshots (if applicable):
