### PR TITLE
Load source geography name (state / town name) for top bar

### DIFF
--- a/app/src/app/components/Topbar/MapHeader.tsx
+++ b/app/src/app/components/Topbar/MapHeader.tsx
@@ -12,11 +12,6 @@ export const MapHeader: React.FC = () => {
   const mapDocument = useMapStore(state => state.mapDocument);
   const mapMetadata = useMapMetadata(mapDocument?.document_id);
 
-  const mapTableName = useMapStore(
-    state =>
-      state.userMaps.find(userMap => userMap.document_id === state.mapDocument?.document_id)
-        ?.name ?? ''
-  );
   const handleMetadataChange = async (updates: Partial<DocumentMetadata>) => {
     await saveMap({
       ...(mapMetadata || DEFAULT_MAP_METADATA),
@@ -37,7 +32,7 @@ export const MapHeader: React.FC = () => {
         handleMetadataChange={handleMetadataChange}
       />
       <Text size="2" className="text-gray-500">
-        {mapTableName || ''}
+        {mapDocument?.map_geo_name || ''}
       </Text>
     </Flex>
   );

--- a/app/src/app/utils/api/apiHandlers/types.ts
+++ b/app/src/app/utils/api/apiHandlers/types.ts
@@ -53,6 +53,7 @@ export interface DocumentObject extends StatusObject {
   child_layer: string | null;
   tiles_s3_path: string | null;
   num_districts: number | null;
+  map_geo_name: string | null;
   created_at: string;
   updated_at: string | null;
   extent: [number, number, number, number]; // [minx, miny, maxx, maxy]

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -96,6 +96,7 @@ def get_document_public(
             DistrictrMap.parent_layer.label("parent_layer"),  # pyright: ignore
             DistrictrMap.child_layer.label("child_layer"),  # pyright: ignore
             DistrictrMap.tiles_s3_path.label("tiles_s3_path"),  # pyright: ignore
+            DistrictrMap.name.label("map_geo_name"),  # pyright: ignore
             DistrictrMap.num_districts.label("num_districts"),  # pyright: ignore
             DistrictrMap.extent.label("extent"),  # pyright: ignore
             DistrictrMap.map_type.label("map_type"),  # pyright: ignore

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -259,6 +259,7 @@ async def create_document(
             DistrictrMap.parent_layer.label("parent_layer"),  # pyright: ignore
             DistrictrMap.child_layer.label("child_layer"),  # pyright: ignore
             DistrictrMap.tiles_s3_path.label("tiles_s3_path"),  # pyright: ignore
+            DistrictrMap.name.label("map_geo_name"),  # pyright: ignore
             DistrictrMap.num_districts.label("num_districts"),  # pyright: ignore
             DistrictrMap.extent.label("extent"),  # pyright: ignore
             DistrictrMap.map_type.label("map_type"),  # pyright: ignore

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -196,6 +196,7 @@ class DocumentPublic(BaseModel):
     access: DocumentShareStatus = DocumentShareStatus.edit
     color_scheme: list[str] | None = None
     map_type: str
+    map_geo_name: str | None = None
 
 
 class DocumentCreatePublic(DocumentPublic):


### PR DESCRIPTION
The top bar of the map shows `DistrictrMap.name`, which is the name of the state/city/source geography of this map, as seen in  #417

The name was extracted from `mapViews` so our local maps (not being part of the public list) were not showing a name.
I also saw some quirks with loading a blank state map, where it couldn't get the name from `mapViews` until I started painting and assignments got saved.

This PR returns the name in the `mapDocument` object we use for `num_districts` and other DistrictrMap info. For Indiana maps it might still be a little different because the states' names include a number of districts ("Florida Congressional (28)") and Indiana does not.