### PR TITLE
Stop chart from rendering before parent is ready

### DIFF
--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationChart.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationChart.tsx
@@ -65,6 +65,11 @@ export const PopulationChart: React.FC<{
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [isHovered, setIsHovered] = useState(false);
 
+  // Parnent container not ready yet
+  if (xMax < 0) {
+    return null;
+  }
+
   return (
     <svg
       width={width}


### PR DESCRIPTION
Small fix to silence warning

When loading into a map, the chart would try to render before the parentSize hook has the width, firing some SVG warnings.
