### PR TITLE
[Hotfix] Increase views cap to 1000

### DIFF
--- a/app/src/app/utils/api/apiHandlers/getAvailableDistrictrMaps.ts
+++ b/app/src/app/utils/api/apiHandlers/getAvailableDistrictrMaps.ts
@@ -10,7 +10,7 @@ interface AvailableDistrictrMapsParams {
 
 export const getAvailableDistrictrMaps = async ({
   group = 'states',
-  limit = 100,
+  limit = 1000,
   offset = 0,
 }: AvailableDistrictrMapsParams): Promise<DistrictrMap[]> => {
   return await axios

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -829,7 +829,7 @@ async def get_projects(
     session: Session = Depends(get_session),
     group: str = Query(default="states"),
     offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=100, le=100),
+    limit: int = Query(default=100, le=1000),
 ):
     gerrydb_views = session.exec(
         select(DistrictrMap)


### PR DESCRIPTION
Currently we have a few pages (places, tags) that just get the full list of views and filter for the correct ones. Longer term we need a better way to query specific view information but for now we can use the same parts and just expand the limit on the amount of data returned. There is a unit of work here to move away from the long list in general, but to get the place pages working again for the short term, this will work.
