### PR TITLE
Add painting event to subscription for update

### DIFF
--- a/app/src/app/utils/map/mapRenderSubs.ts
+++ b/app/src/app/utils/map/mapRenderSubs.ts
@@ -259,6 +259,7 @@ export class MapRenderSubscriber {
           state.mapOptions.lockPaintedAreas,
           state.mapOptions.showZoneNumbers,
           state.mapOptions.showDemographicMap,
+          state.isPainting,
         ],
         () => this.renderColorZones(),
         {equalityFn: shallowCompareArray}


### PR DESCRIPTION
The recent update to how zone labels were calculated sped things up, creating a new race condition. This adds the end of the painting event to the subscription which covers the failure case.