### PR TITLE
Hotfix/shatter undo redo

### DIFF
--- a/app/src/app/store/assignmentsStore.ts
+++ b/app/src/app/store/assignmentsStore.ts
@@ -22,6 +22,35 @@ import {createMapDocument} from '../utils/api/apiHandlers/createMapDocument';
 import {createWithFullMiddlewares} from './middlewares';
 import {confirmMapDocumentUrlParameter} from '../utils/map/confirmMapDocumentUrlParameter';
 
+export type AssignmentsTemporalSnapshot = {
+  shatterIds: {
+    parents: Set<string>;
+    children: Set<string>;
+  };
+  parentToChild: Map<string, Set<string>>;
+  childToParent: Map<string, string>;
+  zoneAssignments: Map<string, NullableZone>;
+  clientLastUpdated: string;
+};
+
+const cloneAssignmentsTemporalSnapshot = (
+  snapshot: AssignmentsTemporalSnapshot
+): AssignmentsTemporalSnapshot => ({
+  shatterIds: {
+    parents: new Set(snapshot.shatterIds.parents),
+    children: new Set(snapshot.shatterIds.children),
+  },
+  parentToChild: new Map(
+    Array.from(snapshot.parentToChild.entries()).map(([parentId, children]) => [
+      parentId,
+      new Set(children),
+    ])
+  ),
+  childToParent: new Map(snapshot.childToParent),
+  zoneAssignments: new Map(snapshot.zoneAssignments),
+  clientLastUpdated: snapshot.clientLastUpdated,
+});
+
 export interface AssignmentsStore {
   /** Map of geoid -> zone assignments currently in memory */
   zoneAssignments: Map<string, NullableZone>;
@@ -47,6 +76,8 @@ export interface AssignmentsStore {
   setZoneAssignments: (zone: NullableZone, gdbPaths: Set<GDBPath>) => void;
 
   clientLastUpdated: string;
+  /** Internal snapshot used to collapse shatter + first child paint into a single undo step */
+  pendingShatterUndoState: AssignmentsTemporalSnapshot | null;
   setClientLastUpdated: (updated_at: string) => void;
   /** Flushes accumulated geoids to the worker & downstream caches */
   ingestAccumulatedAssignments: () => void;
@@ -126,6 +157,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
   parentToChild: new Map<string, Set<string>>(),
   childToParent: new Map<string, string>(),
   clientLastUpdated: '',
+  pendingShatterUndoState: null,
   setClientLastUpdated: (updated_at: string) => {
     set({
       clientLastUpdated: updated_at,
@@ -206,6 +238,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
       parentToChild: new Map(data.parentToChild),
       childToParent: new Map(data.childToParent),
       clientLastUpdated: mapDocument?.updated_at ?? new Date().toISOString(),
+      pendingShatterUndoState: null,
     });
     if (mapDocument) {
       // Save immediately when loading from document (not during painting)
@@ -314,6 +347,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
         parentToChild: new Map(parentToChild),
         childToParent: new Map(childToParent),
         clientLastUpdated: new Date().toISOString(),
+        pendingShatterUndoState: null,
         zonesLastUpdated: new Map(get().zonesLastUpdated),
       });
     }
@@ -375,6 +409,10 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
     const {zoneAssignments, shatterIds, parentToChild, childToParent} = result;
     demographyCache.updatePopulations(zoneAssignments);
     idb.updateIdbAssignments(mapDocument, zoneAssignments);
+    const temporalState = useAssignmentsStore.temporal.getState();
+    if (!temporalState.isTracking) {
+      temporalState.resume();
+    }
 
     set({
       zoneAssignments,
@@ -383,6 +421,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
       parentToChild,
       childToParent,
       clientLastUpdated: new Date().toISOString(),
+      pendingShatterUndoState: null,
       zonesLastUpdated: new Map(zonesLastUpdated),
     });
   },
@@ -390,6 +429,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
   replaceZoneAssignments: assignments => {
     set({
       zoneAssignments: new Map(assignments),
+      pendingShatterUndoState: null,
     });
   },
 
@@ -404,10 +444,26 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
       },
       parentToChild: new Map<string, Set<string>>(),
       childToParent: new Map<string, string>(),
+      pendingShatterUndoState: null,
     });
   },
 
   setShatterState: ({shatterIds, parentToChild, zoneAssignments, childToParent}) => {
+    const {
+      shatterIds: currShatterIds,
+      parentToChild: currParentToChild,
+      childToParent: currChildToParent,
+      zoneAssignments: currZoneAssignments,
+      clientLastUpdated,
+    } = get();
+    const preShatterSnapshot = cloneAssignmentsTemporalSnapshot({
+      shatterIds: currShatterIds,
+      parentToChild: currParentToChild,
+      childToParent: currChildToParent,
+      zoneAssignments: currZoneAssignments,
+      clientLastUpdated,
+    });
+
     // Ensure both maps are provided or build from each other
     const _parentToChild =
       parentToChild && parentToChild.size > 0
@@ -445,6 +501,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
       parentToChild: _parentToChild,
       zoneAssignments: new Map(zoneAssignments),
       childToParent: _childToParent,
+      pendingShatterUndoState: preShatterSnapshot,
     });
   },
 
@@ -456,6 +513,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
       },
       parentToChild: new Map<string, Set<string>>(),
       childToParent: new Map<string, string>(),
+      pendingShatterUndoState: null,
     });
   },
 
@@ -508,6 +566,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
       zoneAssignments: updatedAssignments,
       zonesLastUpdated: updatedZonesLastUpdated,
       accumulatedAssignments: new Map<string, NullableZone>(),
+      pendingShatterUndoState: null,
     });
   },
 

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -181,6 +181,7 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
     exitBlockView: (lock: boolean = false) => {
       const {focusFeatures} = get();
       const {healParentsIfAllChildrenInSameZone} = useAssignmentsStore.getState();
+      const temporalState = useAssignmentsStore.temporal.getState();
       const {setMapOptions} = useMapControlsStore.getState();
 
       set({
@@ -191,8 +192,12 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
       useMapControlsStore.setState({activeTool: 'shatter'});
 
       const parentId = focusFeatures?.[0].id?.toString();
-      if (!parentId) return;
-      healParentsIfAllChildrenInSameZone({}, 'state');
+      if (parentId) {
+        healParentsIfAllChildrenInSameZone({}, 'state');
+      }
+      if (!temporalState.isTracking) {
+        temporalState.resume();
+      }
     },
     getMapRef: () => undefined,
     setMapRef: mapRef => {
@@ -542,6 +547,11 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
         featureBbox?.length && featureBbox?.length >= 4
           ? (featureBbox.slice(0, 4) as maplibregl.LngLatBoundsLike)
           : undefined;
+
+      const temporalState = useAssignmentsStore.temporal.getState();
+      if (temporalState.isTracking) {
+        temporalState.pause();
+      }
 
       setShatterState({
         shatterIds: {

--- a/app/src/app/store/middlewareConfig.ts
+++ b/app/src/app/store/middlewareConfig.ts
@@ -1,7 +1,7 @@
 import {devtools, DevtoolsOptions, PersistOptions} from 'zustand/middleware';
 import {MapStore} from './mapStore';
 import {ZundoOptions} from 'zundo';
-import {AssignmentsStore} from './assignmentsStore';
+import {AssignmentsStore, AssignmentsTemporalSnapshot} from './assignmentsStore';
 
 const prodWrapper: typeof devtools = (store: any) => store;
 export const devwrapper = process.env.NODE_ENV === 'development' ? devtools : prodWrapper;
@@ -33,6 +33,24 @@ export const devToolsConfig: DevtoolsOptions = {
 
 const MIN_DIFF_MS = 3000;
 
+const cloneTemporalSnapshot = (
+  snapshot: AssignmentsTemporalSnapshot
+): AssignmentsTemporalSnapshot => ({
+  shatterIds: {
+    parents: new Set(snapshot.shatterIds.parents),
+    children: new Set(snapshot.shatterIds.children),
+  },
+  parentToChild: new Map(
+    Array.from(snapshot.parentToChild.entries()).map(([parentId, children]) => [
+      parentId,
+      new Set(children),
+    ])
+  ),
+  childToParent: new Map(snapshot.childToParent),
+  zoneAssignments: new Map(snapshot.zoneAssignments),
+  clientLastUpdated: snapshot.clientLastUpdated,
+});
+
 export const temporalConfig: ZundoOptions<any, AssignmentsStore> = {
   // If diff returns null, not state is stored
   diff: (past: Partial<AssignmentsStore>, curr: Partial<AssignmentsStore>) => {
@@ -41,6 +59,9 @@ export const temporalConfig: ZundoOptions<any, AssignmentsStore> = {
     if (past.clientLastUpdated === curr.clientLastUpdated) return null;
     // If not yet ingested, don't store
     if (past.clientLastUpdated === '' || curr.clientLastUpdated === '') return null;
+    if (past.pendingShatterUndoState && !curr.pendingShatterUndoState) {
+      return cloneTemporalSnapshot(past.pendingShatterUndoState);
+    }
     // If the difference is less than the minimum diff time, don't store
     if (
       new Date(curr.clientLastUpdated.toString()).getTime() -
@@ -53,13 +74,21 @@ export const temporalConfig: ZundoOptions<any, AssignmentsStore> = {
   limit: 20,
   // @ts-ignore: save only partial store
   partialize: state => {
-    const {shatterIds, parentToChild, zoneAssignments, clientLastUpdated, childToParent} = state;
+    const {
+      shatterIds,
+      parentToChild,
+      zoneAssignments,
+      clientLastUpdated,
+      childToParent,
+      pendingShatterUndoState,
+    } = state;
     return {
       shatterIds,
       parentToChild,
       childToParent,
       zoneAssignments,
       clientLastUpdated,
+      pendingShatterUndoState,
     } as Partial<AssignmentsStore>;
   },
 };


### PR DESCRIPTION
## Description
- Fixes undo/redo behavior for shatter workflows by removing the intermediate “shattered but unchanged” checkpoint and preserving a pre-shatter snapshot for the first post-shatter paint commit.
- Adds `pendingShatterUndoState` in assignments state, captured during `setShatterState`, and used by zundo `diff` to store the correct undo target.
- Ensures the snapshot path is applied before the `MIN_DIFF_MS` filter so quick shatter -> paint interactions still create the expected undo entry.
- Pauses temporal tracking when shatter is applied, then resumes tracking either on first paint commit or when exiting break mode with no edits (the instant-heal case), so temporal state does not remain paused.

## Reviewers
- Primary:
- Secondary:

## Checklist
- [x] Added/Updated related documentation (if applicable).  
No docs updated; this is internal undo/redo behavior.
- [x] Added/Updated related unit tests (if applicable).  
No unit tests added in this PR.

## Screenshots (if applicable):
- N/A (no UI/layout changes).

## Review required
- UI/UX
- Sanity check on snapshot approach