### PR TITLE
Centralize reused frontend string constants

### DIFF
--- a/app/src/app/api/og/[id]/route.tsx
+++ b/app/src/app/api/og/[id]/route.tsx
@@ -2,6 +2,7 @@ import {API_URL} from '@/app/utils/api/constants';
 import {ImageResponse} from 'next/og';
 import fs from 'fs';
 import {DocumentObject} from '@/app/utils/api/apiHandlers/types';
+import {DRAFT_STATUS_LABELS, DRAFT_STATUS_OG_COLORS} from '@/app/constants/map/draftStatus';
 
 export async function GET(_: Request, {params}: {params: Promise<{id: string}>}) {
   const {id} = await params;
@@ -23,6 +24,9 @@ export async function GET(_: Request, {params}: {params: Promise<{id: string}>})
   // Load the font in an edge-compatible way
   const nunitoBold = fs.readFileSync('./public/Nunito-Bold.ttf');
   const nunitoMedium = fs.readFileSync('./public/Nunito-Medium.ttf');
+  const draftStatus = mapDocument.map_metadata?.draft_status;
+  const draftStatusLabel = draftStatus ? DRAFT_STATUS_LABELS[draftStatus] : null;
+  const draftStatusColor = draftStatus ? DRAFT_STATUS_OG_COLORS[draftStatus] : null;
 
   return new ImageResponse(
     (
@@ -69,12 +73,10 @@ export async function GET(_: Request, {params}: {params: Promise<{id: string}>})
                 {title}
               </h1>
               <div style={{display: 'flex', flexDirection: 'row', gap: '10px'}}>
-                {mapDocument.map_metadata?.draft_status === 'ready_to_share' ? (
-                  <p style={{color: 'green', textTransform: 'uppercase'}}>Ready to Share</p>
-                ) : mapDocument.map_metadata?.draft_status === 'in_progress' ? (
-                  <p style={{color: 'blue', textTransform: 'uppercase'}}>In Progress</p>
-                ) : mapDocument.map_metadata?.draft_status === 'scratch' ? (
-                  <p style={{color: 'orange', textTransform: 'uppercase'}}>Scratch Work</p>
+                {draftStatusLabel ? (
+                  <p style={{color: draftStatusColor ?? 'black', textTransform: 'uppercase'}}>
+                    {draftStatusLabel}
+                  </p>
                 ) : null}
                 <p>{mapDocument.num_districts} districts</p>
               </div>

--- a/app/src/app/components/Cms/RichTextEditor/extensions/Boilerplate/BoilerplateNode.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/Boilerplate/BoilerplateNode.tsx
@@ -1,6 +1,11 @@
 import {Node, mergeAttributes} from '@tiptap/core';
 import {ReactNodeViewRenderer} from '@tiptap/react';
 import BoilerplateNodeView from '@/app/components/Cms/RichTextEditor/extensions/Boilerplate/BoilerplateNodeView';
+import {
+  getRichTextNodeSelector,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -24,12 +29,12 @@ export const BoilerplateNode = Node.create({
       customContent: {
         default: null,
         parseHTML: element => {
-          const content = element.getAttribute('data-custom-content');
+          const content = element.getAttribute(RICH_TEXT_DATA_ATTRIBUTES.CUSTOM_CONTENT);
           return content ? JSON.parse(content) : null;
         },
         renderHTML: attributes => {
           return {
-            'data-custom-content': attributes.customContent
+            [RICH_TEXT_DATA_ATTRIBUTES.CUSTOM_CONTENT]: attributes.customContent
               ? JSON.stringify(attributes.customContent)
               : '',
           };
@@ -41,13 +46,19 @@ export const BoilerplateNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[data-type="boilerplate-node"]',
+        tag: getRichTextNodeSelector(RICH_TEXT_NODE_TYPES.BOILERPLATE),
       },
     ];
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['div', mergeAttributes(HTMLAttributes, {'data-type': 'boilerplate-node'}), 0];
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        [RICH_TEXT_DATA_ATTRIBUTES.TYPE]: RICH_TEXT_NODE_TYPES.BOILERPLATE,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/app/src/app/components/Cms/RichTextEditor/extensions/CommentGallery/CommentGalleryNode.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/CommentGallery/CommentGalleryNode.tsx
@@ -13,6 +13,12 @@ import {Node, mergeAttributes} from '@tiptap/core';
 import {ReactNodeViewRenderer} from '@tiptap/react';
 import CommentGalleryNodeView from './CommentGalleryNodeView';
 import {getJsonHtmlRenderer, getStandardHtmlParser} from '../extensionUtils';
+import {
+  COMMENT_GALLERY_ATTRS,
+  getRichTextNodeSelector,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
 
 // Extend TipTap's command interface to include our custom command
 declare module '@tiptap/core' {
@@ -40,68 +46,68 @@ export const CommentGalleryNode = Node.create({
       renderHTML?: (attributes: Record<string, any>) => Record<string, any>;
     }[] = [
       {
-        name: 'title',
+        name: COMMENT_GALLERY_ATTRS.TITLE,
       },
       {
-        name: 'description',
+        name: COMMENT_GALLERY_ATTRS.DESCRIPTION,
       },
       {
-        name: 'ids',
+        name: COMMENT_GALLERY_ATTRS.IDS,
       },
       {
-        name: 'tags',
+        name: COMMENT_GALLERY_ATTRS.TAGS,
       },
       {
-        name: 'place',
+        name: COMMENT_GALLERY_ATTRS.PLACE,
       },
       {
-        name: 'state',
+        name: COMMENT_GALLERY_ATTRS.STATE,
       },
       {
-        name: 'zipCode',
+        name: COMMENT_GALLERY_ATTRS.ZIP_CODE,
       },
       {
-        name: 'limit',
+        name: COMMENT_GALLERY_ATTRS.LIMIT,
         default: 10,
       },
       {
-        name: 'showIdentifier',
+        name: COMMENT_GALLERY_ATTRS.SHOW_IDENTIFIER,
         default: true,
       },
       {
-        name: 'showTitles',
+        name: COMMENT_GALLERY_ATTRS.SHOW_TITLES,
         default: true,
       },
       {
-        name: 'showPlaces',
+        name: COMMENT_GALLERY_ATTRS.SHOW_PLACES,
         default: true,
       },
       {
-        name: 'showStates',
+        name: COMMENT_GALLERY_ATTRS.SHOW_STATES,
         default: true,
       },
       {
-        name: 'showZipCodes',
+        name: COMMENT_GALLERY_ATTRS.SHOW_ZIP_CODES,
         default: true,
       },
       {
-        name: 'showCreatedAt',
+        name: COMMENT_GALLERY_ATTRS.SHOW_CREATED_AT,
         default: true,
       },
       {
-        name: 'showListView',
+        name: COMMENT_GALLERY_ATTRS.SHOW_LIST_VIEW,
         default: true,
       },
       {
-        name: 'paginate',
+        name: COMMENT_GALLERY_ATTRS.PAGINATE,
         default: true,
       },
       {
-        name: 'showFilters',
+        name: COMMENT_GALLERY_ATTRS.SHOW_FILTERS,
         default: false,
       },
       {
-        name: 'showMaps',
+        name: COMMENT_GALLERY_ATTRS.SHOW_MAPS,
         default: true,
       },
     ];
@@ -122,13 +128,19 @@ export const CommentGalleryNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[data-type="comment-gallery-node"]',
+        tag: getRichTextNodeSelector(RICH_TEXT_NODE_TYPES.COMMENT_GALLERY),
       },
     ];
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['div', mergeAttributes(HTMLAttributes, {'data-type': 'comment-gallery-node'}), 0];
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        [RICH_TEXT_DATA_ATTRIBUTES.TYPE]: RICH_TEXT_NODE_TYPES.COMMENT_GALLERY,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/app/src/app/components/Cms/RichTextEditor/extensions/CommentGallery/CommentGalleryNodeView.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/CommentGallery/CommentGalleryNodeView.tsx
@@ -18,6 +18,12 @@ import {CommentGallery, CommentGalleryProps} from './CommentGallery';
 import {GearIcon, TrashIcon} from '@radix-ui/react-icons';
 import {NoFocusBoundary} from '../NoFocusBoundary';
 import {CmsSettingsChips} from '../EditHelpers/CmsSettingsChips';
+import {
+  COMMENT_GALLERY_ATTRS,
+  COMMENT_GALLERY_DISPLAY_OPTIONS,
+  GALLERY_FILTER_TABS,
+  type CommentGalleryDisplayOptionKey,
+} from '@constants/cms/richText';
 
 const CommentGalleryNodeView: React.FC<NodeViewProps> = ({node, updateAttributes, deleteNode}) => {
   const parentRef = useRef<HTMLDivElement>(null);
@@ -42,6 +48,23 @@ const CommentGalleryNodeView: React.FC<NodeViewProps> = ({node, updateAttributes
     showFilters,
     showMaps,
   } = node.attrs as CommentGalleryProps;
+
+  const displayOptionState: Record<CommentGalleryDisplayOptionKey, boolean> = {
+    [COMMENT_GALLERY_ATTRS.PAGINATE]: Boolean(paginate),
+    [COMMENT_GALLERY_ATTRS.SHOW_LIST_VIEW]: Boolean(showListView),
+    [COMMENT_GALLERY_ATTRS.SHOW_IDENTIFIER]: Boolean(showIdentifier),
+    [COMMENT_GALLERY_ATTRS.SHOW_TITLES]: Boolean(showTitles),
+    [COMMENT_GALLERY_ATTRS.SHOW_PLACES]: Boolean(showPlaces),
+    [COMMENT_GALLERY_ATTRS.SHOW_STATES]: Boolean(showStates),
+    [COMMENT_GALLERY_ATTRS.SHOW_ZIP_CODES]: Boolean(showZipCodes),
+    [COMMENT_GALLERY_ATTRS.SHOW_CREATED_AT]: Boolean(showCreatedAt),
+    [COMMENT_GALLERY_ATTRS.SHOW_FILTERS]: Boolean(showFilters),
+    [COMMENT_GALLERY_ATTRS.SHOW_MAPS]: Boolean(showMaps),
+  };
+
+  const selectedDisplayOptions = COMMENT_GALLERY_DISPLAY_OPTIONS.filter(option => {
+    return displayOptionState[option.key];
+  }).map(option => option.key);
 
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const handleUpdate = (updates: Partial<CommentGalleryProps>) => {
@@ -117,70 +140,58 @@ const CommentGalleryNodeView: React.FC<NodeViewProps> = ({node, updateAttributes
                       md: '3',
                       lg: '4',
                     }}
-                    value={[
-                      paginate ? 'paginate' : '',
-                      showListView ? 'showListView' : '',
-                      showIdentifier ? 'showIdentifier' : '',
-                      showTitles ? 'showTitles' : '',
-                      showPlaces ? 'showPlaces' : '',
-                      showStates ? 'showStates' : '',
-                      showZipCodes ? 'showZipCodes' : '',
-                      showCreatedAt ? 'showCreatedAt' : '',
-                      showFilters ? 'showFilters' : '',
-                      showMaps ? 'showMaps' : '',
-                    ]}
+                    value={selectedDisplayOptions}
                     onValueChange={value => {
+                      const selectedValues = new Set(value);
                       handleUpdate({
-                        paginate: value.includes('paginate'),
-                        showListView: value.includes('showListView'),
-                        showTitles: value.includes('showTitles'),
-                        showPlaces: value.includes('showPlaces'),
-                        showStates: value.includes('showStates'),
-                        showZipCodes: value.includes('showZipCodes'),
-                        showCreatedAt: value.includes('showCreatedAt'),
-                        showIdentifier: value.includes('showIdentifier'),
-                        showFilters: value.includes('showFilters'),
-                        showMaps: value.includes('showMaps'),
+                        paginate: selectedValues.has(COMMENT_GALLERY_ATTRS.PAGINATE),
+                        showListView: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_LIST_VIEW),
+                        showTitles: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_TITLES),
+                        showPlaces: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_PLACES),
+                        showStates: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_STATES),
+                        showZipCodes: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_ZIP_CODES),
+                        showCreatedAt: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_CREATED_AT),
+                        showIdentifier: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_IDENTIFIER),
+                        showFilters: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_FILTERS),
+                        showMaps: selectedValues.has(COMMENT_GALLERY_ATTRS.SHOW_MAPS),
                       });
                     }}
                   >
-                    <CheckboxCards.Item value="paginate">Paginate Results</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showListView">Show List View</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showIdentifier">Show Identifier</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showTitles">Show Titles</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showPlaces">Show Places</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showStates">Show States</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showZipCodes">Show Zip Codes</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showCreatedAt">Show Created At</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showFilters">
-                      Show Filter Controls
-                    </CheckboxCards.Item>
-                    <CheckboxCards.Item value="showMaps">Show Map Links</CheckboxCards.Item>
+                    {COMMENT_GALLERY_DISPLAY_OPTIONS.map(option => (
+                      <CheckboxCards.Item key={option.key} value={option.key}>
+                        {option.label}
+                      </CheckboxCards.Item>
+                    ))}
                   </CheckboxCards.Root>
                 </Flex>
 
                 <Tabs.Root
-                  defaultValue={!!ids ? 'ids' : 'tags'}
+                  defaultValue={!!ids ? GALLERY_FILTER_TABS.IDS : GALLERY_FILTER_TABS.TAGS}
                   onValueChange={value =>
-                    handleUpdate({[value]: [], [value === 'ids' ? 'tags' : 'ids']: null})
+                    handleUpdate({
+                      [value]: [],
+                      [value === GALLERY_FILTER_TABS.IDS
+                        ? GALLERY_FILTER_TABS.TAGS
+                        : GALLERY_FILTER_TABS.IDS]: null,
+                    })
                   }
                 >
                   <Tabs.List>
-                    <Tabs.Trigger value="ids">IDs</Tabs.Trigger>
-                    <Tabs.Trigger value="tags">Tags</Tabs.Trigger>
+                    <Tabs.Trigger value={GALLERY_FILTER_TABS.IDS}>IDs</Tabs.Trigger>
+                    <Tabs.Trigger value={GALLERY_FILTER_TABS.TAGS}>Tags</Tabs.Trigger>
                   </Tabs.List>
-                  <Tabs.Content value="ids">
+                  <Tabs.Content value={GALLERY_FILTER_TABS.IDS}>
                     <CmsSettingsChips
                       entries={ids || []}
                       handleUpdate={handleUpdate}
-                      property="ids"
+                      property={GALLERY_FILTER_TABS.IDS}
                     />
                   </Tabs.Content>
-                  <Tabs.Content value="tags">
+                  <Tabs.Content value={GALLERY_FILTER_TABS.TAGS}>
                     <CmsSettingsChips
                       entries={tags || []}
                       handleUpdate={handleUpdate}
-                      property="tags"
+                      property={GALLERY_FILTER_TABS.TAGS}
                     />
                   </Tabs.Content>
                 </Tabs.Root>

--- a/app/src/app/components/Cms/RichTextEditor/extensions/CommentSubmissionForm/FormNode.ts
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/CommentSubmissionForm/FormNode.ts
@@ -2,6 +2,12 @@ import {Node, mergeAttributes} from '@tiptap/core';
 import {ReactNodeViewRenderer} from '@tiptap/react';
 import FormNodeView from './FormNodeView';
 import {getJsonHtmlRenderer, getStandardHtmlParser} from '../extensionUtils';
+import {
+  FORM_NODE_ATTRS,
+  getRichTextNodeSelector,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -28,11 +34,11 @@ export const FormNode = Node.create({
       renderHTML?: (attributes: Record<string, any>) => Record<string, any>;
     }[] = [
       {
-        name: 'mandatoryTags',
+        name: FORM_NODE_ATTRS.MANDATORY_TAGS,
         default: [],
       },
       {
-        name: 'allowListModules',
+        name: FORM_NODE_ATTRS.ALLOW_LIST_MODULES,
         default: [],
       },
     ];
@@ -51,13 +57,19 @@ export const FormNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[data-type="form-node"]',
+        tag: getRichTextNodeSelector(RICH_TEXT_NODE_TYPES.FORM),
       },
     ];
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['div', mergeAttributes(HTMLAttributes, {'data-type': 'form-node'}), 0];
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        [RICH_TEXT_DATA_ATTRIBUTES.TYPE]: RICH_TEXT_NODE_TYPES.FORM,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/app/src/app/components/Cms/RichTextEditor/extensions/MapCreateButtons/MapCreateButtonsNode.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/MapCreateButtons/MapCreateButtonsNode.tsx
@@ -2,6 +2,12 @@ import {Node, mergeAttributes} from '@tiptap/core';
 import {ReactNodeViewRenderer} from '@tiptap/react';
 import MapCreateButtonsNodeView from './MapCreateButtonsNodeView';
 import {getJsonHtmlRenderer, getStandardHtmlParser} from '../extensionUtils';
+import {
+  getRichTextNodeSelector,
+  MAP_CREATE_BUTTONS_NODE_ATTRS,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -28,11 +34,11 @@ export const MapCreateButtonsNode = Node.create({
       renderHTML?: (attributes: Record<string, any>) => Record<string, any>;
     }[] = [
       {
-        name: 'views',
+        name: MAP_CREATE_BUTTONS_NODE_ATTRS.VIEWS,
         default: [],
       },
       {
-        name: 'type',
+        name: MAP_CREATE_BUTTONS_NODE_ATTRS.TYPE,
         default: 'simple',
       },
     ];
@@ -53,13 +59,19 @@ export const MapCreateButtonsNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[data-type="map-create-buttons-node"]',
+        tag: getRichTextNodeSelector(RICH_TEXT_NODE_TYPES.MAP_CREATE_BUTTONS),
       },
     ];
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['div', mergeAttributes(HTMLAttributes, {'data-type': 'map-create-buttons-node'}), 0];
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        [RICH_TEXT_DATA_ATTRIBUTES.TYPE]: RICH_TEXT_NODE_TYPES.MAP_CREATE_BUTTONS,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/app/src/app/components/Cms/RichTextEditor/extensions/PlanGallery/PlanGalleryNode.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/PlanGallery/PlanGalleryNode.tsx
@@ -2,6 +2,12 @@ import {Node, mergeAttributes} from '@tiptap/core';
 import {ReactNodeViewRenderer} from '@tiptap/react';
 import PlanGalleryNodeView from './PlanGalleryNodeView';
 import {getJsonHtmlRenderer, getStandardHtmlParser} from '../extensionUtils';
+import {
+  getRichTextNodeSelector,
+  PLAN_GALLERY_ATTRS,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -28,51 +34,51 @@ export const PlanGalleryNode = Node.create({
       renderHTML?: (attributes: Record<string, any>) => Record<string, any>;
     }[] = [
       {
-        name: 'ids',
+        name: PLAN_GALLERY_ATTRS.IDS,
       },
       {
-        name: 'tags',
+        name: PLAN_GALLERY_ATTRS.TAGS,
       },
       {
-        name: 'title',
+        name: PLAN_GALLERY_ATTRS.TITLE,
       },
       {
-        name: 'description',
+        name: PLAN_GALLERY_ATTRS.DESCRIPTION,
       },
       {
-        name: 'paginate',
+        name: PLAN_GALLERY_ATTRS.PAGINATE,
         default: true,
       },
       {
-        name: 'showListView',
+        name: PLAN_GALLERY_ATTRS.SHOW_LIST_VIEW,
         default: true,
       },
       {
-        name: 'showThumbnails',
+        name: PLAN_GALLERY_ATTRS.SHOW_THUMBNAILS,
         default: true,
       },
       {
-        name: 'showTitles',
+        name: PLAN_GALLERY_ATTRS.SHOW_TITLES,
         default: true,
       },
       {
-        name: 'showDescriptions',
+        name: PLAN_GALLERY_ATTRS.SHOW_DESCRIPTIONS,
         default: true,
       },
       {
-        name: 'showUpdatedAt',
+        name: PLAN_GALLERY_ATTRS.SHOW_UPDATED_AT,
         default: true,
       },
       {
-        name: 'showTags',
+        name: PLAN_GALLERY_ATTRS.SHOW_TAGS,
         default: true,
       },
       {
-        name: 'showModule',
+        name: PLAN_GALLERY_ATTRS.SHOW_MODULE,
         default: true,
       },
       {
-        name: 'limit',
+        name: PLAN_GALLERY_ATTRS.LIMIT,
         default: 12,
       },
     ];
@@ -93,13 +99,19 @@ export const PlanGalleryNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[data-type="plan-gallery-node"]',
+        tag: getRichTextNodeSelector(RICH_TEXT_NODE_TYPES.PLAN_GALLERY),
       },
     ];
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['div', mergeAttributes(HTMLAttributes, {'data-type': 'plan-gallery-node'}), 0];
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        [RICH_TEXT_DATA_ATTRIBUTES.TYPE]: RICH_TEXT_NODE_TYPES.PLAN_GALLERY,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/app/src/app/components/Cms/RichTextEditor/extensions/PlanGallery/PlanGalleryNodeView.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/PlanGallery/PlanGalleryNodeView.tsx
@@ -19,23 +19,33 @@ import {PlanGallery, PlanGalleryProps} from './PlanGallery';
 import {GearIcon, TrashIcon} from '@radix-ui/react-icons';
 import {NoFocusBoundary} from '../NoFocusBoundary';
 import {CmsSettingsChips} from '../EditHelpers/CmsSettingsChips';
+import {
+  GALLERY_FILTER_TABS,
+  PLAN_GALLERY_ATTRS,
+  PLAN_GALLERY_DISPLAY_OPTIONS,
+  type PlanGalleryDisplayOptionKey,
+} from '@constants/cms/richText';
 
 const PlanGalleryNodeView: React.FC<NodeViewProps> = ({node, updateAttributes, deleteNode}) => {
   const parentRef = useRef<HTMLDivElement>(null);
   // Use a nested editor for the custom content
-  const ids: number[] | undefined = node.attrs.ids || undefined;
-  const tags: string[] | undefined = node.attrs.tags || undefined;
-  const title: string | undefined = node.attrs.title || undefined;
-  const description: string | undefined = node.attrs.description || undefined;
-  const paginate: string | undefined = node.attrs.paginate || undefined;
-  const limit: number | undefined = node.attrs.limit || undefined;
-  const showListView: boolean | undefined = node.attrs.showListView || undefined;
-  const showThumbnails: boolean | undefined = node.attrs.showThumbnails || undefined;
-  const showTitles: boolean | undefined = node.attrs.showTitles || undefined;
-  const showDescriptions: boolean | undefined = node.attrs.showDescriptions || undefined;
-  const showUpdatedAt: boolean | undefined = node.attrs.showUpdatedAt || undefined;
-  const showTags: boolean | undefined = node.attrs.showTags || undefined;
-  const showModule: boolean | undefined = node.attrs.showModule || undefined;
+  const ids: number[] | undefined = node.attrs[PLAN_GALLERY_ATTRS.IDS] || undefined;
+  const tags: string[] | undefined = node.attrs[PLAN_GALLERY_ATTRS.TAGS] || undefined;
+  const title: string | undefined = node.attrs[PLAN_GALLERY_ATTRS.TITLE] || undefined;
+  const description: string | undefined = node.attrs[PLAN_GALLERY_ATTRS.DESCRIPTION] || undefined;
+  const paginate: string | undefined = node.attrs[PLAN_GALLERY_ATTRS.PAGINATE] || undefined;
+  const limit: number | undefined = node.attrs[PLAN_GALLERY_ATTRS.LIMIT] || undefined;
+  const showListView: boolean | undefined =
+    node.attrs[PLAN_GALLERY_ATTRS.SHOW_LIST_VIEW] || undefined;
+  const showThumbnails: boolean | undefined =
+    node.attrs[PLAN_GALLERY_ATTRS.SHOW_THUMBNAILS] || undefined;
+  const showTitles: boolean | undefined = node.attrs[PLAN_GALLERY_ATTRS.SHOW_TITLES] || undefined;
+  const showDescriptions: boolean | undefined =
+    node.attrs[PLAN_GALLERY_ATTRS.SHOW_DESCRIPTIONS] || undefined;
+  const showUpdatedAt: boolean | undefined =
+    node.attrs[PLAN_GALLERY_ATTRS.SHOW_UPDATED_AT] || undefined;
+  const showTags: boolean | undefined = node.attrs[PLAN_GALLERY_ATTRS.SHOW_TAGS] || undefined;
+  const showModule: boolean | undefined = node.attrs[PLAN_GALLERY_ATTRS.SHOW_MODULE] || undefined;
 
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const handleUpdate = (updates: Partial<PlanGalleryProps>) => {
@@ -45,6 +55,21 @@ const PlanGalleryNodeView: React.FC<NodeViewProps> = ({node, updateAttributes, d
     };
     updateAttributes(newAttrs);
   };
+
+  const displayOptionState: Record<PlanGalleryDisplayOptionKey, boolean> = {
+    [PLAN_GALLERY_ATTRS.PAGINATE]: Boolean(paginate),
+    [PLAN_GALLERY_ATTRS.SHOW_LIST_VIEW]: Boolean(showListView),
+    [PLAN_GALLERY_ATTRS.SHOW_THUMBNAILS]: Boolean(showThumbnails),
+    [PLAN_GALLERY_ATTRS.SHOW_TITLES]: Boolean(showTitles),
+    [PLAN_GALLERY_ATTRS.SHOW_DESCRIPTIONS]: Boolean(showDescriptions),
+    [PLAN_GALLERY_ATTRS.SHOW_UPDATED_AT]: Boolean(showUpdatedAt),
+    [PLAN_GALLERY_ATTRS.SHOW_TAGS]: Boolean(showTags),
+    [PLAN_GALLERY_ATTRS.SHOW_MODULE]: Boolean(showModule),
+  };
+
+  const selectedDisplayOptions = PLAN_GALLERY_DISPLAY_OPTIONS.filter(option => {
+    return displayOptionState[option.key];
+  }).map(option => option.key);
 
   return (
     <NodeViewWrapper
@@ -105,64 +130,56 @@ const PlanGalleryNodeView: React.FC<NodeViewProps> = ({node, updateAttributes, d
                       md: '3',
                       lg: '4',
                     }}
-                    value={[
-                      paginate ? 'paginate' : '',
-                      showListView ? 'showListView' : '',
-                      showThumbnails ? 'showThumbnails' : '',
-                      showTitles ? 'showTitles' : '',
-                      showDescriptions ? 'showDescriptions' : '',
-                      showUpdatedAt ? 'showUpdatedAt' : '',
-                      showTags ? 'showTags' : '',
-                      showModule ? 'showModule' : '',
-                    ]}
+                    value={selectedDisplayOptions}
                     onValueChange={value => {
+                      const selectedValues = new Set(value);
                       handleUpdate({
-                        paginate: value.includes('paginate'),
-                        showListView: value.includes('showListView'),
-                        showThumbnails: value.includes('showThumbnails'),
-                        showTitles: value.includes('showTitles'),
-                        showDescriptions: value.includes('showDescriptions'),
-                        showUpdatedAt: value.includes('showUpdatedAt'),
-                        showTags: value.includes('showTags'),
-                        showModule: value.includes('showModule'),
+                        paginate: selectedValues.has(PLAN_GALLERY_ATTRS.PAGINATE),
+                        showListView: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_LIST_VIEW),
+                        showThumbnails: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_THUMBNAILS),
+                        showTitles: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_TITLES),
+                        showDescriptions: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_DESCRIPTIONS),
+                        showUpdatedAt: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_UPDATED_AT),
+                        showTags: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_TAGS),
+                        showModule: selectedValues.has(PLAN_GALLERY_ATTRS.SHOW_MODULE),
                       });
                     }}
                   >
-                    <CheckboxCards.Item value="paginate">Paginate Results</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showListView">Show List View</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showThumbnails">Show Thumbnails</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showTitles">Show Titles</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showDescriptions">
-                      Show Descriptions
-                    </CheckboxCards.Item>
-                    <CheckboxCards.Item value="showUpdatedAt">Show Updated At</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showTags">Show Tags</CheckboxCards.Item>
-                    <CheckboxCards.Item value="showModule">Show Module</CheckboxCards.Item>
+                    {PLAN_GALLERY_DISPLAY_OPTIONS.map(option => (
+                      <CheckboxCards.Item key={option.key} value={option.key}>
+                        {option.label}
+                      </CheckboxCards.Item>
+                    ))}
                   </CheckboxCards.Root>
                 </Flex>
 
                 <Tabs.Root
-                  defaultValue={!!ids ? 'ids' : 'tags'}
+                  defaultValue={!!ids ? GALLERY_FILTER_TABS.IDS : GALLERY_FILTER_TABS.TAGS}
                   onValueChange={value =>
-                    handleUpdate({[value]: [], [value === 'ids' ? 'tags' : 'ids']: null})
+                    handleUpdate({
+                      [value]: [],
+                      [value === GALLERY_FILTER_TABS.IDS
+                        ? GALLERY_FILTER_TABS.TAGS
+                        : GALLERY_FILTER_TABS.IDS]: null,
+                    })
                   }
                 >
                   <Tabs.List>
-                    <Tabs.Trigger value="ids">IDs</Tabs.Trigger>
-                    <Tabs.Trigger value="tags">Tags</Tabs.Trigger>
+                    <Tabs.Trigger value={GALLERY_FILTER_TABS.IDS}>IDs</Tabs.Trigger>
+                    <Tabs.Trigger value={GALLERY_FILTER_TABS.TAGS}>Tags</Tabs.Trigger>
                   </Tabs.List>
-                  <Tabs.Content value="ids">
+                  <Tabs.Content value={GALLERY_FILTER_TABS.IDS}>
                     <CmsSettingsChips
                       entries={ids || []}
                       handleUpdate={handleUpdate}
-                      property="ids"
+                      property={GALLERY_FILTER_TABS.IDS}
                     />
                   </Tabs.Content>
-                  <Tabs.Content value="tags">
+                  <Tabs.Content value={GALLERY_FILTER_TABS.TAGS}>
                     <CmsSettingsChips
                       entries={tags || []}
                       handleUpdate={handleUpdate}
-                      property="tags"
+                      property={GALLERY_FILTER_TABS.TAGS}
                     />
                   </Tabs.Content>
                 </Tabs.Root>

--- a/app/src/app/components/Cms/RichTextEditor/extensions/SectionHeader/SectionHeaderNode.ts
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/SectionHeader/SectionHeaderNode.ts
@@ -2,6 +2,11 @@ import {Node, mergeAttributes} from '@tiptap/core';
 import {ReactNodeViewRenderer} from '@tiptap/react';
 import {ContentHeader} from '@/app/components/Static/ContentHeader';
 import ContentHeaderNodeView from './SectionHeaderNodeView';
+import {
+  getRichTextNodeSelector,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -25,12 +30,14 @@ export const SectionHeaderNode = Node.create({
       title: {
         default: null,
         parseHTML: element => {
-          const content = element.getAttribute('data-title');
+          const content = element.getAttribute(RICH_TEXT_DATA_ATTRIBUTES.TITLE);
           return content ? JSON.parse(content) : null;
         },
         renderHTML: attributes => {
           return {
-            'data-title': attributes.title ? JSON.stringify(attributes.title) : '',
+            [RICH_TEXT_DATA_ATTRIBUTES.TITLE]: attributes.title
+              ? JSON.stringify(attributes.title)
+              : '',
           };
         },
       },
@@ -40,13 +47,19 @@ export const SectionHeaderNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[data-type="section-header-node"]',
+        tag: getRichTextNodeSelector(RICH_TEXT_NODE_TYPES.SECTION_HEADER),
       },
     ];
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['div', mergeAttributes(HTMLAttributes, {'data-type': 'section-header-node'}), 0];
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        [RICH_TEXT_DATA_ATTRIBUTES.TYPE]: RICH_TEXT_NODE_TYPES.SECTION_HEADER,
+      }),
+      0,
+    ];
   },
 
   addCommands() {

--- a/app/src/app/components/Forms/MapSelector.tsx
+++ b/app/src/app/components/Forms/MapSelector.tsx
@@ -6,6 +6,7 @@ import {getDocument} from '@/app/utils/api/apiHandlers/getDocument';
 import {DocumentObject} from '@/app/utils/api/apiHandlers/types';
 import {TILESET_URL} from '@/app/utils/api/constants';
 import {queryClient} from '@/app/utils/api/queryClient';
+import {DRAFT_STATUS} from '@/app/constants/map/draftStatus';
 import {
   Blockquote,
   Box,
@@ -101,7 +102,7 @@ const MapSelectorInner: React.FC<MapSelectorProps> = ({allowListModules}) => {
       throw new Error('Please use a link to a Districtr map.');
     } else if (
       response.mapInfo &&
-      response.mapInfo.map_metadata?.draft_status !== 'ready_to_share'
+      response.mapInfo.map_metadata?.draft_status !== DRAFT_STATUS.READY_TO_SHARE
     ) {
       throw new Error(
         'Please make sure your map is marked as "ready to share" in the map editor. You can update this in the "Save and share" menu or using the button next to the map title on the top of the map editor.'

--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -5,6 +5,7 @@ import {
   ZONE_LABEL_SOURCE_ID,
   ZONE_LABEL_LAYER_IDS,
 } from '@/app/constants/map/layerIds';
+import {TOTAL_COLUMNS} from '@/app/constants/demography';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
@@ -80,7 +81,7 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
       source={child ? SELECTION_POINTS_SOURCE_ID_CHILD : SELECTION_POINTS_SOURCE_ID}
       filter={populationFilter}
       layout={{
-        'text-field': ['get', 'total_pop_20'],
+        'text-field': ['get', TOTAL_COLUMNS.TOTPOP!],
         'text-font': ['Barlow Bold'],
         'text-size': [
           'interpolate',

--- a/app/src/app/components/Map/Tooltip/InpsectorTooltipConfig.tsx
+++ b/app/src/app/components/Map/Tooltip/InpsectorTooltipConfig.tsx
@@ -1,14 +1,5 @@
-import {KeyOfSummaryStatConfig} from '@utils/api/summaryStats';
-import {NumberFormats} from '@utils/numbers';
+import {COLUMN_SET_LABELS, TOTAL_COLUMNS} from '@/app/constants/demography';
 
-export const INSPECTOR_TITLE = {
-  VAP: 'Voting Age Population',
-  TOTPOP: 'Total Population',
-  VOTERHISTORY: 'Voter History',
-};
+export const INSPECTOR_TITLE = COLUMN_SET_LABELS;
 
-export const TOTAL_COLUMN: Record<KeyOfSummaryStatConfig, string | undefined> = {
-  VAP: 'total_vap_20',
-  TOTPOP: 'total_pop_20',
-  VOTERHISTORY: undefined,
-};
+export const TOTAL_COLUMN = TOTAL_COLUMNS;

--- a/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
+++ b/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
@@ -8,15 +8,16 @@ import {CONFIG_BY_COLUMN_SET} from '@store/demography/evaluationConfig';
 import {PARTISAN_SCALE} from '@store/demography/constants';
 import {INSPECTOR_TITLE, TOTAL_COLUMN} from '@components/Map/Tooltip/InpsectorTooltipConfig';
 import {previousHoverFeatures as hoverFeatures} from '@/app/utils/map/hoverFeatures';
+import {COLUMN_SETS} from '@/app/constants/demography';
 
 export const InspectorTooltip = () => {
   const activeColumns = useTooltipStore(state => state.activeColumns);
   const inspectorMode = useTooltipStore(state => state.inspectorMode);
   const inspectorFormat = useTooltipStore(state => state.inspectorFormat);
-  const usePercent = inspectorFormat === 'percent' || inspectorMode === 'VOTERHISTORY';
+  const usePercent = inspectorFormat === 'percent' || inspectorMode === COLUMN_SETS.VOTERHISTORY;
   const columnSuffix = usePercent ? '_pct' : '';
-  const standardFormat =
-    inspectorMode === 'VOTERHISTORY' ? 'partisan' : usePercent ? 'percent' : 'standard';
+  const standardFormat = 'standard';
+  inspectorMode === COLUMN_SETS.VOTERHISTORY ? 'partisan' : usePercent ? 'percent' : 'standard';
   const ids = hoverFeatures.map(f => f.id as string);
   const [inspectorData, setInspectorData] = useState<Record<string, number>>({});
   const config = CONFIG_BY_COLUMN_SET[inspectorMode].sort((a, b) => a.label.localeCompare(b.label));
@@ -28,7 +29,7 @@ export const InspectorTooltip = () => {
   useEffect(() => {
     if (ids.length > 0) {
       const _activeColumns =
-        inspectorMode === 'VOTERHISTORY'
+        inspectorMode === COLUMN_SETS.VOTERHISTORY
           ? [...activeColumns, ...activeColumns.map(colName => colName.replace('_lean', '_total'))]
           : activeColumns;
       const data = demographyCache.calculateSummaryStats(ids, _activeColumns);
@@ -72,12 +73,13 @@ export const InspectorTooltip = () => {
                   className="bg-gray-900 absolute h-full top-0 left-0"
                   style={{
                     width:
-                      inspectorMode === 'VOTERHISTORY'
+                      inspectorMode === COLUMN_SETS.VOTERHISTORY
                         ? '100%'
                         : `${(inspectorData[f.column + '_pct'] ?? 0) * 100}%`,
                     opacity: '.15',
                     backgroundColor:
-                      inspectorMode === 'VOTERHISTORY' && !isNaN(inspectorData[f.column + '_pct'])
+                      inspectorMode === COLUMN_SETS.VOTERHISTORY &&
+                      !isNaN(inspectorData[f.column + '_pct'])
                         ? PARTISAN_SCALE((inspectorData[f.column + '_pct'] + 1) / 2)
                         : undefined,
                   }}

--- a/app/src/app/components/RichTextRenderer/CustomRenderers/DomNodeRenderers.tsx
+++ b/app/src/app/components/RichTextRenderer/CustomRenderers/DomNodeRenderers.tsx
@@ -5,35 +5,63 @@ import {CommentSubmissionForm} from '../../Forms/CommentSubmissionForm';
 import {PlanGallery} from '../../Cms/RichTextEditor/extensions/PlanGallery/PlanGallery';
 import {MapCreateButtons} from '../../Cms/RichTextEditor/extensions/MapCreateButtons/MapCreateButtons';
 import {CommentGallery} from '../../Cms/RichTextEditor/extensions/CommentGallery/CommentGallery';
+import {
+  COMMENT_GALLERY_ATTRS,
+  FORM_NODE_ATTRS,
+  MAP_CREATE_BUTTONS_NODE_ATTRS,
+  PLAN_GALLERY_ATTRS,
+  RICH_TEXT_DATA_ATTRIBUTES,
+  RICH_TEXT_NODE_TYPES,
+} from '@constants/cms/richText';
+
+type AttributedDomNode = DOMNode & {attribs?: Record<string, string | undefined>};
+
+const parseJsonAttribute = (domNode: AttributedDomNode, attrName: string) =>
+  JSON.parse(domNode.attribs?.[attrName] ?? 'null');
 
 export const domNodeReplacers = (disabled: boolean) => {
   const domNodeReplaceFn = (domNode: DOMNode) => {
-    if (domNode.type === 'tag' && domNode.attribs?.['data-type']?.length) {
-      switch (domNode.attribs['data-type']) {
-        case 'boilerplate-node': {
-          const data = domNode.attribs['data-custom-content'];
-          const customContent = data ? JSON.parse(data) : null;
+    const attributedNode = domNode as AttributedDomNode;
+    const nodeType = attributedNode.attribs?.[RICH_TEXT_DATA_ATTRIBUTES.TYPE];
+    if (domNode.type === 'tag' && nodeType?.length) {
+      switch (nodeType) {
+        case RICH_TEXT_NODE_TYPES.BOILERPLATE: {
+          const customContent = parseJsonAttribute(
+            attributedNode,
+            RICH_TEXT_DATA_ATTRIBUTES.CUSTOM_CONTENT
+          );
           return <BoilerplateNodeRenderer customContent={customContent} />;
         }
-        case 'section-header-node': {
-          // Remove outer quotes
-          const title = domNode.attribs['data-title']?.slice(1, -1);
+        case RICH_TEXT_NODE_TYPES.SECTION_HEADER: {
+          const title = parseJsonAttribute(attributedNode, RICH_TEXT_DATA_ATTRIBUTES.TITLE);
           return <ContentHeader title={title} />;
         }
-        case 'plan-gallery-node': {
-          const ids = JSON.parse(domNode.attribs['ids'] ?? 'null');
-          const tags = JSON.parse(domNode.attribs['tags'] ?? 'null');
-          const title = JSON.parse(domNode.attribs['title'] ?? 'null');
-          const description = JSON.parse(domNode.attribs['description'] ?? 'null');
-          const limit = JSON.parse(domNode.attribs['limit'] ?? 'null');
-          const paginate = JSON.parse(domNode.attribs['paginate'] ?? 'null');
-          const showListView = JSON.parse(domNode.attribs['showListView'] ?? 'null');
-          const showThumbnails = JSON.parse(domNode.attribs['showThumbnails'] ?? 'null');
-          const showTitles = JSON.parse(domNode.attribs['showTitles'] ?? 'null');
-          const showDescriptions = JSON.parse(domNode.attribs['showDescriptions'] ?? 'null');
-          const showUpdatedAt = JSON.parse(domNode.attribs['showUpdatedAt'] ?? 'null');
-          const showTags = JSON.parse(domNode.attribs['showTags'] ?? 'null');
-          const showModule = JSON.parse(domNode.attribs['showModule'] ?? 'null');
+        case RICH_TEXT_NODE_TYPES.PLAN_GALLERY: {
+          const ids = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.IDS);
+          const tags = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.TAGS);
+          const title = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.TITLE);
+          const description = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.DESCRIPTION);
+          const limit = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.LIMIT);
+          const paginate = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.PAGINATE);
+          const showListView = parseJsonAttribute(
+            attributedNode,
+            PLAN_GALLERY_ATTRS.SHOW_LIST_VIEW
+          );
+          const showThumbnails = parseJsonAttribute(
+            attributedNode,
+            PLAN_GALLERY_ATTRS.SHOW_THUMBNAILS
+          );
+          const showTitles = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.SHOW_TITLES);
+          const showDescriptions = parseJsonAttribute(
+            attributedNode,
+            PLAN_GALLERY_ATTRS.SHOW_DESCRIPTIONS
+          );
+          const showUpdatedAt = parseJsonAttribute(
+            attributedNode,
+            PLAN_GALLERY_ATTRS.SHOW_UPDATED_AT
+          );
+          const showTags = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.SHOW_TAGS);
+          const showModule = parseJsonAttribute(attributedNode, PLAN_GALLERY_ATTRS.SHOW_MODULE);
           return (
             <PlanGallery
               ids={ids}
@@ -52,9 +80,12 @@ export const domNodeReplacers = (disabled: boolean) => {
             />
           );
         }
-        case 'form-node': {
-          const mandatoryTags = JSON.parse(domNode.attribs['mandatoryTags'] ?? 'null');
-          const allowListModules = JSON.parse(domNode.attribs['allowListModules'] ?? 'null');
+        case RICH_TEXT_NODE_TYPES.FORM: {
+          const mandatoryTags = parseJsonAttribute(attributedNode, FORM_NODE_ATTRS.MANDATORY_TAGS);
+          const allowListModules = parseJsonAttribute(
+            attributedNode,
+            FORM_NODE_ATTRS.ALLOW_LIST_MODULES
+          );
           return (
             <CommentSubmissionForm
               disabled={disabled}
@@ -63,30 +94,45 @@ export const domNodeReplacers = (disabled: boolean) => {
             />
           );
         }
-        case 'map-create-buttons-node': {
-          const views = JSON.parse(domNode.attribs['views'] ?? 'null');
-          const type = JSON.parse(domNode.attribs['type'] ?? 'null');
+        case RICH_TEXT_NODE_TYPES.MAP_CREATE_BUTTONS: {
+          const views = parseJsonAttribute(attributedNode, MAP_CREATE_BUTTONS_NODE_ATTRS.VIEWS);
+          const type = parseJsonAttribute(attributedNode, MAP_CREATE_BUTTONS_NODE_ATTRS.TYPE);
           return <MapCreateButtons views={views} type={type} />;
         }
-        case 'comment-gallery-node': {
-          const ids = JSON.parse(domNode.attribs['ids'] ?? 'null');
-          const tags = JSON.parse(domNode.attribs['tags'] ?? 'null');
-          const limit = JSON.parse(domNode.attribs['limit'] ?? 'null');
-          const place = JSON.parse(domNode.attribs['place'] ?? 'null');
-          const state = JSON.parse(domNode.attribs['state'] ?? 'null');
-          const zipCode = JSON.parse(domNode.attribs['zipCode'] ?? 'null');
-          const showIdentifier = JSON.parse(domNode.attribs['showIdentifier'] ?? 'null');
-          const showTitles = JSON.parse(domNode.attribs['showTitles'] ?? 'null');
-          const title = JSON.parse(domNode.attribs['title'] ?? 'null');
-          const description = JSON.parse(domNode.attribs['description'] ?? 'null');
-          const showPlaces = JSON.parse(domNode.attribs['showPlaces'] ?? 'null');
-          const showStates = JSON.parse(domNode.attribs['showStates'] ?? 'null');
-          const showZipCodes = JSON.parse(domNode.attribs['showZipCodes'] ?? 'null');
-          const showCreatedAt = JSON.parse(domNode.attribs['showCreatedAt'] ?? 'null');
-          const showListView = JSON.parse(domNode.attribs['showListView'] ?? 'null');
-          const paginate = JSON.parse(domNode.attribs['paginate'] ?? 'null');
-          const showFilters = JSON.parse(domNode.attribs['showFilters'] ?? 'null');
-          const showMaps = JSON.parse(domNode.attribs['showMaps'] ?? 'null');
+        case RICH_TEXT_NODE_TYPES.COMMENT_GALLERY: {
+          const ids = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.IDS);
+          const tags = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.TAGS);
+          const limit = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.LIMIT);
+          const place = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.PLACE);
+          const state = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.STATE);
+          const zipCode = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.ZIP_CODE);
+          const showIdentifier = parseJsonAttribute(
+            attributedNode,
+            COMMENT_GALLERY_ATTRS.SHOW_IDENTIFIER
+          );
+          const showTitles = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.SHOW_TITLES);
+          const title = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.TITLE);
+          const description = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.DESCRIPTION);
+          const showPlaces = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.SHOW_PLACES);
+          const showStates = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.SHOW_STATES);
+          const showZipCodes = parseJsonAttribute(
+            attributedNode,
+            COMMENT_GALLERY_ATTRS.SHOW_ZIP_CODES
+          );
+          const showCreatedAt = parseJsonAttribute(
+            attributedNode,
+            COMMENT_GALLERY_ATTRS.SHOW_CREATED_AT
+          );
+          const showListView = parseJsonAttribute(
+            attributedNode,
+            COMMENT_GALLERY_ATTRS.SHOW_LIST_VIEW
+          );
+          const paginate = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.PAGINATE);
+          const showFilters = parseJsonAttribute(
+            attributedNode,
+            COMMENT_GALLERY_ATTRS.SHOW_FILTERS
+          );
+          const showMaps = parseJsonAttribute(attributedNode, COMMENT_GALLERY_ATTRS.SHOW_MAPS);
           return (
             <CommentGallery
               ids={ids}

--- a/app/src/app/components/Toolbar/RecentMapsModal.tsx
+++ b/app/src/app/components/Toolbar/RecentMapsModal.tsx
@@ -1,5 +1,6 @@
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import React, {useEffect} from 'react';
 import {Cross2Icon} from '@radix-ui/react-icons';
 import {Button, Flex, Text, Table, Dialog, Box, Separator, Popover} from '@radix-ui/themes';
@@ -73,7 +74,7 @@ export const RecentMapsModal: React.FC<{
 
   useEffect(() => {
     if (!open) {
-      setActiveTool('pan');
+      setActiveTool(ACTIVE_TOOLS.PAN);
       // Ensure body pointer-events is restored when dialog closes
       document.body.style.pointerEvents = '';
     }

--- a/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
@@ -1,6 +1,7 @@
 import {Box, Flex, Button, Text} from '@radix-ui/themes';
 import {MaskOffIcon} from '@radix-ui/react-icons';
 import {useMapControlsStore} from '@store/mapControlsStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import {useFeatureFlagStore} from '@store/featureFlagStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
 import {BrushSizeSelector} from '@components/Toolbar/ToolControls/BrushSizeSelector';
@@ -26,7 +27,7 @@ export const BrushControls = () => {
           </Box>
         )}
       </Flex>
-      {activeTool === 'brush' ? (
+      {activeTool === ACTIVE_TOOLS.BRUSH ? (
         <div className="flex-grow-0 flex-row p-0 m-0">
           <ZonePicker />
         </div>

--- a/app/src/app/components/Toolbar/ToolControls/InspectorControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/InspectorControls.tsx
@@ -1,6 +1,7 @@
 import {useTooltipStore} from '@store/tooltipStore';
 import {CONFIG_BY_COLUMN_SET} from '@store/demography/evaluationConfig';
 import {demographyCache} from '@utils/demography/demographyCache';
+import {COLUMN_SETS, TOTAL_COLUMNS} from '@/app/constants/demography';
 import {useEffect} from 'react';
 import {Flex, Heading, Button, CheckboxCards, Text} from '@radix-ui/themes';
 import {BrushControls} from '@components/Toolbar/ToolControls/BrushControls';
@@ -32,11 +33,8 @@ export const InspectorControls = () => {
     .filter(f => demographyCache.availableColumns.includes(f.sourceCol ?? f.column))
     .sort((a, b) => a.label.localeCompare(b.label));
 
-  const totalColumn = {
-    VAP: ['total_vap_20'],
-    TOTPOP: ['total_pop_20'],
-    VOTERHISTORY: [],
-  }[inspectorMode];
+  const totalCol = TOTAL_COLUMNS[inspectorMode];
+  const totalColumn = totalCol ? [totalCol] : [];
 
   useEffect(() => {
     setActiveColumns([...totalColumn, ...columnList.map(f => f.column)]);
@@ -51,25 +49,25 @@ export const InspectorControls = () => {
       <Flex direction="row" className="" wrap="wrap" gap="1">
         <Button
           variant="soft"
-          color={inspectorMode === 'VAP' ? 'blue' : 'gray'}
+          color={inspectorMode === COLUMN_SETS.VAP ? 'blue' : 'gray'}
           radius="none"
-          onClick={() => setInspectorMode('VAP')}
+          onClick={() => setInspectorMode(COLUMN_SETS.VAP)}
         >
           Voting Age Population
         </Button>
         <Button
           variant="soft"
-          color={inspectorMode === 'TOTPOP' ? 'blue' : 'gray'}
+          color={inspectorMode === COLUMN_SETS.TOTPOP ? 'blue' : 'gray'}
           radius="none"
-          onClick={() => setInspectorMode('TOTPOP')}
+          onClick={() => setInspectorMode(COLUMN_SETS.TOTPOP)}
         >
           Total Population
         </Button>
         <Button
           variant="soft"
-          color={inspectorMode === 'VOTERHISTORY' ? 'blue' : 'gray'}
+          color={inspectorMode === COLUMN_SETS.VOTERHISTORY ? 'blue' : 'gray'}
           radius="none"
-          onClick={() => setInspectorMode('VOTERHISTORY')}
+          onClick={() => setInspectorMode(COLUMN_SETS.VOTERHISTORY)}
         >
           Voter History
         </Button>

--- a/app/src/app/components/Toolbar/ToolUtils.tsx
+++ b/app/src/app/components/Toolbar/ToolUtils.tsx
@@ -1,5 +1,5 @@
 import {IconButtonProps, IconProps} from '@radix-ui/themes';
-import {ActiveTool} from '@constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '@/app/constants/tools';
 import {useMapStore} from '@/app/store/mapStore';
 import {
   EraserIcon,
@@ -41,7 +41,7 @@ export const useActiveTools = () => {
   const config: ActiveToolConfig[] = [
     {
       hotKeyLabel: 'M',
-      mode: 'pan',
+      mode: ACTIVE_TOOLS.PAN,
       disabled: !mapDocument?.document_id,
       label: 'Move',
       icon: HandIcon,
@@ -51,7 +51,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'P',
-      mode: 'brush',
+      mode: ACTIVE_TOOLS.BRUSH,
       disabled: !mapDocument?.document_id || !isEditing,
       label: 'Paint',
       icon: Pencil2Icon,
@@ -61,7 +61,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'E',
-      mode: 'eraser',
+      mode: ACTIVE_TOOLS.ERASER,
       disabled: !mapDocument?.document_id || !isEditing,
       label: 'Erase',
       icon: EraserIcon,
@@ -71,7 +71,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: `${metaKey} + Z`,
-      mode: 'undo',
+      mode: ACTIVE_TOOLS.UNDO,
       disabled: pastStates.length === 0 || !isEditing,
       label: 'Undo',
       icon: ResetIcon,
@@ -85,7 +85,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: `${metaKey} + Shift + Z`,
-      mode: 'redo',
+      mode: ACTIVE_TOOLS.REDO,
       disabled: futureStates.length === 0 || !isEditing,
       label: 'Redo',
       icon: ResetIcon,
@@ -100,7 +100,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'B',
-      mode: 'shatter',
+      mode: ACTIVE_TOOLS.SHATTER,
       disabled: !mapDocument?.child_layer,
       label: 'Break',
       icon: ViewGridIcon,
@@ -110,7 +110,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'I',
-      mode: 'inspector',
+      mode: ACTIVE_TOOLS.INSPECTOR,
       label: 'Inspector',
       icon: MagnifyingGlassIcon,
       hotKeyAccessor: e => {

--- a/app/src/app/components/Toolbar/Toolbar.tsx
+++ b/app/src/app/components/Toolbar/Toolbar.tsx
@@ -4,7 +4,7 @@ import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {MoveIcon, PinRightIcon, RotateCounterClockwiseIcon} from '@radix-ui/react-icons';
 import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
-import {ActiveTool} from '@constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '@/app/constants/tools';
 import Draggable from 'react-draggable';
 import {ToolbarState, useToolbarStore} from '@/app/store/toolbarStore';
 import {ToolControls} from '@/app/components/Toolbar/ToolControls/ToolControls';
@@ -152,14 +152,14 @@ export const DraggableToolbar = () => {
       grid={[10, 10]}
       onStart={() => {
         previousActiveTool.current = activeTool;
-        setActiveTool('pan');
+        setActiveTool(ACTIVE_TOOLS.PAN);
       }}
       onDrag={(e, {x, y}) => {
         setXY(x, y);
       }}
       onStop={(e, {x, y}) => {
         setXY(x, y, true);
-        setActiveTool(previousActiveTool.current || 'pan');
+        setActiveTool(previousActiveTool.current || ACTIVE_TOOLS.PAN);
       }}
     >
       <div

--- a/app/src/app/components/Topbar/MapStatus.tsx
+++ b/app/src/app/components/Topbar/MapStatus.tsx
@@ -2,6 +2,11 @@
 import {Text, Flex, IconButton, Box, Tooltip, Popover, SegmentedControl} from '@radix-ui/themes';
 import {useState} from 'react';
 import {DocumentMetadata, DocumentObject, DraftStatus} from '@/app/utils/api/apiHandlers/types';
+import {
+  DEFAULT_DRAFT_STATUS,
+  DRAFT_STATUS_LABELS,
+  DRAFT_STATUS_ORDER,
+} from '@/app/constants/map/draftStatus';
 import {InProgressIcon, ScratchWorkIcon, ReadyIcon} from './Icons';
 
 const statusIcons: Record<DraftStatus, React.FC> = {
@@ -10,22 +15,14 @@ const statusIcons: Record<DraftStatus, React.FC> = {
   ready_to_share: ReadyIcon,
 };
 
-const statusText: Record<DraftStatus, string> = {
-  scratch: 'Scratch Work',
-  in_progress: 'In Progress',
-  ready_to_share: 'Ready to Share',
-};
-
-const iconOrder: DraftStatus[] = ['scratch', 'in_progress', 'ready_to_share'];
-
 export const MapStatus: React.FC<{
   mapDocument: DocumentObject | null;
   mapMetadata: DocumentMetadata | null;
   handleMetadataChange: (updates: Partial<DocumentMetadata>) => Promise<void>;
 }> = ({mapDocument, mapMetadata, handleMetadataChange}) => {
-  const draftStatus = mapMetadata?.draft_status ?? 'scratch';
+  const draftStatus = mapMetadata?.draft_status ?? DEFAULT_DRAFT_STATUS;
   const Icon = statusIcons[draftStatus] ?? ScratchWorkIcon;
-  const StatusText = statusText[draftStatus] ?? 'Scratch Work';
+  const statusLabel = DRAFT_STATUS_LABELS[draftStatus] ?? DRAFT_STATUS_LABELS[DEFAULT_DRAFT_STATUS];
   const editing = mapDocument?.access === 'edit';
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -42,7 +39,7 @@ export const MapStatus: React.FC<{
     <Popover.Root open={modalOpen} onOpenChange={setModalOpen}>
       <Popover.Trigger>
         <Box>
-          <Tooltip content={StatusText}>
+          <Tooltip content={statusLabel}>
             <IconButton variant="ghost" color="gray" disabled={!editing} className="cursor-pointer">
               <Icon />
             </IconButton>
@@ -64,11 +61,11 @@ export const MapStatusButtons: React.FC<{
 }> = ({draftStatus, onChange}) => {
   return (
     <SegmentedControl.Root value={draftStatus as string} onValueChange={onChange} size="2">
-      {iconOrder.map(status => (
+      {DRAFT_STATUS_ORDER.map(status => (
         <SegmentedControl.Item key={status} value={status}>
           <Flex direction="row" gap="2" align="center" justify="start">
             {statusIcons[status]({})}
-            <Text>{statusText[status]}</Text>
+            <Text>{DRAFT_STATUS_LABELS[status]}</Text>
           </Flex>
         </SegmentedControl.Item>
       ))}

--- a/app/src/app/components/Topbar/MapTitleDisplay.tsx
+++ b/app/src/app/components/Topbar/MapTitleDisplay.tsx
@@ -18,6 +18,11 @@ import {
   DocumentObject,
   type DraftStatus,
 } from '@/app/utils/api/apiHandlers/types';
+import {
+  DEFAULT_DRAFT_STATUS,
+  DRAFT_STATUS_LABELS,
+  DRAFT_STATUS_ORDER,
+} from '@/app/constants/map/draftStatus';
 import {Cross2Icon, Pencil1Icon} from '@radix-ui/react-icons';
 import {MapContextModuleAndUnits} from './MapContextModuleAndUnits';
 import {InProgressIcon, ReadyIcon, ScratchWorkIcon} from './Icons';
@@ -29,14 +34,6 @@ const statusIcons: Record<DraftStatus, React.FC> = {
   ready_to_share: ReadyIcon,
 };
 
-const statusText: Record<DraftStatus, string> = {
-  scratch: 'Scratch Work',
-  in_progress: 'In Progress',
-  ready_to_share: 'Ready to Share',
-};
-
-const iconOrder: DraftStatus[] = ['scratch', 'in_progress', 'ready_to_share'];
-
 export const MapTitleDisplay: React.FC<{
   mapMetadata: DocumentMetadata | null;
   mapDocument: DocumentObject | null;
@@ -45,7 +42,7 @@ export const MapTitleDisplay: React.FC<{
   const [mapTitleInner, setMapTitleInner] = useState<string>('');
   const [hovered, setHovered] = useState(false);
   const [mapDescriptionInner, setMapDescriptionInner] = useState<string>('');
-  const [mapStatusInner, setMapStatusInner] = useState<DraftStatus>('scratch');
+  const [mapStatusInner, setMapStatusInner] = useState<DraftStatus>(DEFAULT_DRAFT_STATUS);
   const [open, setOpen] = useState(false);
 
   const _mapName = mapMetadata?.name ?? mapDocument?.map_metadata?.name ?? '';
@@ -55,7 +52,7 @@ export const MapTitleDisplay: React.FC<{
   const mapName = isTruncated ? `${_mapName.slice(0, MAX_TITLE_LENGTH)}...` : _mapName;
   const editing = mapDocument?.document_id !== 'anonymous';
 
-  const draftStatus = mapMetadata?.draft_status ?? 'scratch';
+  const draftStatus = mapMetadata?.draft_status ?? DEFAULT_DRAFT_STATUS;
   const DraftStatusIcon = statusIcons[draftStatus] ?? ScratchWorkIcon;
 
   useEffect(() => {
@@ -181,7 +178,7 @@ export const MapTitleDisplay: React.FC<{
                 className="w-full h-full mb-4"
                 style={{width: '100%', maxWidth: '100%'}}
               >
-                {iconOrder.map(status => (
+                {DRAFT_STATUS_ORDER.map(status => (
                   <SegmentedControl.Item key={status} value={status}>
                     <Flex
                       direction="column"
@@ -191,7 +188,7 @@ export const MapTitleDisplay: React.FC<{
                       className="py-1"
                     >
                       {statusIcons[status]({})}
-                      <Text>{statusText[status]}</Text>
+                      <Text>{DRAFT_STATUS_LABELS[status]}</Text>
                     </Flex>
                   </SegmentedControl.Item>
                 ))}

--- a/app/src/app/components/sidebar/DataPanelUtils.tsx
+++ b/app/src/app/components/sidebar/DataPanelUtils.tsx
@@ -1,5 +1,7 @@
 import PopulationPanel from '@components/sidebar/PopulationPanel';
 import {MapControlsStore} from '@/app/store/mapControlsStore';
+import {COLUMN_SETS} from '@/app/constants/demography';
+import {SIDEBAR_PANELS} from '@/app/constants/sidebar';
 import {MapValidation} from './MapValidation/MapValidation';
 import {SummaryPanel} from './SummaryPanel';
 import OverlaysPanel from './OverlaysPanel';
@@ -17,29 +19,37 @@ export interface DataPanelsProps {
 
 export const defaultPanels: DataPanelSpec[] = [
   {
-    title: 'population',
+    title: SIDEBAR_PANELS.POPULATION,
     label: 'Districts',
     content: <PopulationPanel />,
   },
   {
-    title: 'demography',
+    title: SIDEBAR_PANELS.DEMOGRAPHY,
     label: 'Demographics',
-    content: <SummaryPanel defaultColumnSet="VAP" displayedColumnSets={['VAP', 'TOTPOP']} />,
-  },
-  {
-    title: 'election',
-    label: 'Elections',
     content: (
-      <SummaryPanel defaultColumnSet="VOTERHISTORY" displayedColumnSets={['VOTERHISTORY']} />
+      <SummaryPanel
+        defaultColumnSet={COLUMN_SETS.VAP}
+        displayedColumnSets={[COLUMN_SETS.VAP, COLUMN_SETS.TOTPOP]}
+      />
     ),
   },
   {
-    title: 'mapValidation',
+    title: SIDEBAR_PANELS.ELECTION,
+    label: 'Elections',
+    content: (
+      <SummaryPanel
+        defaultColumnSet={COLUMN_SETS.VOTERHISTORY}
+        displayedColumnSets={[COLUMN_SETS.VOTERHISTORY]}
+      />
+    ),
+  },
+  {
+    title: SIDEBAR_PANELS.MAP_VALIDATION,
     label: 'Map validation',
     content: <MapValidation />,
   },
   {
-    title: 'overlays',
+    title: SIDEBAR_PANELS.OVERLAYS,
     label: 'Overlays',
     content: <OverlaysPanel />,
   },

--- a/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
+++ b/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
@@ -20,6 +20,7 @@ import {AllEvaluationConfigs, SummaryStatConfig} from '@/app/utils/api/summarySt
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {
   EvalModes,
+  EVAL_MODES,
   modeButtonConfig,
   numberFormats,
   summaryStatLabels,
@@ -27,6 +28,7 @@ import {
 import {PARTISAN_SCALE} from '@/app/store/demography/constants';
 import {GearIcon} from '@radix-ui/react-icons';
 import {useColorScheme} from '@/app/hooks/useColorScheme';
+import {COLUMN_SETS} from '@/app/constants/demography';
 
 type EvaluationProps = {
   summaryType: keyof SummaryStatConfig;
@@ -35,7 +37,7 @@ type EvaluationProps = {
   columnConfig: AllEvaluationConfigs;
 };
 const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
-  const [evalMode, setEvalMode] = useState<EvalModes>('share');
+  const [evalMode, setEvalMode] = useState<EvalModes>(EVAL_MODES.SHARE);
   const [colorBg, setColorBg] = useState<boolean>(true);
   const [showUnassigned, setShowUnassigned] = useState<boolean>(true);
   const {zoneStats, demoIsLoaded, zoneData} = useSummaryStats(showUnassigned);
@@ -46,7 +48,8 @@ const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
   const showModeButtons = Boolean(
     summaryStatConfig?.supportedModes?.length && summaryStatConfig?.supportedModes?.length > 1
   );
-  const numberFormat = numberFormats[summaryType === 'VOTERHISTORY' ? 'partisan' : evalMode];
+  const numberFormat =
+    numberFormats[summaryType === COLUMN_SETS.VOTERHISTORY ? 'partisan' : evalMode];
 
   useEffect(() => {
     if (
@@ -175,7 +178,7 @@ const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
                               : value;
                         let backgroundColor: string | undefined;
                         if (value === undefined || colorValue === undefined) {
-                        } else if (colorBg && summaryType === 'VOTERHISTORY') {
+                        } else if (colorBg && summaryType === COLUMN_SETS.VOTERHISTORY) {
                           backgroundColor = PARTISAN_SCALE(((value as number) + 1) / 2);
                         } else if (colorBg && !isUnassigned) {
                           backgroundColor = interpolateGreys(colorValue as number)

--- a/app/src/app/components/sidebar/ToolbarInSidebar.tsx
+++ b/app/src/app/components/sidebar/ToolbarInSidebar.tsx
@@ -5,6 +5,7 @@ import {PinLeftIcon} from '@radix-ui/react-icons';
 import {useToolbarStore} from '@/app/store/toolbarStore';
 import {Toolbar} from '../Toolbar/Toolbar';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 
 export const ToolbarInSidebar = () => {
   const toolbarLocation = useToolbarStore(store => store.toolbarLocation);
@@ -15,7 +16,7 @@ export const ToolbarInSidebar = () => {
 
   return (
     <Box
-      className={`my-1 flex-none ${activeTool !== 'pan' && 'border-b-[1px] border-gray-300'} overflow-x-auto overflow-y-hidden`}
+      className={`my-1 flex-none ${activeTool !== ACTIVE_TOOLS.PAN && 'border-b-[1px] border-gray-300'} overflow-x-auto overflow-y-hidden`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/app/src/app/constants/cms/richText.ts
+++ b/app/src/app/constants/cms/richText.ts
@@ -1,0 +1,99 @@
+export const RICH_TEXT_DATA_ATTRIBUTES = {
+  TYPE: 'data-type',
+  CUSTOM_CONTENT: 'data-custom-content',
+  TITLE: 'data-title',
+} as const;
+
+export const RICH_TEXT_NODE_TYPES = {
+  BOILERPLATE: 'boilerplate-node',
+  SECTION_HEADER: 'section-header-node',
+  PLAN_GALLERY: 'plan-gallery-node',
+  FORM: 'form-node',
+  MAP_CREATE_BUTTONS: 'map-create-buttons-node',
+  COMMENT_GALLERY: 'comment-gallery-node',
+} as const;
+
+export type RichTextNodeType =
+  (typeof RICH_TEXT_NODE_TYPES)[keyof typeof RICH_TEXT_NODE_TYPES];
+
+export const getRichTextNodeSelector = (nodeType: RichTextNodeType) =>
+  `div[${RICH_TEXT_DATA_ATTRIBUTES.TYPE}="${nodeType}"]`;
+
+export const GALLERY_FILTER_TABS = {
+  IDS: 'ids',
+  TAGS: 'tags',
+} as const;
+
+export const COMMON_GALLERY_ATTRS = {
+  IDS: GALLERY_FILTER_TABS.IDS,
+  TAGS: GALLERY_FILTER_TABS.TAGS,
+  TITLE: 'title',
+  DESCRIPTION: 'description',
+  LIMIT: 'limit',
+  PAGINATE: 'paginate',
+  SHOW_LIST_VIEW: 'showListView',
+} as const;
+
+export const PLAN_GALLERY_ATTRS = {
+  ...COMMON_GALLERY_ATTRS,
+  SHOW_THUMBNAILS: 'showThumbnails',
+  SHOW_TITLES: 'showTitles',
+  SHOW_DESCRIPTIONS: 'showDescriptions',
+  SHOW_UPDATED_AT: 'showUpdatedAt',
+  SHOW_TAGS: 'showTags',
+  SHOW_MODULE: 'showModule',
+} as const;
+
+export const PLAN_GALLERY_DISPLAY_OPTIONS = [
+  {key: PLAN_GALLERY_ATTRS.PAGINATE, label: 'Paginate Results'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_LIST_VIEW, label: 'Show List View'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_THUMBNAILS, label: 'Show Thumbnails'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_TITLES, label: 'Show Titles'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_DESCRIPTIONS, label: 'Show Descriptions'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_UPDATED_AT, label: 'Show Updated At'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_TAGS, label: 'Show Tags'},
+  {key: PLAN_GALLERY_ATTRS.SHOW_MODULE, label: 'Show Module'},
+] as const;
+
+export type PlanGalleryDisplayOptionKey = (typeof PLAN_GALLERY_DISPLAY_OPTIONS)[number]['key'];
+
+export const COMMENT_GALLERY_ATTRS = {
+  ...COMMON_GALLERY_ATTRS,
+  PLACE: 'place',
+  STATE: 'state',
+  ZIP_CODE: 'zipCode',
+  SHOW_IDENTIFIER: 'showIdentifier',
+  SHOW_TITLES: 'showTitles',
+  SHOW_PLACES: 'showPlaces',
+  SHOW_STATES: 'showStates',
+  SHOW_ZIP_CODES: 'showZipCodes',
+  SHOW_CREATED_AT: 'showCreatedAt',
+  SHOW_FILTERS: 'showFilters',
+  SHOW_MAPS: 'showMaps',
+} as const;
+
+export const COMMENT_GALLERY_DISPLAY_OPTIONS = [
+  {key: COMMENT_GALLERY_ATTRS.PAGINATE, label: 'Paginate Results'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_LIST_VIEW, label: 'Show List View'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_IDENTIFIER, label: 'Show Identifier'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_TITLES, label: 'Show Titles'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_PLACES, label: 'Show Places'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_STATES, label: 'Show States'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_ZIP_CODES, label: 'Show Zip Codes'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_CREATED_AT, label: 'Show Created At'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_FILTERS, label: 'Show Filter Controls'},
+  {key: COMMENT_GALLERY_ATTRS.SHOW_MAPS, label: 'Show Map Links'},
+] as const;
+
+export type CommentGalleryDisplayOptionKey =
+  (typeof COMMENT_GALLERY_DISPLAY_OPTIONS)[number]['key'];
+
+export const FORM_NODE_ATTRS = {
+  MANDATORY_TAGS: 'mandatoryTags',
+  ALLOW_LIST_MODULES: 'allowListModules',
+} as const;
+
+export const MAP_CREATE_BUTTONS_NODE_ATTRS = {
+  VIEWS: 'views',
+  TYPE: 'type',
+} as const;

--- a/app/src/app/constants/cms/richText.ts
+++ b/app/src/app/constants/cms/richText.ts
@@ -13,8 +13,7 @@ export const RICH_TEXT_NODE_TYPES = {
   COMMENT_GALLERY: 'comment-gallery-node',
 } as const;
 
-export type RichTextNodeType =
-  (typeof RICH_TEXT_NODE_TYPES)[keyof typeof RICH_TEXT_NODE_TYPES];
+export type RichTextNodeType = (typeof RICH_TEXT_NODE_TYPES)[keyof typeof RICH_TEXT_NODE_TYPES];
 
 export const getRichTextNodeSelector = (nodeType: RichTextNodeType) =>
   `div[${RICH_TEXT_DATA_ATTRIBUTES.TYPE}="${nodeType}"]`;

--- a/app/src/app/constants/demography.ts
+++ b/app/src/app/constants/demography.ts
@@ -1,0 +1,29 @@
+import {KeyOfSummaryStatConfig, summaryStatsConfig} from '@utils/api/summaryStats';
+
+/**
+ * Column set key constants, matching the keys in summaryStatsConfig.
+ */
+export const COLUMN_SETS = {
+  TOTPOP: 'TOTPOP',
+  VAP: 'VAP',
+  VOTERHISTORY: 'VOTERHISTORY',
+} as const satisfies Record<string, KeyOfSummaryStatConfig>;
+
+/**
+ * The total/denominator column for each column set.
+ * Derived from summaryStatsConfig sumColumn where available.
+ */
+export const TOTAL_COLUMNS: Record<KeyOfSummaryStatConfig, string | undefined> = {
+  [COLUMN_SETS.TOTPOP]: summaryStatsConfig.TOTPOP.sumColumn,
+  [COLUMN_SETS.VAP]: summaryStatsConfig.VAP.sumColumn,
+  [COLUMN_SETS.VOTERHISTORY]: undefined,
+};
+
+/**
+ * Human-readable labels for each column set.
+ */
+export const COLUMN_SET_LABELS: Record<KeyOfSummaryStatConfig, string> = {
+  [COLUMN_SETS.VAP]: 'Voting Age Population',
+  [COLUMN_SETS.TOTPOP]: 'Total Population',
+  [COLUMN_SETS.VOTERHISTORY]: 'Voter History',
+};

--- a/app/src/app/constants/map/draftStatus.ts
+++ b/app/src/app/constants/map/draftStatus.ts
@@ -1,0 +1,27 @@
+import {DraftStatus} from '@/app/utils/api/apiHandlers/types';
+
+export const DRAFT_STATUS = {
+  SCRATCH: 'scratch',
+  IN_PROGRESS: 'in_progress',
+  READY_TO_SHARE: 'ready_to_share',
+} as const satisfies Record<string, DraftStatus>;
+
+export const DEFAULT_DRAFT_STATUS: DraftStatus = DRAFT_STATUS.SCRATCH;
+
+export const DRAFT_STATUS_ORDER: DraftStatus[] = [
+  DRAFT_STATUS.SCRATCH,
+  DRAFT_STATUS.IN_PROGRESS,
+  DRAFT_STATUS.READY_TO_SHARE,
+];
+
+export const DRAFT_STATUS_LABELS: Record<DraftStatus, string> = {
+  [DRAFT_STATUS.SCRATCH]: 'Scratch Work',
+  [DRAFT_STATUS.IN_PROGRESS]: 'In Progress',
+  [DRAFT_STATUS.READY_TO_SHARE]: 'Ready to Share',
+};
+
+export const DRAFT_STATUS_OG_COLORS: Record<DraftStatus, string> = {
+  [DRAFT_STATUS.SCRATCH]: 'orange',
+  [DRAFT_STATUS.IN_PROGRESS]: 'blue',
+  [DRAFT_STATUS.READY_TO_SHARE]: 'green',
+};

--- a/app/src/app/constants/sidebar.ts
+++ b/app/src/app/constants/sidebar.ts
@@ -1,0 +1,10 @@
+export const SIDEBAR_PANELS = {
+  LAYERS: 'layers',
+  POPULATION: 'population',
+  DEMOGRAPHY: 'demography',
+  ELECTION: 'election',
+  MAP_VALIDATION: 'mapValidation',
+  OVERLAYS: 'overlays',
+} as const;
+
+export type SidebarPanel = (typeof SIDEBAR_PANELS)[keyof typeof SIDEBAR_PANELS];

--- a/app/src/app/constants/tools.ts
+++ b/app/src/app/constants/tools.ts
@@ -1,0 +1,11 @@
+export const ACTIVE_TOOLS = {
+  PAN: 'pan',
+  BRUSH: 'brush',
+  ERASER: 'eraser',
+  SHATTER: 'shatter',
+  UNDO: 'undo',
+  REDO: 'redo',
+  INSPECTOR: 'inspector',
+} as const;
+
+export type ActiveTool = (typeof ACTIVE_TOOLS)[keyof typeof ACTIVE_TOOLS];

--- a/app/src/app/constants/types.ts
+++ b/app/src/app/constants/types.ts
@@ -1,4 +1,5 @@
 import type {MapOptions, MapLibreEvent, MapGeoJSONFeature} from 'maplibre-gl';
+export {type ActiveTool} from './tools';
 
 export type Zone = number;
 export type NullableZone = Zone | null;
@@ -8,8 +9,6 @@ export type GEOID = string;
 export type GDBPath = string;
 
 export type ZoneDict = Map<GEOID, Zone>;
-
-export type ActiveTool = 'pan' | 'brush' | 'eraser' | 'shatter' | 'undo' | 'redo' | 'inspector'; // others?
 
 export type SpatialUnit = 'county' | 'tract' | 'block' | 'block_group' | 'voting_district'; // others?
 

--- a/app/src/app/hooks/usePointData.tsx
+++ b/app/src/app/hooks/usePointData.tsx
@@ -4,6 +4,7 @@ import {useAssignmentsStore} from '../store/assignmentsStore';
 import {getPointSelectionData} from '../utils/api/apiHandlers/getPointSelectionData';
 import {EMPTY_FT_COLLECTION} from '../constants/map/layerStyle';
 import {BLOCK_SOURCE_ID} from '../constants/map/layerIds';
+import {TOTAL_COLUMNS} from '../constants/demography';
 import {useQuery} from '@tanstack/react-query';
 import GeometryWorker from '../utils/GeometryWorker';
 
@@ -30,7 +31,7 @@ const updateData = async (
 
   const result = await getPointSelectionData({
     layer,
-    columns: ['path', 'x', 'y', 'total_pop_20'],
+    columns: ['path', 'x', 'y', TOTAL_COLUMNS.TOTPOP!],
     filterIds: isChild ? exposedChildIds : undefined,
     source: BLOCK_SOURCE_ID,
   });

--- a/app/src/app/store/demography/constants.ts
+++ b/app/src/app/store/demography/constants.ts
@@ -8,6 +8,7 @@ import {
 } from '@utils/api/summaryStats';
 import {scaleLinear} from '@visx/scale';
 import {AnyD3Scale} from './types';
+import {COLUMN_SETS} from '@/app/constants/demography';
 
 export const DEFAULT_COLOR_SCHEME = chromatic.schemeBlues;
 export const DEFAULT_COLOR_SCHEME_GRAY = chromatic.schemeGreys;
@@ -19,9 +20,9 @@ export const PARTISAN_SCALE = scaleLinear()
 // type up some abstractions / api layer stuff
 // tabular configuration
 export const choroplethMapVariables: {
-  TOTPOP: MapColumnConfiguration<SummaryStatConfig['TOTPOP']>;
-  VAP: MapColumnConfiguration<SummaryStatConfig['VAP']>;
-  VOTERHISTORY: MapColumnConfiguration<SummaryStatConfig['VOTERHISTORY']>;
+  TOTPOP: MapColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.TOTPOP]>;
+  VAP: MapColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.VAP]>;
+  VOTERHISTORY: MapColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.VOTERHISTORY]>;
 } = {
   TOTPOP: [
     {

--- a/app/src/app/store/demography/evaluationConfig.ts
+++ b/app/src/app/store/demography/evaluationConfig.ts
@@ -4,10 +4,20 @@ import {
   SummaryStatConfig,
   summaryStatsConfig,
 } from '@/app/utils/api/summaryStats';
+import {COLUMN_SET_LABELS, COLUMN_SETS} from '@/app/constants/demography';
 
-export type EvalModes = 'share' | 'count' | 'totpop' | 'partisan';
+export const EVAL_MODES = {
+  SHARE: 'share',
+  COUNT: 'count',
+  TOTPOP: 'totpop',
+  PARTISAN: 'partisan',
+} as const satisfies Record<string, string>;
 
-export const TOTPOPColumnConfig: EvalColumnConfiguration<SummaryStatConfig['TOTPOP']> = [
+export type EvalModes = (typeof EVAL_MODES)[keyof typeof EVAL_MODES];
+
+export const TOTPOPColumnConfig: EvalColumnConfiguration<
+  SummaryStatConfig[typeof COLUMN_SETS.TOTPOP]
+> = [
   {
     label: 'Black',
     column: 'bpop_20',
@@ -34,7 +44,7 @@ export const TOTPOPColumnConfig: EvalColumnConfiguration<SummaryStatConfig['TOTP
   },
 ];
 
-export const VAPColumnConfig: EvalColumnConfiguration<SummaryStatConfig['VAP']> = [
+export const VAPColumnConfig: EvalColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.VAP]> = [
   {column: 'bvap_20', label: 'Black'},
   {column: 'hvap_20', label: 'Hispanic'},
   {column: 'amin_vap_20', label: 'AMIN'},
@@ -99,18 +109,18 @@ export const summaryStatLabels: Array<{
   supportedModes: EvalModes[];
 }> = [
   {
-    value: 'VAP',
-    label: 'Voting age population',
-    supportedModes: ['share', 'count'],
+    value: COLUMN_SETS.VAP,
+    label: COLUMN_SET_LABELS[COLUMN_SETS.VAP],
+    supportedModes: [EVAL_MODES.SHARE, EVAL_MODES.COUNT],
   },
   {
-    value: 'TOTPOP',
-    label: 'Total population',
-    supportedModes: ['share', 'count'],
+    value: COLUMN_SETS.TOTPOP,
+    label: COLUMN_SET_LABELS[COLUMN_SETS.TOTPOP],
+    supportedModes: [EVAL_MODES.SHARE, EVAL_MODES.COUNT],
   },
   {
-    value: 'VOTERHISTORY',
-    label: 'Voter history',
-    supportedModes: ['share'],
+    value: COLUMN_SETS.VOTERHISTORY,
+    label: COLUMN_SET_LABELS[COLUMN_SETS.VOTERHISTORY],
+    supportedModes: [EVAL_MODES.SHARE],
   },
 ];

--- a/app/src/app/store/mapControlsStore.tsx
+++ b/app/src/app/store/mapControlsStore.tsx
@@ -3,20 +3,14 @@ import {create} from 'zustand';
 import {subscribeWithSelector} from 'zustand/middleware';
 import type {MapOptions} from 'maplibre-gl';
 import {FALLBACK_NUM_DISTRICTS, OVERLAY_OPACITY} from '../constants/map/mapDefaults';
-import {ActiveTool, NullableZone, SpatialUnit, Zone} from '../constants/types';
+import {NullableZone, SpatialUnit, Zone} from '../constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '../constants/tools';
+import {SIDEBAR_PANELS, type SidebarPanel} from '../constants/sidebar';
 import {DistrictrMapOptions} from './types';
 import {useAssignmentsStore} from './assignmentsStore';
 import {useMapStore} from './mapStore';
 import {PaintEventHandler} from '@utils/map/types';
 import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
-
-type SidebarPanel =
-  | 'layers'
-  | 'population'
-  | 'demography'
-  | 'election'
-  | 'mapValidation'
-  | 'overlays';
 
 export interface MapControlsStore {
   selectedZone: Zone;
@@ -85,7 +79,7 @@ export const useMapControlsStore = create<MapControlsStore>()(
     },
     isEditing: false,
     setIsEditing: isEditing => set({isEditing}),
-    activeTool: 'pan',
+    activeTool: ACTIVE_TOOLS.PAN,
     setActiveTool: tool => {
       const canEdit = useMapStore.getState().mapStatus?.access === 'edit';
       if (canEdit) {
@@ -135,7 +129,7 @@ export const useMapControlsStore = create<MapControlsStore>()(
     },
     spatialUnit: 'tract',
     setSpatialUnit: spatialUnit => set({spatialUnit}),
-    sidebarPanels: ['population'],
+    sidebarPanels: [SIDEBAR_PANELS.POPULATION],
     setSidebarPanels: sidebarPanels => set({sidebarPanels}),
   }))
 );

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -20,6 +20,8 @@ import {setZones} from '@utils/map/setZones';
 import bbox from '@turf/bbox';
 import {FALLBACK_NUM_DISTRICTS} from '../constants/map/layerStyle';
 import {BLOCK_SOURCE_ID} from '../constants/map/layerIds';
+import {ACTIVE_TOOLS} from '../constants/tools';
+import {SIDEBAR_PANELS} from '../constants/sidebar';
 import {onlyUnique} from '../utils/arrays';
 import {queryClient} from '../utils/api/queryClient';
 import {createWithDevWrapperAndSubscribe} from './middlewares';
@@ -266,9 +268,9 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
           bounds: mapDocument.extent,
           stateFipsSet: newStateFipsSet,
         },
-        activeTool: mapDocument.access === 'edit' ? mapControlsState.activeTool : 'pan',
+        activeTool: mapDocument.access === 'edit' ? mapControlsState.activeTool : ACTIVE_TOOLS.PAN,
         selectedZone: 1,
-        sidebarPanels: ['population'],
+        sidebarPanels: [SIDEBAR_PANELS.POPULATION],
         isPainting: false,
         isEditing: mapDocument.access === 'edit',
       });

--- a/app/src/app/store/tooltipStore.ts
+++ b/app/src/app/store/tooltipStore.ts
@@ -1,5 +1,6 @@
 import {TooltipState} from '@utils/map/types';
 import {KeyOfSummaryStatConfig} from '../utils/api/summaryStats';
+import {COLUMN_SETS} from '@/app/constants/demography';
 import {createWithDevWrapperAndSubscribe} from './middlewares';
 
 export interface ZoneCommentTooltipState {
@@ -32,7 +33,7 @@ export const useTooltipStore = createWithDevWrapperAndSubscribe<TooltipStore>(
     if (currentTooltip === tooltip) return;
     set({tooltip});
   },
-  inspectorMode: 'VAP',
+  inspectorMode: COLUMN_SETS.VAP,
   setInspectorMode: mode => set({inspectorMode: mode}),
   inspectorFormat: 'standard',
   setInspectorFormat: format => set({inspectorFormat: format}),

--- a/app/src/app/utils/demography/demographyCache.ts
+++ b/app/src/app/utils/demography/demographyCache.ts
@@ -20,6 +20,7 @@ import {
   TabularDataWithPercent,
   AllMapConfigs,
 } from '../api/summaryStats';
+import {COLUMN_SETS} from '@/app/constants/demography';
 import {getColumnDerives, getPctDerives, getRollups} from './arquero';
 import * as scale from 'd3-scale';
 import {type AnyD3Scale} from '@/app/store/demography/types';
@@ -67,8 +68,8 @@ class DemographyCache {
    * Available summary statistics / derived values.
    */
   summaryStats: {
-    TOTPOP?: (typeof summaryStatsWithPctConfig)['TOTPOP'];
-    VAP?: (typeof summaryStatsWithPctConfig)['VAP'];
+    TOTPOP?: (typeof summaryStatsWithPctConfig)[typeof COLUMN_SETS.TOTPOP];
+    VAP?: (typeof summaryStatsWithPctConfig)[typeof COLUMN_SETS.VAP];
     idealpop?: number;
     totalPopulation?: number;
     unassigned?: number;

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -27,7 +27,7 @@ import {
 } from '@/app/constants/map/layerIds';
 import {ResetMapSelectState} from '@utils/events/handlers';
 import GeometryWorker from '../GeometryWorker';
-import {ActiveTool} from '@/app/constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '@/app/constants/tools';
 import {throttle} from 'lodash';
 import {useTooltipStore} from '@/app/store/tooltipStore';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
@@ -36,10 +36,14 @@ import {setHoverFeatures} from '../map/hoverFeatures';
 // Zone label layer IDs for interaction
 const ZONE_LABEL_LAYER_IDS = ['ZONE_LABEL', 'ZONE_LABEL_BG', 'ZONE_COMMENT_INDICATOR'];
 
-export const AREA_SELECT_TOOLS = ['brush', 'eraser', 'inspector'];
-export const POINT_SELECT_TOOLS = ['shatter'];
-export const ALL_BRUSHING_TOOLS = [...AREA_SELECT_TOOLS, ...POINT_SELECT_TOOLS];
-export const TOOLTIP_TOOLS = ['inspector'];
+export const AREA_SELECT_TOOLS: ActiveTool[] = [
+  ACTIVE_TOOLS.BRUSH,
+  ACTIVE_TOOLS.ERASER,
+  ACTIVE_TOOLS.INSPECTOR,
+];
+export const POINT_SELECT_TOOLS: ActiveTool[] = [ACTIVE_TOOLS.SHATTER];
+export const ALL_BRUSHING_TOOLS: ActiveTool[] = [...AREA_SELECT_TOOLS, ...POINT_SELECT_TOOLS];
+export const TOOLTIP_TOOLS = [ACTIVE_TOOLS.INSPECTOR];
 
 export const EMPTY_FEATURE_ARRAY: MapGeoJSONFeature[] = [];
 /*
@@ -57,7 +61,7 @@ export const EMPTY_FEATURE_ARRAY: MapGeoJSONFeature[] = [];
  * @returns string[], the layer IDs to paint
  */
 function getLayerIdsToPaint(child_layer: string | undefined | null, activeTool: ActiveTool) {
-  if (activeTool === 'shatter') {
+  if (activeTool === ACTIVE_TOOLS.SHATTER) {
     return [BLOCK_HOVER_LAYER_ID];
   }
 
@@ -80,20 +84,20 @@ export const handleFeatureSelection = (
   const {activeTool, selectedZone, setIsPainting} = useMapControlsStore.getState();
   const {mutateZoneAssignments} = useAssignmentsStore.getState();
   switch (activeTool) {
-    case 'shatter':
+    case ACTIVE_TOOLS.SHATTER:
       const documentId = mapStore.mapDocument?.document_id;
       if (documentId && selectedFeatures?.length) {
         mapStore.handleShatter(selectedFeatures || []);
       }
       return;
-    case 'brush':
-    case 'eraser':
+    case ACTIVE_TOOLS.BRUSH:
+    case ACTIVE_TOOLS.ERASER:
       if (sourceLayer && selectedFeatures && mapRef && mapStore) {
         // select on both the map object and the store
         mutateZoneAssignments(
           mapRef,
           selectedFeatures || [],
-          activeTool === 'brush' ? selectedZone : null
+          activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null
         );
         setIsPainting(false);
       }
@@ -124,7 +128,7 @@ export const handleMapClick = throttle((e: MapLayerMouseEvent | MapLayerTouchEve
     }),
   });
 
-  if (zoneLabelFeatures.length > 0 && activeTool === 'pan') {
+  if (zoneLabelFeatures.length > 0 && activeTool === ACTIVE_TOOLS.PAN) {
     const zone = zoneLabelFeatures[0].properties?.zone;
     if (zone !== undefined) {
       const comments = mapStore.mapDocument?.document_comments || [];
@@ -163,7 +167,7 @@ export const handleMapMouseUp = (e: MapLayerMouseEvent | MapLayerTouchEvent) => 
   const activeTool = mapControls.activeTool;
   const isPainting = mapControls.isPainting;
 
-  if ((activeTool === 'brush' || activeTool === 'eraser') && isPainting) {
+  if ((activeTool === ACTIVE_TOOLS.BRUSH || activeTool === ACTIVE_TOOLS.ERASER) && isPainting) {
     // set isPainting to false
     mapControls.setIsPainting(false);
   }
@@ -175,10 +179,10 @@ export const handleMapMouseDown = (e: MapLayerMouseEvent | MapLayerTouchEvent) =
   const mapControls = useMapControlsStore.getState();
   const activeTool = mapControls.activeTool;
 
-  if (activeTool === 'pan') {
+  if (activeTool === ACTIVE_TOOLS.PAN) {
     // enable drag pan
     mapRef.dragPan.enable();
-  } else if (activeTool === 'brush' || activeTool === 'eraser') {
+  } else if (activeTool === ACTIVE_TOOLS.BRUSH || activeTool === ACTIVE_TOOLS.ERASER) {
     // disable drag pan
     mapRef.dragPan.disable();
     mapControls.setIsPainting(true);
@@ -243,7 +247,7 @@ export const handleMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerTouc
     }),
   });
 
-  if (zoneLabelFeatures.length > 0 && activeTool === 'pan') {
+  if (zoneLabelFeatures.length > 0 && activeTool === ACTIVE_TOOLS.PAN) {
     const zone = zoneLabelFeatures[0].properties?.zone;
     if (zone !== undefined) {
       const comments = mapStore.mapDocument?.document_comments || [];
@@ -291,7 +295,11 @@ export const handleMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerTouc
   if (selectedFeatures && isBrushingTool && isPainting) {
     // selects in the map object; the store object
     // is updated in the mouseup event
-    mutateZoneAssignments(mapRef, selectedFeatures, activeTool === 'brush' ? selectedZone : null);
+    mutateZoneAssignments(
+      mapRef,
+      selectedFeatures,
+      activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null
+    );
   }
 
   if (
@@ -348,7 +356,7 @@ export const handleMapContextMenu = (e: MapLayerMouseEvent | MapLayerTouchEvent)
   const mapStore = useMapStore.getState();
   const mapControls = useMapControlsStore.getState();
   const activeTool = mapControls.activeTool;
-  if (activeTool !== 'pan') {
+  if (activeTool !== ACTIVE_TOOLS.PAN) {
     return;
   }
   e.preventDefault();

--- a/app/src/app/utils/language.ts
+++ b/app/src/app/utils/language.ts
@@ -1,4 +1,5 @@
 import {DocumentMetadata} from './api/apiHandlers/types';
+import {DEFAULT_DRAFT_STATUS} from '@/app/constants/map/draftStatus';
 
 export const LANG_MAPPING = {
   en: 'English',
@@ -19,5 +20,5 @@ export const DEFAULT_MAP_METADATA: DocumentMetadata = {
   tags: null,
   description: null,
   eventId: null,
-  draft_status: 'scratch',
+  draft_status: DEFAULT_DRAFT_STATUS,
 };

--- a/app/src/app/utils/map/filterFeatures.ts
+++ b/app/src/app/utils/map/filterFeatures.ts
@@ -4,6 +4,7 @@ import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import {booleanIntersects, area, intersect} from '@turf/turf';
 import {MultiPolygon, Polygon} from 'geojson';
 
@@ -50,7 +51,7 @@ export const filterFeatures = ({
     filterFunctions.push(f => captiveIds.has(f.id?.toString() || ''));
   }
   if (filterLocked) {
-    if (activeTool === 'brush' && mapOptions.lockPaintedAreas.includes(selectedZone)) {
+    if (activeTool === ACTIVE_TOOLS.BRUSH && mapOptions.lockPaintedAreas.includes(selectedZone)) {
       return [];
     } else if (mapOptions.lockPaintedAreas.length) {
       const lockedAreas = mapOptions.lockPaintedAreas;

--- a/app/src/app/utils/map/mapRenderSubs.ts
+++ b/app/src/app/utils/map/mapRenderSubs.ts
@@ -1,5 +1,6 @@
 import {getLayerFill} from '@constants/map/layerStyle';
 import {PARENT_LAYERS, CHILD_LAYERS, BLOCK_SOURCE_ID} from '@constants/map/layerIds';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import {ColorZoneAssignmentsState} from '@utils/map/types';
 import {colorZoneAssignments} from '@utils/map/colorZoneAssignments';
 import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
@@ -173,12 +174,12 @@ export class MapRenderSubscriber {
       ? getFeaturesIntersectingCounties
       : getFeaturesInBbox;
     switch (activeTool) {
-      case 'pan':
-      case 'brush':
-      case 'eraser':
+      case ACTIVE_TOOLS.PAN:
+      case ACTIVE_TOOLS.BRUSH:
+      case ACTIVE_TOOLS.ERASER:
         setPaintFunction(defaultPaintFunction);
         break;
-      case 'shatter':
+      case ACTIVE_TOOLS.SHATTER:
         setPaintFunction(getFeatureUnderCursor);
         break;
       default:

--- a/app/src/app/utils/metadata/handleCreateBlankMetadataObject.ts
+++ b/app/src/app/utils/metadata/handleCreateBlankMetadataObject.ts
@@ -1,4 +1,5 @@
 import {DocumentMetadata} from '../api/apiHandlers/types';
+import {DEFAULT_DRAFT_STATUS} from '@/app/constants/map/draftStatus';
 
 export const handleCreateBlankMetadataObject = (): DocumentMetadata => {
   return {
@@ -6,7 +7,7 @@ export const handleCreateBlankMetadataObject = (): DocumentMetadata => {
     group: null,
     tags: null,
     description: null,
-    draft_status: 'scratch',
+    draft_status: DEFAULT_DRAFT_STATUS,
     eventId: null,
   };
 };


### PR DESCRIPTION
## Description
- Centralize reused frontend string constants into dedicated constant modules to reduce magic strings and improve maintainability
- Extract tool names (eg. 'paint'), standard column set names (eg. 'total_population') to constants
- Extract draft status constants (`DRAFT_STATUS`, `DEFAULT_DRAFT_STATUS`, `DRAFT_STATUS_ORDER`, `DRAFT_STATUS_LABELS`, `DRAFT_STATUS_OG_COLORS`) into `app/src/app/constants/map/draftStatus.ts`, replacing inline string literals like `'scratch'`, `'in_progress'`, `'ready_to_share'` across `MapStatus`, `MapTitleDisplay`, `MapSelector`, OG image route, and metadata utilities
- Extract CMS rich text editor constants (`RICH_TEXT_DATA_ATTRIBUTES`, `RICH_TEXT_NODE_TYPES`, gallery attribute maps, display option arrays) into `app/src/app/constants/cms/richText.ts`, replacing hardcoded `data-type`, `data-custom-content`, and attribute key strings across all TipTap extension nodes (`BoilerplateNode`, `CommentGalleryNode`, `FormNode`, `MapCreateButtonsNode`, `PlanGalleryNode`, `SectionHeaderNode`) and their views
- Update `DomNodeRenderers.tsx` to use the new constants for DOM node type matching and attribute access
- Simplify the OG image route's draft status rendering from a chain of ternaries to a single constant-driven lookup

## Reviewers

- Primary:
- Secondary:

## Checklist
- [x] Added/Updated related documentation (if applicable).
- [x] Added/Updated related unit tests (if applicable).
  - No new behavior introduced; this is a refactor consolidating existing string literals into constants.

## Screenshots (if applicable):
N/A — no visual changes; purely a refactor of string constants.