### PR TITLE
Centralize tool modes, column sets, and sidebar panel constants

### DIFF
--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -5,6 +5,7 @@ import {
   ZONE_LABEL_SOURCE_ID,
   ZONE_LABEL_LAYER_IDS,
 } from '@/app/constants/map/layerIds';
+import {TOTAL_COLUMNS} from '@/app/constants/demography';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
@@ -80,7 +81,7 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
       source={child ? SELECTION_POINTS_SOURCE_ID_CHILD : SELECTION_POINTS_SOURCE_ID}
       filter={populationFilter}
       layout={{
-        'text-field': ['get', 'total_pop_20'],
+        'text-field': ['get', TOTAL_COLUMNS.TOTPOP!],
         'text-font': ['Barlow Bold'],
         'text-size': [
           'interpolate',

--- a/app/src/app/components/Map/Tooltip/InpsectorTooltipConfig.tsx
+++ b/app/src/app/components/Map/Tooltip/InpsectorTooltipConfig.tsx
@@ -1,14 +1,5 @@
-import {KeyOfSummaryStatConfig} from '@utils/api/summaryStats';
-import {NumberFormats} from '@utils/numbers';
+import {COLUMN_SET_LABELS, TOTAL_COLUMNS} from '@/app/constants/demography';
 
-export const INSPECTOR_TITLE = {
-  VAP: 'Voting Age Population',
-  TOTPOP: 'Total Population',
-  VOTERHISTORY: 'Voter History',
-};
+export const INSPECTOR_TITLE = COLUMN_SET_LABELS;
 
-export const TOTAL_COLUMN: Record<KeyOfSummaryStatConfig, string | undefined> = {
-  VAP: 'total_vap_20',
-  TOTPOP: 'total_pop_20',
-  VOTERHISTORY: undefined,
-};
+export const TOTAL_COLUMN = TOTAL_COLUMNS;

--- a/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
+++ b/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
@@ -8,15 +8,16 @@ import {CONFIG_BY_COLUMN_SET} from '@store/demography/evaluationConfig';
 import {PARTISAN_SCALE} from '@store/demography/constants';
 import {INSPECTOR_TITLE, TOTAL_COLUMN} from '@components/Map/Tooltip/InpsectorTooltipConfig';
 import {previousHoverFeatures as hoverFeatures} from '@/app/utils/map/hoverFeatures';
+import {COLUMN_SETS} from '@/app/constants/demography';
 
 export const InspectorTooltip = () => {
   const activeColumns = useTooltipStore(state => state.activeColumns);
   const inspectorMode = useTooltipStore(state => state.inspectorMode);
   const inspectorFormat = useTooltipStore(state => state.inspectorFormat);
-  const usePercent = inspectorFormat === 'percent' || inspectorMode === 'VOTERHISTORY';
+  const usePercent = inspectorFormat === 'percent' || inspectorMode === COLUMN_SETS.VOTERHISTORY;
   const columnSuffix = usePercent ? '_pct' : '';
-  const standardFormat =
-    inspectorMode === 'VOTERHISTORY' ? 'partisan' : usePercent ? 'percent' : 'standard';
+  const standardFormat = 'standard';
+    inspectorMode === COLUMN_SETS.VOTERHISTORY ? 'partisan' : usePercent ? 'percent' : 'standard';
   const ids = hoverFeatures.map(f => f.id as string);
   const [inspectorData, setInspectorData] = useState<Record<string, number>>({});
   const config = CONFIG_BY_COLUMN_SET[inspectorMode].sort((a, b) => a.label.localeCompare(b.label));
@@ -28,7 +29,7 @@ export const InspectorTooltip = () => {
   useEffect(() => {
     if (ids.length > 0) {
       const _activeColumns =
-        inspectorMode === 'VOTERHISTORY'
+        inspectorMode === COLUMN_SETS.VOTERHISTORY
           ? [...activeColumns, ...activeColumns.map(colName => colName.replace('_lean', '_total'))]
           : activeColumns;
       const data = demographyCache.calculateSummaryStats(ids, _activeColumns);
@@ -72,12 +73,12 @@ export const InspectorTooltip = () => {
                   className="bg-gray-900 absolute h-full top-0 left-0"
                   style={{
                     width:
-                      inspectorMode === 'VOTERHISTORY'
+                      inspectorMode === COLUMN_SETS.VOTERHISTORY
                         ? '100%'
                         : `${(inspectorData[f.column + '_pct'] ?? 0) * 100}%`,
                     opacity: '.15',
                     backgroundColor:
-                      inspectorMode === 'VOTERHISTORY' && !isNaN(inspectorData[f.column + '_pct'])
+                      inspectorMode === COLUMN_SETS.VOTERHISTORY && !isNaN(inspectorData[f.column + '_pct'])
                         ? PARTISAN_SCALE((inspectorData[f.column + '_pct'] + 1) / 2)
                         : undefined,
                   }}

--- a/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
+++ b/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
@@ -17,7 +17,7 @@ export const InspectorTooltip = () => {
   const usePercent = inspectorFormat === 'percent' || inspectorMode === COLUMN_SETS.VOTERHISTORY;
   const columnSuffix = usePercent ? '_pct' : '';
   const standardFormat = 'standard';
-    inspectorMode === COLUMN_SETS.VOTERHISTORY ? 'partisan' : usePercent ? 'percent' : 'standard';
+  inspectorMode === COLUMN_SETS.VOTERHISTORY ? 'partisan' : usePercent ? 'percent' : 'standard';
   const ids = hoverFeatures.map(f => f.id as string);
   const [inspectorData, setInspectorData] = useState<Record<string, number>>({});
   const config = CONFIG_BY_COLUMN_SET[inspectorMode].sort((a, b) => a.label.localeCompare(b.label));
@@ -78,7 +78,8 @@ export const InspectorTooltip = () => {
                         : `${(inspectorData[f.column + '_pct'] ?? 0) * 100}%`,
                     opacity: '.15',
                     backgroundColor:
-                      inspectorMode === COLUMN_SETS.VOTERHISTORY && !isNaN(inspectorData[f.column + '_pct'])
+                      inspectorMode === COLUMN_SETS.VOTERHISTORY &&
+                      !isNaN(inspectorData[f.column + '_pct'])
                         ? PARTISAN_SCALE((inspectorData[f.column + '_pct'] + 1) / 2)
                         : undefined,
                   }}

--- a/app/src/app/components/Toolbar/RecentMapsModal.tsx
+++ b/app/src/app/components/Toolbar/RecentMapsModal.tsx
@@ -1,5 +1,6 @@
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import React, {useEffect} from 'react';
 import {Cross2Icon} from '@radix-ui/react-icons';
 import {Button, Flex, Text, Table, Dialog, Box, Separator, Popover} from '@radix-ui/themes';
@@ -73,7 +74,7 @@ export const RecentMapsModal: React.FC<{
 
   useEffect(() => {
     if (!open) {
-      setActiveTool('pan');
+      setActiveTool(ACTIVE_TOOLS.PAN);
       // Ensure body pointer-events is restored when dialog closes
       document.body.style.pointerEvents = '';
     }

--- a/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
@@ -1,6 +1,7 @@
 import {Box, Flex, Button, Text} from '@radix-ui/themes';
 import {MaskOffIcon} from '@radix-ui/react-icons';
 import {useMapControlsStore} from '@store/mapControlsStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import {useFeatureFlagStore} from '@store/featureFlagStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
 import {BrushSizeSelector} from '@components/Toolbar/ToolControls/BrushSizeSelector';
@@ -26,7 +27,7 @@ export const BrushControls = () => {
           </Box>
         )}
       </Flex>
-      {activeTool === 'brush' ? (
+      {activeTool === ACTIVE_TOOLS.BRUSH ? (
         <div className="flex-grow-0 flex-row p-0 m-0">
           <ZonePicker />
         </div>

--- a/app/src/app/components/Toolbar/ToolControls/InspectorControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/InspectorControls.tsx
@@ -1,6 +1,7 @@
 import {useTooltipStore} from '@store/tooltipStore';
 import {CONFIG_BY_COLUMN_SET} from '@store/demography/evaluationConfig';
 import {demographyCache} from '@utils/demography/demographyCache';
+import {COLUMN_SETS, TOTAL_COLUMNS} from '@/app/constants/demography';
 import {useEffect} from 'react';
 import {Flex, Heading, Button, CheckboxCards, Text} from '@radix-ui/themes';
 import {BrushControls} from '@components/Toolbar/ToolControls/BrushControls';
@@ -32,11 +33,8 @@ export const InspectorControls = () => {
     .filter(f => demographyCache.availableColumns.includes(f.sourceCol ?? f.column))
     .sort((a, b) => a.label.localeCompare(b.label));
 
-  const totalColumn = {
-    VAP: ['total_vap_20'],
-    TOTPOP: ['total_pop_20'],
-    VOTERHISTORY: [],
-  }[inspectorMode];
+  const totalCol = TOTAL_COLUMNS[inspectorMode];
+  const totalColumn = totalCol ? [totalCol] : [];
 
   useEffect(() => {
     setActiveColumns([...totalColumn, ...columnList.map(f => f.column)]);
@@ -51,25 +49,25 @@ export const InspectorControls = () => {
       <Flex direction="row" className="" wrap="wrap" gap="1">
         <Button
           variant="soft"
-          color={inspectorMode === 'VAP' ? 'blue' : 'gray'}
+          color={inspectorMode === COLUMN_SETS.VAP ? 'blue' : 'gray'}
           radius="none"
-          onClick={() => setInspectorMode('VAP')}
+          onClick={() => setInspectorMode(COLUMN_SETS.VAP)}
         >
           Voting Age Population
         </Button>
         <Button
           variant="soft"
-          color={inspectorMode === 'TOTPOP' ? 'blue' : 'gray'}
+          color={inspectorMode === COLUMN_SETS.TOTPOP ? 'blue' : 'gray'}
           radius="none"
-          onClick={() => setInspectorMode('TOTPOP')}
+          onClick={() => setInspectorMode(COLUMN_SETS.TOTPOP)}
         >
           Total Population
         </Button>
         <Button
           variant="soft"
-          color={inspectorMode === 'VOTERHISTORY' ? 'blue' : 'gray'}
+          color={inspectorMode === COLUMN_SETS.VOTERHISTORY ? 'blue' : 'gray'}
           radius="none"
-          onClick={() => setInspectorMode('VOTERHISTORY')}
+          onClick={() => setInspectorMode(COLUMN_SETS.VOTERHISTORY)}
         >
           Voter History
         </Button>

--- a/app/src/app/components/Toolbar/ToolUtils.tsx
+++ b/app/src/app/components/Toolbar/ToolUtils.tsx
@@ -1,5 +1,5 @@
 import {IconButtonProps, IconProps} from '@radix-ui/themes';
-import {ActiveTool} from '@constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '@/app/constants/tools';
 import {useMapStore} from '@/app/store/mapStore';
 import {
   EraserIcon,
@@ -41,7 +41,7 @@ export const useActiveTools = () => {
   const config: ActiveToolConfig[] = [
     {
       hotKeyLabel: 'M',
-      mode: 'pan',
+      mode: ACTIVE_TOOLS.PAN,
       disabled: !mapDocument?.document_id,
       label: 'Move',
       icon: HandIcon,
@@ -51,7 +51,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'P',
-      mode: 'brush',
+      mode: ACTIVE_TOOLS.BRUSH,
       disabled: !mapDocument?.document_id || !isEditing,
       label: 'Paint',
       icon: Pencil2Icon,
@@ -61,7 +61,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'E',
-      mode: 'eraser',
+      mode: ACTIVE_TOOLS.ERASER,
       disabled: !mapDocument?.document_id || !isEditing,
       label: 'Erase',
       icon: EraserIcon,
@@ -71,7 +71,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: `${metaKey} + Z`,
-      mode: 'undo',
+      mode: ACTIVE_TOOLS.UNDO,
       disabled: pastStates.length === 0 || !isEditing,
       label: 'Undo',
       icon: ResetIcon,
@@ -85,7 +85,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: `${metaKey} + Shift + Z`,
-      mode: 'redo',
+      mode: ACTIVE_TOOLS.REDO,
       disabled: futureStates.length === 0 || !isEditing,
       label: 'Redo',
       icon: ResetIcon,
@@ -100,7 +100,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'B',
-      mode: 'shatter',
+      mode: ACTIVE_TOOLS.SHATTER,
       disabled: !mapDocument?.child_layer,
       label: 'Break',
       icon: ViewGridIcon,
@@ -110,7 +110,7 @@ export const useActiveTools = () => {
     },
     {
       hotKeyLabel: 'I',
-      mode: 'inspector',
+      mode: ACTIVE_TOOLS.INSPECTOR,
       label: 'Inspector',
       icon: MagnifyingGlassIcon,
       hotKeyAccessor: e => {

--- a/app/src/app/components/Toolbar/Toolbar.tsx
+++ b/app/src/app/components/Toolbar/Toolbar.tsx
@@ -4,7 +4,7 @@ import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {MoveIcon, PinRightIcon, RotateCounterClockwiseIcon} from '@radix-ui/react-icons';
 import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
-import {ActiveTool} from '@constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '@/app/constants/tools';
 import Draggable from 'react-draggable';
 import {ToolbarState, useToolbarStore} from '@/app/store/toolbarStore';
 import {ToolControls} from '@/app/components/Toolbar/ToolControls/ToolControls';
@@ -152,14 +152,14 @@ export const DraggableToolbar = () => {
       grid={[10, 10]}
       onStart={() => {
         previousActiveTool.current = activeTool;
-        setActiveTool('pan');
+        setActiveTool(ACTIVE_TOOLS.PAN);
       }}
       onDrag={(e, {x, y}) => {
         setXY(x, y);
       }}
       onStop={(e, {x, y}) => {
         setXY(x, y, true);
-        setActiveTool(previousActiveTool.current || 'pan');
+        setActiveTool(previousActiveTool.current || ACTIVE_TOOLS.PAN);
       }}
     >
       <div

--- a/app/src/app/components/sidebar/DataPanelUtils.tsx
+++ b/app/src/app/components/sidebar/DataPanelUtils.tsx
@@ -1,5 +1,7 @@
 import PopulationPanel from '@components/sidebar/PopulationPanel';
 import {MapControlsStore} from '@/app/store/mapControlsStore';
+import {COLUMN_SETS} from '@/app/constants/demography';
+import {SIDEBAR_PANELS} from '@/app/constants/sidebar';
 import {MapValidation} from './MapValidation/MapValidation';
 import {SummaryPanel} from './SummaryPanel';
 import OverlaysPanel from './OverlaysPanel';
@@ -17,29 +19,37 @@ export interface DataPanelsProps {
 
 export const defaultPanels: DataPanelSpec[] = [
   {
-    title: 'population',
+    title: SIDEBAR_PANELS.POPULATION,
     label: 'Districts',
     content: <PopulationPanel />,
   },
   {
-    title: 'demography',
+    title: SIDEBAR_PANELS.DEMOGRAPHY,
     label: 'Demographics',
-    content: <SummaryPanel defaultColumnSet="VAP" displayedColumnSets={['VAP', 'TOTPOP']} />,
-  },
-  {
-    title: 'election',
-    label: 'Elections',
     content: (
-      <SummaryPanel defaultColumnSet="VOTERHISTORY" displayedColumnSets={['VOTERHISTORY']} />
+      <SummaryPanel
+        defaultColumnSet={COLUMN_SETS.VAP}
+        displayedColumnSets={[COLUMN_SETS.VAP, COLUMN_SETS.TOTPOP]}
+      />
     ),
   },
   {
-    title: 'mapValidation',
+    title: SIDEBAR_PANELS.ELECTION,
+    label: 'Elections',
+    content: (
+      <SummaryPanel
+        defaultColumnSet={COLUMN_SETS.VOTERHISTORY}
+        displayedColumnSets={[COLUMN_SETS.VOTERHISTORY]}
+      />
+    ),
+  },
+  {
+    title: SIDEBAR_PANELS.MAP_VALIDATION,
     label: 'Map validation',
     content: <MapValidation />,
   },
   {
-    title: 'overlays',
+    title: SIDEBAR_PANELS.OVERLAYS,
     label: 'Overlays',
     content: <OverlaysPanel />,
   },

--- a/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
+++ b/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
@@ -28,7 +28,7 @@ import {
 import {PARTISAN_SCALE} from '@/app/store/demography/constants';
 import {GearIcon} from '@radix-ui/react-icons';
 import {useColorScheme} from '@/app/hooks/useColorScheme';
-import { COLUMN_SETS } from '@/app/constants/demography';
+import {COLUMN_SETS} from '@/app/constants/demography';
 
 type EvaluationProps = {
   summaryType: keyof SummaryStatConfig;
@@ -48,7 +48,8 @@ const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
   const showModeButtons = Boolean(
     summaryStatConfig?.supportedModes?.length && summaryStatConfig?.supportedModes?.length > 1
   );
-  const numberFormat = numberFormats[summaryType === COLUMN_SETS.VOTERHISTORY ? 'partisan' : evalMode];
+  const numberFormat =
+    numberFormats[summaryType === COLUMN_SETS.VOTERHISTORY ? 'partisan' : evalMode];
 
   useEffect(() => {
     if (

--- a/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
+++ b/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
@@ -20,6 +20,7 @@ import {AllEvaluationConfigs, SummaryStatConfig} from '@/app/utils/api/summarySt
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {
   EvalModes,
+  EVAL_MODES,
   modeButtonConfig,
   numberFormats,
   summaryStatLabels,
@@ -27,6 +28,7 @@ import {
 import {PARTISAN_SCALE} from '@/app/store/demography/constants';
 import {GearIcon} from '@radix-ui/react-icons';
 import {useColorScheme} from '@/app/hooks/useColorScheme';
+import { COLUMN_SETS } from '@/app/constants/demography';
 
 type EvaluationProps = {
   summaryType: keyof SummaryStatConfig;
@@ -35,7 +37,7 @@ type EvaluationProps = {
   columnConfig: AllEvaluationConfigs;
 };
 const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
-  const [evalMode, setEvalMode] = useState<EvalModes>('share');
+  const [evalMode, setEvalMode] = useState<EvalModes>(EVAL_MODES.SHARE);
   const [colorBg, setColorBg] = useState<boolean>(true);
   const [showUnassigned, setShowUnassigned] = useState<boolean>(true);
   const {zoneStats, demoIsLoaded, zoneData} = useSummaryStats(showUnassigned);
@@ -46,7 +48,7 @@ const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
   const showModeButtons = Boolean(
     summaryStatConfig?.supportedModes?.length && summaryStatConfig?.supportedModes?.length > 1
   );
-  const numberFormat = numberFormats[summaryType === 'VOTERHISTORY' ? 'partisan' : evalMode];
+  const numberFormat = numberFormats[summaryType === COLUMN_SETS.VOTERHISTORY ? 'partisan' : evalMode];
 
   useEffect(() => {
     if (
@@ -175,7 +177,7 @@ const Evaluation: React.FC<EvaluationProps> = ({summaryType, columnConfig}) => {
                               : value;
                         let backgroundColor: string | undefined;
                         if (value === undefined || colorValue === undefined) {
-                        } else if (colorBg && summaryType === 'VOTERHISTORY') {
+                        } else if (colorBg && summaryType === COLUMN_SETS.VOTERHISTORY) {
                           backgroundColor = PARTISAN_SCALE(((value as number) + 1) / 2);
                         } else if (colorBg && !isUnassigned) {
                           backgroundColor = interpolateGreys(colorValue as number)

--- a/app/src/app/components/sidebar/ToolbarInSidebar.tsx
+++ b/app/src/app/components/sidebar/ToolbarInSidebar.tsx
@@ -5,6 +5,7 @@ import {PinLeftIcon} from '@radix-ui/react-icons';
 import {useToolbarStore} from '@/app/store/toolbarStore';
 import {Toolbar} from '../Toolbar/Toolbar';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 
 export const ToolbarInSidebar = () => {
   const toolbarLocation = useToolbarStore(store => store.toolbarLocation);
@@ -15,7 +16,7 @@ export const ToolbarInSidebar = () => {
 
   return (
     <Box
-      className={`my-1 flex-none ${activeTool !== 'pan' && 'border-b-[1px] border-gray-300'} overflow-x-auto overflow-y-hidden`}
+      className={`my-1 flex-none ${activeTool !== ACTIVE_TOOLS.PAN && 'border-b-[1px] border-gray-300'} overflow-x-auto overflow-y-hidden`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/app/src/app/constants/cms/richText.ts
+++ b/app/src/app/constants/cms/richText.ts
@@ -13,8 +13,7 @@ export const RICH_TEXT_NODE_TYPES = {
   COMMENT_GALLERY: 'comment-gallery-node',
 } as const;
 
-export type RichTextNodeType =
-  (typeof RICH_TEXT_NODE_TYPES)[keyof typeof RICH_TEXT_NODE_TYPES];
+export type RichTextNodeType = (typeof RICH_TEXT_NODE_TYPES)[keyof typeof RICH_TEXT_NODE_TYPES];
 
 export const getRichTextNodeSelector = (nodeType: RichTextNodeType) =>
   `div[${RICH_TEXT_DATA_ATTRIBUTES.TYPE}="${nodeType}"]`;

--- a/app/src/app/constants/demography.ts
+++ b/app/src/app/constants/demography.ts
@@ -1,0 +1,29 @@
+import {KeyOfSummaryStatConfig, summaryStatsConfig} from '@utils/api/summaryStats';
+
+/**
+ * Column set key constants, matching the keys in summaryStatsConfig.
+ */
+export const COLUMN_SETS = {
+  TOTPOP: 'TOTPOP',
+  VAP: 'VAP',
+  VOTERHISTORY: 'VOTERHISTORY',
+} as const satisfies Record<string, KeyOfSummaryStatConfig>;
+
+/**
+ * The total/denominator column for each column set.
+ * Derived from summaryStatsConfig sumColumn where available.
+ */
+export const TOTAL_COLUMNS: Record<KeyOfSummaryStatConfig, string | undefined> = {
+  [COLUMN_SETS.TOTPOP]: summaryStatsConfig.TOTPOP.sumColumn,
+  [COLUMN_SETS.VAP]: summaryStatsConfig.VAP.sumColumn,
+  [COLUMN_SETS.VOTERHISTORY]: undefined,
+};
+
+/**
+ * Human-readable labels for each column set.
+ */
+export const COLUMN_SET_LABELS: Record<KeyOfSummaryStatConfig, string> = {
+  [COLUMN_SETS.VAP]: 'Voting Age Population',
+  [COLUMN_SETS.TOTPOP]: 'Total Population',
+  [COLUMN_SETS.VOTERHISTORY]: 'Voter History',
+};

--- a/app/src/app/constants/sidebar.ts
+++ b/app/src/app/constants/sidebar.ts
@@ -1,0 +1,10 @@
+export const SIDEBAR_PANELS = {
+  LAYERS: 'layers',
+  POPULATION: 'population',
+  DEMOGRAPHY: 'demography',
+  ELECTION: 'election',
+  MAP_VALIDATION: 'mapValidation',
+  OVERLAYS: 'overlays',
+} as const;
+
+export type SidebarPanel = (typeof SIDEBAR_PANELS)[keyof typeof SIDEBAR_PANELS];

--- a/app/src/app/constants/tools.ts
+++ b/app/src/app/constants/tools.ts
@@ -1,0 +1,11 @@
+export const ACTIVE_TOOLS = {
+  PAN: 'pan',
+  BRUSH: 'brush',
+  ERASER: 'eraser',
+  SHATTER: 'shatter',
+  UNDO: 'undo',
+  REDO: 'redo',
+  INSPECTOR: 'inspector',
+} as const;
+
+export type ActiveTool = (typeof ACTIVE_TOOLS)[keyof typeof ACTIVE_TOOLS];

--- a/app/src/app/constants/types.ts
+++ b/app/src/app/constants/types.ts
@@ -1,4 +1,5 @@
 import type {MapOptions, MapLibreEvent, MapGeoJSONFeature} from 'maplibre-gl';
+export {type ActiveTool} from './tools';
 
 export type Zone = number;
 export type NullableZone = Zone | null;
@@ -8,8 +9,6 @@ export type GEOID = string;
 export type GDBPath = string;
 
 export type ZoneDict = Map<GEOID, Zone>;
-
-export type ActiveTool = 'pan' | 'brush' | 'eraser' | 'shatter' | 'undo' | 'redo' | 'inspector'; // others?
 
 export type SpatialUnit = 'county' | 'tract' | 'block' | 'block_group' | 'voting_district'; // others?
 

--- a/app/src/app/hooks/usePointData.tsx
+++ b/app/src/app/hooks/usePointData.tsx
@@ -4,6 +4,7 @@ import {useAssignmentsStore} from '../store/assignmentsStore';
 import {getPointSelectionData} from '../utils/api/apiHandlers/getPointSelectionData';
 import {EMPTY_FT_COLLECTION} from '../constants/map/layerStyle';
 import {BLOCK_SOURCE_ID} from '../constants/map/layerIds';
+import {TOTAL_COLUMNS} from '../constants/demography';
 import {useQuery} from '@tanstack/react-query';
 import GeometryWorker from '../utils/GeometryWorker';
 
@@ -30,7 +31,7 @@ const updateData = async (
 
   const result = await getPointSelectionData({
     layer,
-    columns: ['path', 'x', 'y', 'total_pop_20'],
+    columns: ['path', 'x', 'y', TOTAL_COLUMNS.TOTPOP!],
     filterIds: isChild ? exposedChildIds : undefined,
     source: BLOCK_SOURCE_ID,
   });

--- a/app/src/app/store/demography/constants.ts
+++ b/app/src/app/store/demography/constants.ts
@@ -8,7 +8,7 @@ import {
 } from '@utils/api/summaryStats';
 import {scaleLinear} from '@visx/scale';
 import {AnyD3Scale} from './types';
-import { COLUMN_SETS } from '@/app/constants/demography';
+import {COLUMN_SETS} from '@/app/constants/demography';
 
 export const DEFAULT_COLOR_SCHEME = chromatic.schemeBlues;
 export const DEFAULT_COLOR_SCHEME_GRAY = chromatic.schemeGreys;

--- a/app/src/app/store/demography/constants.ts
+++ b/app/src/app/store/demography/constants.ts
@@ -8,6 +8,7 @@ import {
 } from '@utils/api/summaryStats';
 import {scaleLinear} from '@visx/scale';
 import {AnyD3Scale} from './types';
+import { COLUMN_SETS } from '@/app/constants/demography';
 
 export const DEFAULT_COLOR_SCHEME = chromatic.schemeBlues;
 export const DEFAULT_COLOR_SCHEME_GRAY = chromatic.schemeGreys;
@@ -19,9 +20,9 @@ export const PARTISAN_SCALE = scaleLinear()
 // type up some abstractions / api layer stuff
 // tabular configuration
 export const choroplethMapVariables: {
-  TOTPOP: MapColumnConfiguration<SummaryStatConfig['TOTPOP']>;
-  VAP: MapColumnConfiguration<SummaryStatConfig['VAP']>;
-  VOTERHISTORY: MapColumnConfiguration<SummaryStatConfig['VOTERHISTORY']>;
+  TOTPOP: MapColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.TOTPOP]>;
+  VAP: MapColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.VAP]>;
+  VOTERHISTORY: MapColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.VOTERHISTORY]>;
 } = {
   TOTPOP: [
     {

--- a/app/src/app/store/demography/evaluationConfig.ts
+++ b/app/src/app/store/demography/evaluationConfig.ts
@@ -4,7 +4,7 @@ import {
   SummaryStatConfig,
   summaryStatsConfig,
 } from '@/app/utils/api/summaryStats';
-import { COLUMN_SET_LABELS, COLUMN_SETS } from '@/app/constants/demography';
+import {COLUMN_SET_LABELS, COLUMN_SETS} from '@/app/constants/demography';
 
 export const EVAL_MODES = {
   SHARE: 'share',
@@ -13,9 +13,11 @@ export const EVAL_MODES = {
   PARTISAN: 'partisan',
 } as const satisfies Record<string, string>;
 
-export type EvalModes = typeof EVAL_MODES[keyof typeof EVAL_MODES];
+export type EvalModes = (typeof EVAL_MODES)[keyof typeof EVAL_MODES];
 
-export const TOTPOPColumnConfig: EvalColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.TOTPOP]> = [
+export const TOTPOPColumnConfig: EvalColumnConfiguration<
+  SummaryStatConfig[typeof COLUMN_SETS.TOTPOP]
+> = [
   {
     label: 'Black',
     column: 'bpop_20',

--- a/app/src/app/store/demography/evaluationConfig.ts
+++ b/app/src/app/store/demography/evaluationConfig.ts
@@ -4,10 +4,18 @@ import {
   SummaryStatConfig,
   summaryStatsConfig,
 } from '@/app/utils/api/summaryStats';
+import { COLUMN_SET_LABELS, COLUMN_SETS } from '@/app/constants/demography';
 
-export type EvalModes = 'share' | 'count' | 'totpop' | 'partisan';
+export const EVAL_MODES = {
+  SHARE: 'share',
+  COUNT: 'count',
+  TOTPOP: 'totpop',
+  PARTISAN: 'partisan',
+} as const satisfies Record<string, string>;
 
-export const TOTPOPColumnConfig: EvalColumnConfiguration<SummaryStatConfig['TOTPOP']> = [
+export type EvalModes = typeof EVAL_MODES[keyof typeof EVAL_MODES];
+
+export const TOTPOPColumnConfig: EvalColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.TOTPOP]> = [
   {
     label: 'Black',
     column: 'bpop_20',
@@ -34,7 +42,7 @@ export const TOTPOPColumnConfig: EvalColumnConfiguration<SummaryStatConfig['TOTP
   },
 ];
 
-export const VAPColumnConfig: EvalColumnConfiguration<SummaryStatConfig['VAP']> = [
+export const VAPColumnConfig: EvalColumnConfiguration<SummaryStatConfig[typeof COLUMN_SETS.VAP]> = [
   {column: 'bvap_20', label: 'Black'},
   {column: 'hvap_20', label: 'Hispanic'},
   {column: 'amin_vap_20', label: 'AMIN'},
@@ -99,18 +107,18 @@ export const summaryStatLabels: Array<{
   supportedModes: EvalModes[];
 }> = [
   {
-    value: 'VAP',
-    label: 'Voting age population',
-    supportedModes: ['share', 'count'],
+    value: COLUMN_SETS.VAP,
+    label: COLUMN_SET_LABELS[COLUMN_SETS.VAP],
+    supportedModes: [EVAL_MODES.SHARE, EVAL_MODES.COUNT],
   },
   {
-    value: 'TOTPOP',
-    label: 'Total population',
-    supportedModes: ['share', 'count'],
+    value: COLUMN_SETS.TOTPOP,
+    label: COLUMN_SET_LABELS[COLUMN_SETS.TOTPOP],
+    supportedModes: [EVAL_MODES.SHARE, EVAL_MODES.COUNT],
   },
   {
-    value: 'VOTERHISTORY',
-    label: 'Voter history',
-    supportedModes: ['share'],
+    value: COLUMN_SETS.VOTERHISTORY,
+    label: COLUMN_SET_LABELS[COLUMN_SETS.VOTERHISTORY],
+    supportedModes: [EVAL_MODES.SHARE],
   },
 ];

--- a/app/src/app/store/mapControlsStore.tsx
+++ b/app/src/app/store/mapControlsStore.tsx
@@ -3,20 +3,14 @@ import {create} from 'zustand';
 import {subscribeWithSelector} from 'zustand/middleware';
 import type {MapOptions} from 'maplibre-gl';
 import {FALLBACK_NUM_DISTRICTS, OVERLAY_OPACITY} from '../constants/map/mapDefaults';
-import {ActiveTool, NullableZone, SpatialUnit, Zone} from '../constants/types';
+import {NullableZone, SpatialUnit, Zone} from '../constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '../constants/tools';
+import {SIDEBAR_PANELS, type SidebarPanel} from '../constants/sidebar';
 import {DistrictrMapOptions} from './types';
 import {useAssignmentsStore} from './assignmentsStore';
 import {useMapStore} from './mapStore';
 import {PaintEventHandler} from '@utils/map/types';
 import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
-
-type SidebarPanel =
-  | 'layers'
-  | 'population'
-  | 'demography'
-  | 'election'
-  | 'mapValidation'
-  | 'overlays';
 
 export interface MapControlsStore {
   selectedZone: Zone;
@@ -85,7 +79,7 @@ export const useMapControlsStore = create<MapControlsStore>()(
     },
     isEditing: false,
     setIsEditing: isEditing => set({isEditing}),
-    activeTool: 'pan',
+    activeTool: ACTIVE_TOOLS.PAN,
     setActiveTool: tool => {
       const canEdit = useMapStore.getState().mapStatus?.access === 'edit';
       if (canEdit) {
@@ -135,7 +129,7 @@ export const useMapControlsStore = create<MapControlsStore>()(
     },
     spatialUnit: 'tract',
     setSpatialUnit: spatialUnit => set({spatialUnit}),
-    sidebarPanels: ['population'],
+    sidebarPanels: [SIDEBAR_PANELS.POPULATION],
     setSidebarPanels: sidebarPanels => set({sidebarPanels}),
   }))
 );

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -20,6 +20,8 @@ import {setZones} from '@utils/map/setZones';
 import bbox from '@turf/bbox';
 import {FALLBACK_NUM_DISTRICTS} from '../constants/map/layerStyle';
 import {BLOCK_SOURCE_ID} from '../constants/map/layerIds';
+import {ACTIVE_TOOLS} from '../constants/tools';
+import {SIDEBAR_PANELS} from '../constants/sidebar';
 import {onlyUnique} from '../utils/arrays';
 import {queryClient} from '../utils/api/queryClient';
 import {createWithDevWrapperAndSubscribe} from './middlewares';
@@ -266,9 +268,9 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
           bounds: mapDocument.extent,
           stateFipsSet: newStateFipsSet,
         },
-        activeTool: mapDocument.access === 'edit' ? mapControlsState.activeTool : 'pan',
+        activeTool: mapDocument.access === 'edit' ? mapControlsState.activeTool : ACTIVE_TOOLS.PAN,
         selectedZone: 1,
-        sidebarPanels: ['population'],
+        sidebarPanels: [SIDEBAR_PANELS.POPULATION],
         isPainting: false,
         isEditing: mapDocument.access === 'edit',
       });

--- a/app/src/app/store/tooltipStore.ts
+++ b/app/src/app/store/tooltipStore.ts
@@ -1,5 +1,6 @@
 import {TooltipState} from '@utils/map/types';
 import {KeyOfSummaryStatConfig} from '../utils/api/summaryStats';
+import {COLUMN_SETS} from '@/app/constants/demography';
 import {createWithDevWrapperAndSubscribe} from './middlewares';
 
 export interface ZoneCommentTooltipState {
@@ -32,7 +33,7 @@ export const useTooltipStore = createWithDevWrapperAndSubscribe<TooltipStore>(
     if (currentTooltip === tooltip) return;
     set({tooltip});
   },
-  inspectorMode: 'VAP',
+  inspectorMode: COLUMN_SETS.VAP,
   setInspectorMode: mode => set({inspectorMode: mode}),
   inspectorFormat: 'standard',
   setInspectorFormat: format => set({inspectorFormat: format}),

--- a/app/src/app/utils/demography/demographyCache.ts
+++ b/app/src/app/utils/demography/demographyCache.ts
@@ -20,6 +20,7 @@ import {
   TabularDataWithPercent,
   AllMapConfigs,
 } from '../api/summaryStats';
+import { COLUMN_SETS } from '@/app/constants/demography';
 import {getColumnDerives, getPctDerives, getRollups} from './arquero';
 import * as scale from 'd3-scale';
 import {type AnyD3Scale} from '@/app/store/demography/types';
@@ -67,8 +68,8 @@ class DemographyCache {
    * Available summary statistics / derived values.
    */
   summaryStats: {
-    TOTPOP?: (typeof summaryStatsWithPctConfig)['TOTPOP'];
-    VAP?: (typeof summaryStatsWithPctConfig)['VAP'];
+    TOTPOP?: (typeof summaryStatsWithPctConfig)[typeof COLUMN_SETS.TOTPOP];
+    VAP?: (typeof summaryStatsWithPctConfig)[typeof COLUMN_SETS.VAP];
     idealpop?: number;
     totalPopulation?: number;
     unassigned?: number;

--- a/app/src/app/utils/demography/demographyCache.ts
+++ b/app/src/app/utils/demography/demographyCache.ts
@@ -20,7 +20,7 @@ import {
   TabularDataWithPercent,
   AllMapConfigs,
 } from '../api/summaryStats';
-import { COLUMN_SETS } from '@/app/constants/demography';
+import {COLUMN_SETS} from '@/app/constants/demography';
 import {getColumnDerives, getPctDerives, getRollups} from './arquero';
 import * as scale from 'd3-scale';
 import {type AnyD3Scale} from '@/app/store/demography/types';

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -291,7 +291,11 @@ export const handleMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerTouc
   if (selectedFeatures && isBrushingTool && isPainting) {
     // selects in the map object; the store object
     // is updated in the mouseup event
-    mutateZoneAssignments(mapRef, selectedFeatures, activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null);
+    mutateZoneAssignments(
+      mapRef,
+      selectedFeatures,
+      activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null
+    );
   }
 
   if (

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -36,9 +36,13 @@ import {setHoverFeatures} from '../map/hoverFeatures';
 // Zone label layer IDs for interaction
 const ZONE_LABEL_LAYER_IDS = ['ZONE_LABEL', 'ZONE_LABEL_BG', 'ZONE_COMMENT_INDICATOR'];
 
-export const AREA_SELECT_TOOLS = [ACTIVE_TOOLS.BRUSH, ACTIVE_TOOLS.ERASER, ACTIVE_TOOLS.INSPECTOR];
-export const POINT_SELECT_TOOLS = [ACTIVE_TOOLS.SHATTER];
-export const ALL_BRUSHING_TOOLS = [...AREA_SELECT_TOOLS, ...POINT_SELECT_TOOLS];
+export const AREA_SELECT_TOOLS: ActiveTool[] = [
+  ACTIVE_TOOLS.BRUSH,
+  ACTIVE_TOOLS.ERASER,
+  ACTIVE_TOOLS.INSPECTOR,
+];
+export const POINT_SELECT_TOOLS: ActiveTool[] = [ACTIVE_TOOLS.SHATTER];
+export const ALL_BRUSHING_TOOLS: ActiveTool[] = [...AREA_SELECT_TOOLS, ...POINT_SELECT_TOOLS];
 export const TOOLTIP_TOOLS = [ACTIVE_TOOLS.INSPECTOR];
 
 export const EMPTY_FEATURE_ARRAY: MapGeoJSONFeature[] = [];

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -27,7 +27,7 @@ import {
 } from '@/app/constants/map/layerIds';
 import {ResetMapSelectState} from '@utils/events/handlers';
 import GeometryWorker from '../GeometryWorker';
-import {ActiveTool} from '@/app/constants/types';
+import {ACTIVE_TOOLS, type ActiveTool} from '@/app/constants/tools';
 import {throttle} from 'lodash';
 import {useTooltipStore} from '@/app/store/tooltipStore';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
@@ -36,10 +36,10 @@ import {setHoverFeatures} from '../map/hoverFeatures';
 // Zone label layer IDs for interaction
 const ZONE_LABEL_LAYER_IDS = ['ZONE_LABEL', 'ZONE_LABEL_BG', 'ZONE_COMMENT_INDICATOR'];
 
-export const AREA_SELECT_TOOLS = ['brush', 'eraser', 'inspector'];
-export const POINT_SELECT_TOOLS = ['shatter'];
+export const AREA_SELECT_TOOLS = [ACTIVE_TOOLS.BRUSH, ACTIVE_TOOLS.ERASER, ACTIVE_TOOLS.INSPECTOR];
+export const POINT_SELECT_TOOLS = [ACTIVE_TOOLS.SHATTER];
 export const ALL_BRUSHING_TOOLS = [...AREA_SELECT_TOOLS, ...POINT_SELECT_TOOLS];
-export const TOOLTIP_TOOLS = ['inspector'];
+export const TOOLTIP_TOOLS = [ACTIVE_TOOLS.INSPECTOR];
 
 export const EMPTY_FEATURE_ARRAY: MapGeoJSONFeature[] = [];
 /*
@@ -57,7 +57,7 @@ export const EMPTY_FEATURE_ARRAY: MapGeoJSONFeature[] = [];
  * @returns string[], the layer IDs to paint
  */
 function getLayerIdsToPaint(child_layer: string | undefined | null, activeTool: ActiveTool) {
-  if (activeTool === 'shatter') {
+  if (activeTool === ACTIVE_TOOLS.SHATTER) {
     return [BLOCK_HOVER_LAYER_ID];
   }
 
@@ -80,20 +80,20 @@ export const handleFeatureSelection = (
   const {activeTool, selectedZone, setIsPainting} = useMapControlsStore.getState();
   const {mutateZoneAssignments} = useAssignmentsStore.getState();
   switch (activeTool) {
-    case 'shatter':
+    case ACTIVE_TOOLS.SHATTER:
       const documentId = mapStore.mapDocument?.document_id;
       if (documentId && selectedFeatures?.length) {
         mapStore.handleShatter(selectedFeatures || []);
       }
       return;
-    case 'brush':
-    case 'eraser':
+    case ACTIVE_TOOLS.BRUSH:
+    case ACTIVE_TOOLS.ERASER:
       if (sourceLayer && selectedFeatures && mapRef && mapStore) {
         // select on both the map object and the store
         mutateZoneAssignments(
           mapRef,
           selectedFeatures || [],
-          activeTool === 'brush' ? selectedZone : null
+          activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null
         );
         setIsPainting(false);
       }
@@ -124,7 +124,7 @@ export const handleMapClick = throttle((e: MapLayerMouseEvent | MapLayerTouchEve
     }),
   });
 
-  if (zoneLabelFeatures.length > 0 && activeTool === 'pan') {
+  if (zoneLabelFeatures.length > 0 && activeTool === ACTIVE_TOOLS.PAN) {
     const zone = zoneLabelFeatures[0].properties?.zone;
     if (zone !== undefined) {
       const comments = mapStore.mapDocument?.document_comments || [];
@@ -163,7 +163,7 @@ export const handleMapMouseUp = (e: MapLayerMouseEvent | MapLayerTouchEvent) => 
   const activeTool = mapControls.activeTool;
   const isPainting = mapControls.isPainting;
 
-  if ((activeTool === 'brush' || activeTool === 'eraser') && isPainting) {
+  if ((activeTool === ACTIVE_TOOLS.BRUSH || activeTool === ACTIVE_TOOLS.ERASER) && isPainting) {
     // set isPainting to false
     mapControls.setIsPainting(false);
   }
@@ -175,10 +175,10 @@ export const handleMapMouseDown = (e: MapLayerMouseEvent | MapLayerTouchEvent) =
   const mapControls = useMapControlsStore.getState();
   const activeTool = mapControls.activeTool;
 
-  if (activeTool === 'pan') {
+  if (activeTool === ACTIVE_TOOLS.PAN) {
     // enable drag pan
     mapRef.dragPan.enable();
-  } else if (activeTool === 'brush' || activeTool === 'eraser') {
+  } else if (activeTool === ACTIVE_TOOLS.BRUSH || activeTool === ACTIVE_TOOLS.ERASER) {
     // disable drag pan
     mapRef.dragPan.disable();
     mapControls.setIsPainting(true);
@@ -243,7 +243,7 @@ export const handleMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerTouc
     }),
   });
 
-  if (zoneLabelFeatures.length > 0 && activeTool === 'pan') {
+  if (zoneLabelFeatures.length > 0 && activeTool === ACTIVE_TOOLS.PAN) {
     const zone = zoneLabelFeatures[0].properties?.zone;
     if (zone !== undefined) {
       const comments = mapStore.mapDocument?.document_comments || [];
@@ -291,7 +291,7 @@ export const handleMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerTouc
   if (selectedFeatures && isBrushingTool && isPainting) {
     // selects in the map object; the store object
     // is updated in the mouseup event
-    mutateZoneAssignments(mapRef, selectedFeatures, activeTool === 'brush' ? selectedZone : null);
+    mutateZoneAssignments(mapRef, selectedFeatures, activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null);
   }
 
   if (
@@ -348,7 +348,7 @@ export const handleMapContextMenu = (e: MapLayerMouseEvent | MapLayerTouchEvent)
   const mapStore = useMapStore.getState();
   const mapControls = useMapControlsStore.getState();
   const activeTool = mapControls.activeTool;
-  if (activeTool !== 'pan') {
+  if (activeTool !== ACTIVE_TOOLS.PAN) {
     return;
   }
   e.preventDefault();

--- a/app/src/app/utils/map/filterFeatures.ts
+++ b/app/src/app/utils/map/filterFeatures.ts
@@ -4,6 +4,7 @@ import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import {booleanIntersects, area, intersect} from '@turf/turf';
 import {MultiPolygon, Polygon} from 'geojson';
 
@@ -50,7 +51,7 @@ export const filterFeatures = ({
     filterFunctions.push(f => captiveIds.has(f.id?.toString() || ''));
   }
   if (filterLocked) {
-    if (activeTool === 'brush' && mapOptions.lockPaintedAreas.includes(selectedZone)) {
+    if (activeTool === ACTIVE_TOOLS.BRUSH && mapOptions.lockPaintedAreas.includes(selectedZone)) {
       return [];
     } else if (mapOptions.lockPaintedAreas.length) {
       const lockedAreas = mapOptions.lockPaintedAreas;

--- a/app/src/app/utils/map/mapRenderSubs.ts
+++ b/app/src/app/utils/map/mapRenderSubs.ts
@@ -1,5 +1,6 @@
 import {getLayerFill} from '@constants/map/layerStyle';
 import {PARENT_LAYERS, CHILD_LAYERS, BLOCK_SOURCE_ID} from '@constants/map/layerIds';
+import {ACTIVE_TOOLS} from '@/app/constants/tools';
 import {ColorZoneAssignmentsState} from '@utils/map/types';
 import {colorZoneAssignments} from '@utils/map/colorZoneAssignments';
 import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
@@ -173,12 +174,12 @@ export class MapRenderSubscriber {
       ? getFeaturesIntersectingCounties
       : getFeaturesInBbox;
     switch (activeTool) {
-      case 'pan':
-      case 'brush':
-      case 'eraser':
+      case ACTIVE_TOOLS.PAN:
+      case ACTIVE_TOOLS.BRUSH:
+      case ACTIVE_TOOLS.ERASER:
         setPaintFunction(defaultPaintFunction);
         break;
-      case 'shatter':
+      case ACTIVE_TOOLS.SHATTER:
         setPaintFunction(getFeatureUnderCursor);
         break;
       default:


### PR DESCRIPTION
## Summary
- Adds `constants/tools.ts` with `ACTIVE_TOOLS` constant and derived `ActiveTool` type, replacing hardcoded `'pan'`, `'brush'`, `'eraser'`, etc. across 11 files
- Adds `constants/demography.ts` with `COLUMN_SETS`, `TOTAL_COLUMNS`, and `COLUMN_SET_LABELS`, eliminating repeated `'TOTPOP'`, `'VAP'`, `'total_pop_20'` strings across 6 files
- Adds `constants/sidebar.ts` with `SIDEBAR_PANELS` constant and derived `SidebarPanel` type, replacing the inline type union and hardcoded panel strings across 3 files

## Test plan
- [ ] Verify app loads and map toolbar tools (pan, brush, eraser, shatter, inspector) work correctly
- [ ] Verify sidebar panels (Districts, Demographics, Elections, Map Validation, Overlays) render and switch properly
- [ ] Verify inspector mode toggles between VAP/TOTPOP/Voter History correctly
- [ ] Verify population tooltip displays correct total_pop_20 values on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)