### PR TITLE
Track communities in communities temporal state

### DIFF
--- a/app/src/app/components/Toolbar/CoiZonePicker.tsx
+++ b/app/src/app/components/Toolbar/CoiZonePicker.tsx
@@ -108,8 +108,9 @@ export const CoiZonePicker: React.FC = () => {
                 <AlertDialog.Content maxWidth="450px">
                   <AlertDialog.Title>Remove Community</AlertDialog.Title>
                   <AlertDialog.Description size="2">
-                    Are you sure? This will permanently delete this community, its assignments, and
-                    its comments. This cannot be undone.
+                    Are you sure? This will permanently delete this community, its painted areas,
+                    and its comments. Your paint undo/redo history will also be cleared. This cannot
+                    be undone.
                   </AlertDialog.Description>
                   <Flex gap="3" mt="4" justify="end">
                     <AlertDialog.Cancel>

--- a/app/src/app/components/Toolbar/CoiZonePicker.tsx
+++ b/app/src/app/components/Toolbar/CoiZonePicker.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useState} from 'react';
-import {Box, Flex, Button} from '@radix-ui/themes';
+import {AlertDialog, Box, Flex, Button} from '@radix-ui/themes';
 import {EyeOpenIcon, EyeClosedIcon} from '@radix-ui/react-icons';
 import {useMapStore} from '../../store/mapStore';
 import {useMapControlsStore} from '../../store/mapControlsStore';
@@ -94,15 +94,41 @@ export const CoiZonePicker: React.FC = () => {
               >
                 Add Community
               </Button>
-              <Button
-                size="1"
-                variant="soft"
-                color="red"
-                onClick={() => removeCommunity(selectedZone)}
-                disabled={isReadOnly || communities.length <= COI_MIN_COMMUNITIES}
-              >
-                Remove Community
-              </Button>
+              <AlertDialog.Root>
+                <AlertDialog.Trigger>
+                  <Button
+                    size="1"
+                    variant="soft"
+                    color="red"
+                    disabled={isReadOnly || communities.length <= COI_MIN_COMMUNITIES}
+                  >
+                    Remove Community
+                  </Button>
+                </AlertDialog.Trigger>
+                <AlertDialog.Content maxWidth="450px">
+                  <AlertDialog.Title>Remove Community</AlertDialog.Title>
+                  <AlertDialog.Description size="2">
+                    Are you sure? This will permanently delete this community, its assignments, and
+                    its comments. This cannot be undone.
+                  </AlertDialog.Description>
+                  <Flex gap="3" mt="4" justify="end">
+                    <AlertDialog.Cancel>
+                      <Button variant="soft" color="gray">
+                        Cancel
+                      </Button>
+                    </AlertDialog.Cancel>
+                    <AlertDialog.Action>
+                      <Button
+                        variant="solid"
+                        color="red"
+                        onClick={() => removeCommunity(selectedZone)}
+                      >
+                        Remove Community
+                      </Button>
+                    </AlertDialog.Action>
+                  </Flex>
+                </AlertDialog.Content>
+              </AlertDialog.Root>
             </Flex>
             <Button size="1" variant="ghost" onClick={toggleNotSelectedVisibility}>
               {anyNotSelectedVisible ? <EyeOpenIcon /> : <EyeClosedIcon />}

--- a/app/src/app/store/coiAssignmentsStore.ts
+++ b/app/src/app/store/coiAssignmentsStore.ts
@@ -94,6 +94,11 @@ export interface CoiAssignmentsStore {
   clientLastUpdated: string;
   setClientLastUpdated: (updatedAt: string) => void;
 
+  /** Mirrored community metadata for undo/redo tracking. Authoritative source is mapStore. */
+  communities: Community[];
+  /** Atomically syncs communities from mapStore and updates the timestamp (triggers temporal snapshot). */
+  syncCommunitiesAndTimestamp: (clientLastUpdated: string) => void;
+
   /** Lookup helpers for rendering/UI. */
   getCommunitiesForGeoid: (geoid: string) => Set<Zone>;
   getPrimaryCommunityForGeoid: (geoid: string) => NullableZone;
@@ -751,9 +756,14 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
   parentToChild: new Map<string, Set<string>>(),
   childToParent: new Map<string, string>(),
   clientLastUpdated: '',
+  communities: [],
 
   setClientLastUpdated: (updatedAt: string) => {
     set({clientLastUpdated: updatedAt});
+  },
+
+  syncCommunitiesAndTimestamp: (clientLastUpdated: string) => {
+    set({communities: useMapStore.getState().communities, clientLastUpdated});
   },
 
   getCommunitiesForGeoid: geoid => {
@@ -1184,6 +1194,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       parentToChild: new Map<string, Set<string>>(data.parentToChild),
       childToParent: new Map<string, string>(data.childToParent),
       clientLastUpdated: baselineUpdatedAt,
+      communities: useMapStore.getState().communities,
     });
 
     // console.log('[hydration] COI store updated, final state:', {
@@ -1324,6 +1335,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       communityLastUpdated: newLastUpdated,
       accumulatedAssignments: new Map<string, CoiAccumulatedMutation>(),
       clientLastUpdated: currTime,
+      communities: useMapStore.getState().communities,
     });
 
     healTouchedParentsIfEligible({
@@ -1380,6 +1392,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       communityLastUpdated: newLastUpdated,
       accumulatedAssignments: new Map<string, CoiAccumulatedMutation>(),
       clientLastUpdated: currTime,
+      communities: useMapStore.getState().communities,
     });
 
     healTouchedParentsIfEligible({

--- a/app/src/app/store/coiAssignmentsStore.ts
+++ b/app/src/app/store/coiAssignmentsStore.ts
@@ -8,7 +8,7 @@ import {
 } from '@constants/types';
 import {BLOCK_SOURCE_ID} from '../constants/map/layerIds';
 import {Map as MaplibreMap, MapGeoJSONFeature} from 'maplibre-gl';
-import {Community, DocumentObject} from '../utils/api/apiHandlers/types';
+import {Community, DocumentComment, DocumentObject} from '../utils/api/apiHandlers/types';
 import {
   DEFAULT_COMMUNITY_DESCRIPTION,
   getCommunityFeatureStateKey,
@@ -96,7 +96,9 @@ export interface CoiAssignmentsStore {
 
   /** Mirrored community metadata for undo/redo tracking. Authoritative source is mapStore. */
   communities: Community[];
-  /** Atomically syncs communities from mapStore and updates the timestamp (triggers temporal snapshot). */
+  /** Mirrored description comments (linked via descriptionCommentId) for undo/redo tracking. User-authored zone comments are excluded. */
+  documentComments: DocumentComment[];
+  /** Atomically syncs communities and comments from mapStore and updates the timestamp (triggers temporal snapshot). */
   syncCommunitiesAndTimestamp: (clientLastUpdated: string) => void;
 
   /** Lookup helpers for rendering/UI. */
@@ -263,6 +265,19 @@ const buildCommunityVisibilityMap = (
     nextVisibility.set(communityId, currentVisibility.get(communityId) ?? true);
   }
   return nextVisibility;
+};
+
+/**
+ * Extracts description comments (linked via descriptionCommentId) from mapStore's document_comments.
+ * Only these are tracked in the temporal store for undo/redo; user-authored zone comments are excluded.
+ */
+const getDescriptionCommentsFromMapStore = (): DocumentComment[] => {
+  const mapState = useMapStore.getState();
+  const allComments = mapState.mapDocument?.document_comments ?? [];
+  const descriptionIds = new Set(
+    mapState.communities.map(c => c.descriptionCommentId).filter(Boolean)
+  );
+  return allComments.filter(c => c.comment_id && descriptionIds.has(c.comment_id));
 };
 
 /**
@@ -757,13 +772,18 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
   childToParent: new Map<string, string>(),
   clientLastUpdated: '',
   communities: [],
+  documentComments: [],
 
   setClientLastUpdated: (updatedAt: string) => {
     set({clientLastUpdated: updatedAt});
   },
 
   syncCommunitiesAndTimestamp: (clientLastUpdated: string) => {
-    set({communities: useMapStore.getState().communities, clientLastUpdated});
+    set({
+      communities: useMapStore.getState().communities,
+      documentComments: getDescriptionCommentsFromMapStore(),
+      clientLastUpdated,
+    });
   },
 
   getCommunitiesForGeoid: geoid => {
@@ -1195,6 +1215,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       childToParent: new Map<string, string>(data.childToParent),
       clientLastUpdated: baselineUpdatedAt,
       communities: useMapStore.getState().communities,
+      documentComments: getDescriptionCommentsFromMapStore(),
     });
 
     // console.log('[hydration] COI store updated, final state:', {
@@ -1336,6 +1357,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       accumulatedAssignments: new Map<string, CoiAccumulatedMutation>(),
       clientLastUpdated: currTime,
       communities: useMapStore.getState().communities,
+      documentComments: getDescriptionCommentsFromMapStore(),
     });
 
     healTouchedParentsIfEligible({
@@ -1393,6 +1415,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       accumulatedAssignments: new Map<string, CoiAccumulatedMutation>(),
       clientLastUpdated: currTime,
       communities: useMapStore.getState().communities,
+      documentComments: getDescriptionCommentsFromMapStore(),
     });
 
     healTouchedParentsIfEligible({

--- a/app/src/app/store/coiAssignmentsStore.ts
+++ b/app/src/app/store/coiAssignmentsStore.ts
@@ -8,7 +8,7 @@ import {
 } from '@constants/types';
 import {BLOCK_SOURCE_ID} from '../constants/map/layerIds';
 import {Map as MaplibreMap, MapGeoJSONFeature} from 'maplibre-gl';
-import {Community, DocumentComment, DocumentObject} from '../utils/api/apiHandlers/types';
+import {Community, DocumentObject} from '../utils/api/apiHandlers/types';
 import {
   DEFAULT_COMMUNITY_DESCRIPTION,
   getCommunityFeatureStateKey,
@@ -32,6 +32,7 @@ import {confirmMapDocumentUrlParameter} from '../utils/map/confirmMapDocumentUrl
 
 import {createWithFullMiddlewares} from './middlewares';
 import {coiAssignmentsTemporalConfig} from './middlewareConfig';
+import {temporalManager} from '../utils/temporal';
 import {
   DocumentNotFoundError,
   DocumentCreationError,
@@ -93,13 +94,6 @@ export interface CoiAssignmentsStore {
 
   clientLastUpdated: string;
   setClientLastUpdated: (updatedAt: string) => void;
-
-  /** Mirrored community metadata for undo/redo tracking. Authoritative source is mapStore. */
-  communities: Community[];
-  /** Mirrored description comments (linked via descriptionCommentId) for undo/redo tracking. User-authored zone comments are excluded. */
-  documentComments: DocumentComment[];
-  /** Atomically syncs communities and comments from mapStore and updates the timestamp (triggers temporal snapshot). */
-  syncCommunitiesAndTimestamp: (clientLastUpdated: string) => void;
 
   /** Lookup helpers for rendering/UI. */
   getCommunitiesForGeoid: (geoid: string) => Set<Zone>;
@@ -265,19 +259,6 @@ const buildCommunityVisibilityMap = (
     nextVisibility.set(communityId, currentVisibility.get(communityId) ?? true);
   }
   return nextVisibility;
-};
-
-/**
- * Extracts description comments (linked via descriptionCommentId) from mapStore's document_comments.
- * Only these are tracked in the temporal store for undo/redo; user-authored zone comments are excluded.
- */
-const getDescriptionCommentsFromMapStore = (): DocumentComment[] => {
-  const mapState = useMapStore.getState();
-  const allComments = mapState.mapDocument?.document_comments ?? [];
-  const descriptionIds = new Set(
-    mapState.communities.map(c => c.descriptionCommentId).filter(Boolean)
-  );
-  return allComments.filter(c => c.comment_id && descriptionIds.has(c.comment_id));
 };
 
 /**
@@ -771,19 +752,9 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
   parentToChild: new Map<string, Set<string>>(),
   childToParent: new Map<string, string>(),
   clientLastUpdated: '',
-  communities: [],
-  documentComments: [],
 
   setClientLastUpdated: (updatedAt: string) => {
     set({clientLastUpdated: updatedAt});
-  },
-
-  syncCommunitiesAndTimestamp: (clientLastUpdated: string) => {
-    set({
-      communities: useMapStore.getState().communities,
-      documentComments: getDescriptionCommentsFromMapStore(),
-      clientLastUpdated,
-    });
   },
 
   getCommunitiesForGeoid: geoid => {
@@ -1214,8 +1185,6 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       parentToChild: new Map<string, Set<string>>(data.parentToChild),
       childToParent: new Map<string, string>(data.childToParent),
       clientLastUpdated: baselineUpdatedAt,
-      communities: useMapStore.getState().communities,
-      documentComments: getDescriptionCommentsFromMapStore(),
     });
 
     // console.log('[hydration] COI store updated, final state:', {
@@ -1317,6 +1286,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
     const currTime = new Date().toISOString();
 
     const affectedGeometries = new Set<string>();
+    const removedCommunityIds: Zone[] = [];
 
     newAssignments.forEach((geoids, community) => {
       if (community > maxCommunity) {
@@ -1325,6 +1295,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
         });
         newAssignments.delete(community);
         newLastUpdated.set(community, currTime);
+        removedCommunityIds.push(community);
       }
     });
 
@@ -1356,8 +1327,6 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       communityLastUpdated: newLastUpdated,
       accumulatedAssignments: new Map<string, CoiAccumulatedMutation>(),
       clientLastUpdated: currTime,
-      communities: useMapStore.getState().communities,
-      documentComments: getDescriptionCommentsFromMapStore(),
     });
 
     healTouchedParentsIfEligible({
@@ -1366,6 +1335,8 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       childToParent,
       healParentsIfAllChildrenInSameCommunities: get().healParentsIfAllChildrenInSameCommunities,
     });
+
+    removedCommunityIds.forEach(id => temporalManager.purgeZone('coi', id));
   },
 
   removeCommunity: (removedCommunity: Zone) => {
@@ -1414,8 +1385,6 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       communityLastUpdated: newLastUpdated,
       accumulatedAssignments: new Map<string, CoiAccumulatedMutation>(),
       clientLastUpdated: currTime,
-      communities: useMapStore.getState().communities,
-      documentComments: getDescriptionCommentsFromMapStore(),
     });
 
     healTouchedParentsIfEligible({
@@ -1424,6 +1393,8 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       childToParent,
       healParentsIfAllChildrenInSameCommunities: get().healParentsIfAllChildrenInSameCommunities,
     });
+
+    temporalManager.purgeZone('coi', removedCommunity);
   },
 
   handlePutAssignments: async (overwrite = false) => {
@@ -1570,3 +1541,4 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
     await get().resolveConflict(resolution, sycnConflictInfo, options);
   },
 }));
+

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -821,7 +821,7 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
       });
       useCoiAssignmentsStore.getState().ensureCommunityVisibility(nextCommunityId);
       useMapControlsStore.getState().setSelectedZone(nextCommunityId);
-      useCoiAssignmentsStore.getState().syncCommunitiesAndTimestamp(clientLastUpdated);
+      useCoiAssignmentsStore.getState().setClientLastUpdated(clientLastUpdated);
       if (mapDocument.document_id) {
         idb
           .getDocument(mapDocument.document_id)
@@ -902,7 +902,7 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
         },
       });
 
-      useCoiAssignmentsStore.getState().syncCommunitiesAndTimestamp(clientLastUpdated);
+      useCoiAssignmentsStore.getState().setClientLastUpdated(clientLastUpdated);
 
       if (mapDocument.document_id) {
         idb

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -821,7 +821,7 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
       });
       useCoiAssignmentsStore.getState().ensureCommunityVisibility(nextCommunityId);
       useMapControlsStore.getState().setSelectedZone(nextCommunityId);
-      useCoiAssignmentsStore.getState().setClientLastUpdated(clientLastUpdated);
+      useCoiAssignmentsStore.getState().syncCommunitiesAndTimestamp(clientLastUpdated);
       if (mapDocument.document_id) {
         idb
           .getDocument(mapDocument.document_id)
@@ -902,7 +902,7 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
         },
       });
 
-      useCoiAssignmentsStore.getState().setClientLastUpdated(clientLastUpdated);
+      useCoiAssignmentsStore.getState().syncCommunitiesAndTimestamp(clientLastUpdated);
 
       if (mapDocument.document_id) {
         idb

--- a/app/src/app/store/middlewareConfig.ts
+++ b/app/src/app/store/middlewareConfig.ts
@@ -94,6 +94,7 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
       communityVisibility,
       clientLastUpdated,
       communities,
+      documentComments,
     } = state;
     return {
       shatterIds,
@@ -103,6 +104,7 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
       communityVisibility,
       clientLastUpdated,
       communities,
+      documentComments,
     };
   },
 };

--- a/app/src/app/store/middlewareConfig.ts
+++ b/app/src/app/store/middlewareConfig.ts
@@ -3,7 +3,6 @@ import {MapStore} from './mapStore';
 import {MIN_DIFF_MS} from '../constants/configuration';
 import {ZundoOptions} from 'zundo';
 import {AssignmentsStore} from './assignmentsStore';
-import type {CoiAssignmentsStore} from './coiAssignmentsStore';
 import {TEMPORAL_HISTORY_LIMIT} from '../constants/configuration';
 import {cloneTemporalSnapshot} from '../utils/temporalSnapshot';
 
@@ -85,7 +84,7 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
   diff: temporalDiff,
   limit: TEMPORAL_HISTORY_LIMIT,
   // @ts-ignore: save only partial store
-  partialize: (state: CoiAssignmentsStore) => {
+  partialize: state => {
     const {
       shatterIds,
       parentToChild,
@@ -93,8 +92,6 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
       communityAssignments,
       communityVisibility,
       clientLastUpdated,
-      communities,
-      documentComments,
     } = state;
     return {
       shatterIds,
@@ -103,8 +100,6 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
       communityAssignments,
       communityVisibility,
       clientLastUpdated,
-      communities,
-      documentComments,
     };
   },
 };

--- a/app/src/app/store/middlewareConfig.ts
+++ b/app/src/app/store/middlewareConfig.ts
@@ -3,6 +3,7 @@ import {MapStore} from './mapStore';
 import {MIN_DIFF_MS} from '../constants/configuration';
 import {ZundoOptions} from 'zundo';
 import {AssignmentsStore} from './assignmentsStore';
+import type {CoiAssignmentsStore} from './coiAssignmentsStore';
 import {TEMPORAL_HISTORY_LIMIT} from '../constants/configuration';
 import {cloneTemporalSnapshot} from '../utils/temporalSnapshot';
 
@@ -92,6 +93,7 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
       communityAssignments,
       communityVisibility,
       clientLastUpdated,
+      communities,
     } = state;
     return {
       shatterIds,
@@ -100,6 +102,7 @@ export const coiAssignmentsTemporalConfig: ZundoOptions<any, AssignmentsStore> =
       communityAssignments,
       communityVisibility,
       clientLastUpdated,
+      communities,
     };
   },
 };

--- a/app/src/app/store/subscriptions.tsx
+++ b/app/src/app/store/subscriptions.tsx
@@ -33,6 +33,15 @@ export const initSubs = () => {
       useDemographyStore.getState().updateData(curr);
     }
   );
+  // Clear undo/redo history when switching documents
+  const clearTemporalOnDocChangeSub = useMapStore.subscribe(
+    state => state.mapDocument?.document_id,
+    (curr, prev) => {
+      if (prev === curr) return;
+      useAssignmentsStore.temporal.getState().clear();
+      useCoiAssignmentsStore.temporal.getState().clear();
+    }
+  );
   const numDistrictsSub = useMapStore.subscribe(
     state => state.mapDocument?.num_districts,
     (curr, prev) => {
@@ -104,11 +113,50 @@ export const initSubs = () => {
     }
   );
 
+  // Reverse sync: when undo/redo restores description comments in coiAssignmentsStore,
+  // merge them with user-authored zone comments (which are never affected by undo/redo).
+  // Comments for communities that no longer exist in the restored state are dropped.
+  const coiDocumentCommentsSyncSub = useCoiAssignmentsStore.subscribe(
+    state => state.documentComments,
+    (restoredDescriptionComments, previousDescriptionComments) => {
+      if (useMapControlsStore.getState().mapMode !== 'coi') return;
+      if (!restoredDescriptionComments) return;
+      const mapDocument = useMapStore.getState().mapDocument;
+      if (!mapDocument) return;
+
+      const restoredCommunities = useCoiAssignmentsStore.getState().communities;
+      const restoredCommunityIds = new Set(restoredCommunities.map(c => c.id));
+
+      // Collect description IDs from both restored and previous states so that
+      // description comments from newly-created communities (which may reuse a
+      // zone ID) are properly replaced rather than duplicated.
+      const descriptionIdsToReplace = new Set([
+        ...restoredDescriptionComments.map(c => c.comment_id).filter(Boolean),
+        ...(previousDescriptionComments ?? []).map(c => c.comment_id).filter(Boolean),
+      ]);
+
+      const currentComments = mapDocument.document_comments ?? [];
+
+      // Keep user-authored comments whose zone still exists in the restored communities.
+      // Drop all known description comments (they'll be replaced by the restored ones).
+      const userComments = currentComments.filter(c => {
+        if (c.comment_id && descriptionIdsToReplace.has(c.comment_id)) return false;
+        if (c.zone != null && !restoredCommunityIds.has(c.zone)) return false;
+        return true;
+      });
+
+      const merged = [...userComments, ...restoredDescriptionComments];
+      if (JSON.stringify(currentComments) === JSON.stringify(merged)) return;
+      useMapStore.getState().mutateMapDocument({document_comments: merged});
+    }
+  );
+
   const unsub = () => {
     querySubs();
     mapEditSubs.forEach(sub => sub());
     demogInitSub();
     demogMapDocumentSub();
+    clearTemporalOnDocChangeSub();
     numDistrictsSub();
     numCommunitiesSub();
     demogShatterSub();
@@ -116,6 +164,7 @@ export const initSubs = () => {
     paintFlushSub();
     featureFlagSub();
     coiCommunitySyncSub();
+    coiDocumentCommentsSyncSub();
   };
   return unsub;
 };

--- a/app/src/app/store/subscriptions.tsx
+++ b/app/src/app/store/subscriptions.tsx
@@ -88,6 +88,22 @@ export const initSubs = () => {
     }
   );
 
+  // Reverse sync: when undo/redo restores communities in coiAssignmentsStore,
+  // push the restored metadata back to mapStore so the UI stays consistent.
+  const coiCommunitySyncSub = useCoiAssignmentsStore.subscribe(
+    state => state.communities,
+    communities => {
+      if (useMapControlsStore.getState().mapMode !== 'coi') return;
+      if (!communities?.length) return;
+      const current = useMapStore.getState().communities;
+      if (current === communities) return;
+      const currentIds = current.map(c => c.id).join(',');
+      const newIds = communities.map(c => c.id).join(',');
+      if (currentIds === newIds && JSON.stringify(current) === JSON.stringify(communities)) return;
+      useMapStore.getState().setCommunities(communities);
+    }
+  );
+
   const unsub = () => {
     querySubs();
     mapEditSubs.forEach(sub => sub());
@@ -99,6 +115,7 @@ export const initSubs = () => {
     demogCoiShatterSub();
     paintFlushSub();
     featureFlagSub();
+    coiCommunitySyncSub();
   };
   return unsub;
 };

--- a/app/src/app/store/subscriptions.tsx
+++ b/app/src/app/store/subscriptions.tsx
@@ -34,13 +34,18 @@ export const initSubs = () => {
       useDemographyStore.getState().updateData(curr);
     }
   );
-  // Clear undo/redo history when switching documents
+  // Clear undo/redo history when switching documents.
+  // Also reset clientLastUpdated to '' so that temporalDiff treats the next
+  // ingestFromDocument as "not yet ingested" and doesn't create a stale snapshot
+  // from the previous document's state.
   const clearTemporalOnDocChangeSub = useMapStore.subscribe(
     state => state.mapDocument?.document_id,
     (curr, prev) => {
       if (curr === prev) return;
       useAssignmentsStore.temporal.getState().clear();
       useCoiAssignmentsStore.temporal.getState().clear();
+      useAssignmentsStore.setState({clientLastUpdated: ''});
+      useCoiAssignmentsStore.setState({clientLastUpdated: ''});
     }
   );
   const numDistrictsSub = useMapStore.subscribe(

--- a/app/src/app/store/subscriptions.tsx
+++ b/app/src/app/store/subscriptions.tsx
@@ -7,6 +7,7 @@ import {useMapControlsStore} from './mapControlsStore';
 import {useAssignmentsStore} from './assignmentsStore';
 import {useCoiAssignmentsStore} from './coiAssignmentsStore';
 import {demographyCache} from '../utils/demography/demographyCache';
+import {shallowCompareArray} from '../utils/arrays';
 
 export const initSubs = () => {
   // these need to initialize after the map store
@@ -37,7 +38,7 @@ export const initSubs = () => {
   const clearTemporalOnDocChangeSub = useMapStore.subscribe(
     state => state.mapDocument?.document_id,
     (curr, prev) => {
-      if (prev === curr) return;
+      if (curr === prev) return;
       useAssignmentsStore.temporal.getState().clear();
       useCoiAssignmentsStore.temporal.getState().clear();
     }
@@ -97,60 +98,6 @@ export const initSubs = () => {
     }
   );
 
-  // Reverse sync: when undo/redo restores communities in coiAssignmentsStore,
-  // push the restored metadata back to mapStore so the UI stays consistent.
-  const coiCommunitySyncSub = useCoiAssignmentsStore.subscribe(
-    state => state.communities,
-    communities => {
-      if (useMapControlsStore.getState().mapMode !== 'coi') return;
-      if (!communities?.length) return;
-      const current = useMapStore.getState().communities;
-      if (current === communities) return;
-      const currentIds = current.map(c => c.id).join(',');
-      const newIds = communities.map(c => c.id).join(',');
-      if (currentIds === newIds && JSON.stringify(current) === JSON.stringify(communities)) return;
-      useMapStore.getState().setCommunities(communities);
-    }
-  );
-
-  // Reverse sync: when undo/redo restores description comments in coiAssignmentsStore,
-  // merge them with user-authored zone comments (which are never affected by undo/redo).
-  // Comments for communities that no longer exist in the restored state are dropped.
-  const coiDocumentCommentsSyncSub = useCoiAssignmentsStore.subscribe(
-    state => state.documentComments,
-    (restoredDescriptionComments, previousDescriptionComments) => {
-      if (useMapControlsStore.getState().mapMode !== 'coi') return;
-      if (!restoredDescriptionComments) return;
-      const mapDocument = useMapStore.getState().mapDocument;
-      if (!mapDocument) return;
-
-      const restoredCommunities = useCoiAssignmentsStore.getState().communities;
-      const restoredCommunityIds = new Set(restoredCommunities.map(c => c.id));
-
-      // Collect description IDs from both restored and previous states so that
-      // description comments from newly-created communities (which may reuse a
-      // zone ID) are properly replaced rather than duplicated.
-      const descriptionIdsToReplace = new Set([
-        ...restoredDescriptionComments.map(c => c.comment_id).filter(Boolean),
-        ...(previousDescriptionComments ?? []).map(c => c.comment_id).filter(Boolean),
-      ]);
-
-      const currentComments = mapDocument.document_comments ?? [];
-
-      // Keep user-authored comments whose zone still exists in the restored communities.
-      // Drop all known description comments (they'll be replaced by the restored ones).
-      const userComments = currentComments.filter(c => {
-        if (c.comment_id && descriptionIdsToReplace.has(c.comment_id)) return false;
-        if (c.zone != null && !restoredCommunityIds.has(c.zone)) return false;
-        return true;
-      });
-
-      const merged = [...userComments, ...restoredDescriptionComments];
-      if (JSON.stringify(currentComments) === JSON.stringify(merged)) return;
-      useMapStore.getState().mutateMapDocument({document_comments: merged});
-    }
-  );
-
   const unsub = () => {
     querySubs();
     mapEditSubs.forEach(sub => sub());
@@ -163,8 +110,6 @@ export const initSubs = () => {
     demogCoiShatterSub();
     paintFlushSub();
     featureFlagSub();
-    coiCommunitySyncSub();
-    coiDocumentCommentsSyncSub();
   };
   return unsub;
 };

--- a/app/src/app/utils/api/apiHandlers/createMapDocument.ts
+++ b/app/src/app/utils/api/apiHandlers/createMapDocument.ts
@@ -1,5 +1,8 @@
 import {DocumentCreate, DocumentObject} from './types';
 import {post} from '../factory';
+import {temporalManager} from '../../temporal';
 
-export const createMapDocument = async (document: DocumentCreate) =>
-  post<DocumentCreate, DocumentObject>('create_document')({body: document});
+export const createMapDocument = async (document: DocumentCreate) => {
+  temporalManager.clear(document.map_type == 'community' ? 'coi' : 'districts');
+  return post<DocumentCreate, DocumentObject>('create_document')({body: document});
+};

--- a/app/src/app/utils/temporal.ts
+++ b/app/src/app/utils/temporal.ts
@@ -1,6 +1,7 @@
 import {useAssignmentsStore} from '../store/assignmentsStore';
 import {useCoiAssignmentsStore} from '../store/coiAssignmentsStore';
 import {MapControlsStore} from '../store/mapControlsStore';
+import {Zone} from '../constants/types';
 
 /**
  * Manages undo/redo temporal state across different map modes (district vs COI).
@@ -8,13 +9,13 @@ import {MapControlsStore} from '../store/mapControlsStore';
  */
 class TemporalManager {
   /**
-   * Returns the temporal (undo/redo) state for the given map mode's assignments store.
+   * Returns the temporal (undo/redo) store for the given map mode's assignments store.
    * @param mapMode - The active map mode, determines which assignments store to use.
    */
-  private getTemporalState(mapMode: MapControlsStore['mapMode']) {
+  private getTemporalStore(mapMode: MapControlsStore['mapMode']) {
     return mapMode === 'coi'
-      ? useCoiAssignmentsStore.temporal.getState()
-      : useAssignmentsStore.temporal.getState();
+      ? useCoiAssignmentsStore.temporal
+      : useAssignmentsStore.temporal;
   }
 
   /**
@@ -22,9 +23,9 @@ class TemporalManager {
    * @param mapMode - The active map mode, determines which assignments store to use.
    */
   public pause(mapMode: MapControlsStore['mapMode']) {
-    const temporalState = this.getTemporalState(mapMode);
-    if (temporalState.isTracking) {
-      temporalState.pause();
+    const state = this.getTemporalStore(mapMode).getState();
+    if (state.isTracking) {
+      state.pause();
     }
   }
 
@@ -33,8 +34,8 @@ class TemporalManager {
    * @param mapMode - The active map mode, determines which assignments store to use.
    */
   public resume(mapMode: MapControlsStore['mapMode']) {
-    const temporalState = this.getTemporalState(mapMode);
-    !temporalState.isTracking && temporalState.resume();
+    const state = this.getTemporalStore(mapMode).getState();
+    !state.isTracking && state.resume();
   }
 
   /**
@@ -42,7 +43,51 @@ class TemporalManager {
    * @param mapMode - The active map mode, determines which assignments store to use.
    */
   public clear(mapMode: MapControlsStore['mapMode']) {
-    this.getTemporalState(mapMode).clear();
+    this.getTemporalStore(mapMode).getState().clear();
+  }
+
+  /**
+   * Purges all references to a zone from past and future undo/redo states.
+   * For COI mode: removes the zone key from communityAssignments and communityVisibility.
+   * For district mode: nullifies any geoid assigned to the zone in zoneAssignments.
+   *
+   * @param mapMode - The active map mode.
+   * @param zone - The zone/community ID to purge.
+   */
+  // TODO: integrate for district maps when supporting variable district counts
+  public purgeZone(mapMode: MapControlsStore['mapMode'], zone: Zone) {
+    const store = this.getTemporalStore(mapMode);
+    const {pastStates, futureStates} = store.getState();
+
+    const purge = (state: Record<string, any>): Record<string, any> => {
+      const result = {...state};
+      if (mapMode === 'coi') {
+        if (result.communityAssignments) {
+          result.communityAssignments = new Map(result.communityAssignments);
+          result.communityAssignments.delete(zone);
+        }
+        if (result.communityVisibility) {
+          result.communityVisibility = new Map(result.communityVisibility);
+          result.communityVisibility.delete(zone);
+        }
+      } else {
+        if (result.zoneAssignments) {
+          const patched = new Map(result.zoneAssignments);
+          for (const [geoid, assigned] of patched) {
+            if (assigned === zone) {
+              patched.set(geoid, null);
+            }
+          }
+          result.zoneAssignments = patched;
+        }
+      }
+      return result;
+    };
+
+    store.setState({
+      pastStates: pastStates.map(purge),
+      futureStates: futureStates.map(purge),
+    });
   }
 }
 

--- a/app/src/app/utils/temporal.ts
+++ b/app/src/app/utils/temporal.ts
@@ -13,9 +13,7 @@ class TemporalManager {
    * @param mapMode - The active map mode, determines which assignments store to use.
    */
   private getTemporalStore(mapMode: MapControlsStore['mapMode']) {
-    return mapMode === 'coi'
-      ? useCoiAssignmentsStore.temporal
-      : useAssignmentsStore.temporal;
+    return mapMode === 'coi' ? useCoiAssignmentsStore.temporal : useAssignmentsStore.temporal;
   }
 
   /**
@@ -47,47 +45,15 @@ class TemporalManager {
   }
 
   /**
-   * Purges all references to a zone from past and future undo/redo states.
-   * For COI mode: removes the zone key from communityAssignments and communityVisibility.
-   * For district mode: nullifies any geoid assigned to the zone in zoneAssignments.
+   * Clears all undo/redo history when a zone is permanently removed.
+   * This is simpler than trying to surgically remove the zone from each snapshot.
    *
    * @param mapMode - The active map mode.
-   * @param zone - The zone/community ID to purge.
+   * @param _zone - The zone/community ID being removed (reserved for future per-zone purge).
    */
   // TODO: integrate for district maps when supporting variable district counts
-  public purgeZone(mapMode: MapControlsStore['mapMode'], zone: Zone) {
-    const store = this.getTemporalStore(mapMode);
-    const {pastStates, futureStates} = store.getState();
-
-    const purge = (state: Record<string, any>): Record<string, any> => {
-      const result = {...state};
-      if (mapMode === 'coi') {
-        if (result.communityAssignments) {
-          result.communityAssignments = new Map(result.communityAssignments);
-          result.communityAssignments.delete(zone);
-        }
-        if (result.communityVisibility) {
-          result.communityVisibility = new Map(result.communityVisibility);
-          result.communityVisibility.delete(zone);
-        }
-      } else {
-        if (result.zoneAssignments) {
-          const patched = new Map(result.zoneAssignments);
-          for (const [geoid, assigned] of patched) {
-            if (assigned === zone) {
-              patched.set(geoid, null);
-            }
-          }
-          result.zoneAssignments = patched;
-        }
-      }
-      return result;
-    };
-
-    store.setState({
-      pastStates: pastStates.map(purge),
-      futureStates: futureStates.map(purge),
-    });
+  public purgeZone(mapMode: MapControlsStore['mapMode'], _zone: Zone) {
+    this.clear(mapMode);
   }
 }
 


### PR DESCRIPTION
## Description
- Undo/redo caused some issues in temporal state when communities were deleted
- This tracks community metadata in temporal state so that undo/redos include deleting communities
