### PR TITLE
Coalition builder fixes

### DIFF
--- a/app/src/app/components/sidebar/CoalitionBuilder.tsx
+++ b/app/src/app/components/sidebar/CoalitionBuilder.tsx
@@ -79,7 +79,7 @@ export const CoalitionBuilder: React.FC<CoalitionBuilderProps> = ({summaryType})
           </Text>
           <br />
           <Text size="2" color="gray">
-            Universe total
+            Statewide total
           </Text>
         </Box>
         <Box flexGrow="1">

--- a/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
+++ b/app/src/app/components/sidebar/Evaluation/Evaluation.tsx
@@ -99,7 +99,7 @@ function buildUniverseRow({
 }): Record<string, number | string | boolean> {
   const coalitionStats = demographyCache.getCoalitionUniverseStats(summaryType, coalitionGroups);
   const row: Record<string, number | string | boolean> = {
-    zone: 'Universe',
+    zone: 'Statewide',
     __isUniverse: true,
   };
   const universeTotal = summaryData[universeTotalColumn];

--- a/app/src/app/components/sidebar/SummaryPanel.tsx
+++ b/app/src/app/components/sidebar/SummaryPanel.tsx
@@ -145,7 +145,7 @@ export const SummaryPanel: React.FC<SummaryPanelProps> = ({
   return (
     <Flex direction="column" gap="2">
       <SectionHeader
-        title={summaryType === 'VOTERHISTORY' ? 'Voter History Table' : 'Table'}
+        title={'Table'}
         isOpen={openSections.evaluation}
         onToggle={() => toggleSection('evaluation')}
       />

--- a/app/src/app/components/sidebar/SummaryPanel.tsx
+++ b/app/src/app/components/sidebar/SummaryPanel.tsx
@@ -145,7 +145,7 @@ export const SummaryPanel: React.FC<SummaryPanelProps> = ({
   return (
     <Flex direction="column" gap="2">
       <SectionHeader
-        title={summaryType === 'VOTERHISTORY' ? 'Voter History Table' : 'Demographic table'}
+        title={summaryType === 'VOTERHISTORY' ? 'Voter History Table' : 'Table'}
         isOpen={openSections.evaluation}
         onToggle={() => toggleSection('evaluation')}
       />


### PR DESCRIPTION
- Rename "Demographics Table" to just "Table" in the headers. Right now it repetitively says "Demography" as the top level header and then "Demography Table" underneath
- Change "Universe" to "Statewide" in the label for overall population numbers