### PR TITLE
V2.2.1 Bugfixes

### DIFF
--- a/app/src/app/components/Map/GeocodeSearchBar.tsx
+++ b/app/src/app/components/Map/GeocodeSearchBar.tsx
@@ -179,9 +179,7 @@ export const GeocodeSearchBar: React.FC<{
         aria-autocomplete="list"
         aria-controls={listboxId}
         aria-expanded={open && (suggestions.length > 0 || loading)}
-        aria-activedescendant={
-          activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
-        }
+        aria-activedescendant={activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined}
       />
       {open && (suggestions.length > 0 || loading) && (
         <ul

--- a/app/src/app/components/MapPage/CoiMapPage.tsx
+++ b/app/src/app/components/MapPage/CoiMapPage.tsx
@@ -20,6 +20,7 @@ import {SaveConflictModal} from '../SaveConflictModal';
 import {migrateUserMapsFromLocalStorage} from '@/app/utils/idb/migrateUserMaps';
 import {DemographicMap} from '../Map/DemographicMap';
 import {useInitializeMapMode} from '@/app/hooks/useInitializeMapMode';
+import {isUUID} from '@/app/utils/metadata/isUUID';
 
 interface CoiMapPageProps {
   isEditing: boolean;
@@ -28,6 +29,7 @@ interface CoiMapPageProps {
 
 const ChildCoiMapPage: React.FC<CoiMapPageProps> = ({isEditing, documentId}) => {
   const isMapModeReady = useInitializeMapMode('coi');
+  const isPublicPage = !isEditing && !!documentId && !isUUID(documentId);
   const showDemographicMap = useMapControlsStore(
     state => state.mapOptions.showDemographicMap === 'side-by-side'
   );
@@ -48,6 +50,7 @@ const ChildCoiMapPage: React.FC<CoiMapPageProps> = ({isEditing, documentId}) => 
     conflictModal,
   } = useDocumentWithSync({
     document_id: documentId || undefined,
+    isPublicPage,
     enabled: isMapModeReady && !!documentId,
   });
 
@@ -70,11 +73,11 @@ const ChildCoiMapPage: React.FC<CoiMapPageProps> = ({isEditing, documentId}) => 
   }, [userID, setUserID]);
 
   useEffect(() => {
-    const unsub = initSubs();
+    const unsub = initSubs(isPublicPage);
     return () => {
       unsub();
     };
-  }, []);
+  }, [isPublicPage]);
 
   if (!isMapModeReady) {
     return null;

--- a/app/src/app/components/SaveConflictModal.tsx
+++ b/app/src/app/components/SaveConflictModal.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react';
+import {useRouter} from 'next/navigation';
 import {SyncConflictInfo} from '@/app/utils/api/apiHandlers/fetchDocument';
 import {useMapStore} from '../store/mapStore';
 import {useAssignmentsStore} from '../store/assignmentsStore';
@@ -9,8 +10,11 @@ import {getDocument} from '../utils/api/apiHandlers/getDocument';
 import {SyncConflictModal} from './SyncConflictModal';
 
 export const SaveConflictModal: React.FC = ({}) => {
+  const router = useRouter();
   const showSaveConflictModal = useMapStore(state => state.showSaveConflictModal);
   const localMapDocument = useMapStore(state => state.mapDocument);
+  const setAppLoadingState = useMapStore(state => state.setAppLoadingState);
+  const setMapRenderingState = useMapStore(state => state.setMapRenderingState);
   const mapMode = useMapControlsStore(state => state.mapMode);
   const isCommunity = localMapDocument?.map_type === 'community' || mapMode === 'coi';
   const districtLocalTimeUpdated = useAssignmentsStore(state => state.clientLastUpdated);
@@ -52,7 +56,17 @@ export const SaveConflictModal: React.FC = ({}) => {
     <SyncConflictModal
       open={showSaveConflictModal}
       conflict={conflict}
-      onResolve={resolution => handlePutAssignmentsConflict(resolution, conflict)}
+      onResolve={resolution =>
+        handlePutAssignmentsConflict(resolution, conflict, {
+          onNavigate: documentId => {
+            router.push(isCommunity ? `/coi/edit/${documentId}` : `/map/edit/${documentId}`);
+          },
+          onComplete: () => {
+            setAppLoadingState('loaded');
+            setMapRenderingState('loaded');
+          },
+        })
+      }
       loading={!serverMapDocument}
     />
   );

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationLabels.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationChart/PopulationLabels.tsx
@@ -45,7 +45,7 @@ export const PopulationLabels: React.FC<{
         : _popDiffLabel;
   const popLabel = formatNumber(entry.total_pop_20, 'string');
   if (popLabel === undefined) return null;
-  const [left, top] = [xScale(entry.total_pop_20), yScale(index) + barHeight];
+  const [left, top] = [xScale(entry.total_pop_20), yScale(index) + 5 + barHeight / 2];
   const showDeviationLabel = hasIdealPopulation && !!(isHovered || showTopBottomDeviation);
 
   let offsetLeft = 0;
@@ -59,7 +59,14 @@ export const PopulationLabels: React.FC<{
     <Group left={left + offsetLeft} top={top} style={{pointerEvents: 'none'}}>
       {!!(isHovered || showPopNumbers) && (
         <>
-          <text x={5} y={-2} fontSize={14} fontWeight={'bold'} textAnchor="start">
+          <text
+            x={5}
+            y={0}
+            fontSize={14}
+            fontWeight={'bold'}
+            textAnchor="start"
+            dominantBaseline="central"
+          >
             {popLabel}
           </text>
         </>
@@ -68,16 +75,17 @@ export const PopulationLabels: React.FC<{
         <>
           <text
             x={-5}
-            y={-1}
+            y={0}
             fontSize={14}
             textAnchor="end"
+            dominantBaseline="central"
             fill="white"
             stroke="white"
             strokeWidth="3"
           >
             {popDiffLabel}
           </text>
-          <text x={-5} y={-1} fontSize={14} textAnchor="end">
+          <text x={-5} y={0} fontSize={14} textAnchor="end" dominantBaseline="central">
             {popDiffLabel}
           </text>
         </>

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -22,6 +22,15 @@ import {useColorScheme} from '@/app/hooks/useColorScheme';
 
 const maxNumberOrderedBars = 40; // max number of zones to consider while keeping blank spaces for missing zones
 
+// The chart draws bars at yScale(i) + 5 with height (ROW_HEIGHT - 6), so bar
+// centers land at TOP_MARGIN + 21 + i * ROW_HEIGHT. The left column mirrors
+// that with a fixed top spacer + fixed-height rows (align-center) so icons
+// line up with bars: SPACER + ROW_HEIGHT/2 = TOP_MARGIN + 21 ⇒ SPACER = 22.
+const POP_ROW_HEIGHT = 38;
+const POP_CHART_TOP_MARGIN = 20;
+const POP_CHART_BOTTOM_MARGIN = 80;
+const POP_LEFT_COL_TOP_SPACER = 22;
+
 export const PopulationPanel = () => {
   const {populationData, demoIsLoaded} = useZonePopulations();
   const {summaryStats, zoneStats} = useSummaryStats();
@@ -132,14 +141,12 @@ export const PopulationPanel = () => {
         />
       </Flex>
       <Flex direction="row" width={'100%'} gap="1">
-        <Flex
-          direction={'column'}
-          gap={'2'}
-          className={'flex-grow-0 p-0 pb-[80px]'}
-          justify={'between'}
-          minWidth={'5rem'}
-        >
-          <Flex justify="end" minHeight={isCommunityMode ? '12px' : '28px'}>
+        <Flex direction={'column'} className={'flex-grow-0 p-0'} minWidth={'5rem'}>
+          <Flex
+            justify="end"
+            align="center"
+            style={{height: POP_LEFT_COL_TOP_SPACER, overflow: 'visible'}}
+          >
             {!isCommunityMode && (
               <IconButton
                 onClick={toggleLockAllAreas}
@@ -157,11 +164,11 @@ export const PopulationPanel = () => {
             <Flex
               key={d.zone}
               direction={'row'}
-              gapY="1"
               gapX="1"
               align={'center'}
               className="p-0 m-0"
               justify={'between'}
+              style={{height: POP_ROW_HEIGHT}}
             >
               {!!showDistrictNumbers && (
                 <IconButton
@@ -212,7 +219,9 @@ export const PopulationPanel = () => {
         </Flex>
         <ParentSize
           style={{
-            height: populationData.length ? `${populationData.length * 38 + 76}px` : '200px',
+            height: populationData.length
+              ? `${populationData.length * POP_ROW_HEIGHT + POP_CHART_TOP_MARGIN + POP_CHART_BOTTOM_MARGIN}px`
+              : '200px',
             width: '100%',
           }}
         >
@@ -223,6 +232,12 @@ export const PopulationPanel = () => {
               data={populationData}
               idealPopulation={effectiveIdealPopulation}
               onBarSelect={selectCommunity}
+              margins={{
+                left: 5,
+                right: 20,
+                top: POP_CHART_TOP_MARGIN,
+                bottom: POP_CHART_BOTTOM_MARGIN,
+              }}
             />
           )}
         </ParentSize>

--- a/app/src/app/hooks/useDocumentWithSync.tsx
+++ b/app/src/app/hooks/useDocumentWithSync.tsx
@@ -99,7 +99,15 @@ export function useDocumentWithSync({
           setIsLoading(false);
         }
       } else if (isPublicPage) {
+        const isCommunityDocument = result.response.document.map_type === 'community';
         setMapDocument(result.response.document);
+        // District public views render via PublicSource (aggregated stats endpoint).
+        // Community public views have no equivalent stats path, so load individual
+        // community assignments here so CoiMap can color zones on the read-only page.
+        if (isCommunityDocument) {
+          const data = formatCoiAssignmentsFromDocument(result.response.assignments);
+          ingestCoiFromDocument(data, result.response.document);
+        }
         setIsLoading(false);
         setAppLoadingState('loaded');
       } else {

--- a/app/src/app/store/assignmentsStore.ts
+++ b/app/src/app/store/assignmentsStore.ts
@@ -96,7 +96,8 @@ export interface AssignmentsStore {
   handleRevert: (mapDocument: DocumentObject) => Promise<void>;
   handlePutAssignmentsConflict: (
     resolution: SyncConflictResolution,
-    conflict: SyncConflictInfo
+    conflict: SyncConflictInfo,
+    options?: Pick<ConflictResolutionOptions, 'onNavigate' | 'onComplete'>
   ) => void;
   /** Unified conflict resolution method that handles both save and load conflicts */
   resolveConflict: (
@@ -279,14 +280,29 @@ const resolveFork = async ({
 }: ConflictDependencies) => {
   setMapLock({isLocked: true, reason: 'Creating a new plan from local changes.'});
   try {
-    const createMapDocumentResponse = await createMapDocument(syncConflictInfo.serverDocument);
+    const createMapDocumentResponse = await createMapDocument({
+      districtr_map_slug: syncConflictInfo.serverDocument.districtr_map_slug,
+      map_type: syncConflictInfo.serverDocument.map_type,
+      copy_from_doc: syncConflictInfo.serverDocument.document_id,
+    });
     if (!createMapDocumentResponse.ok) {
       throw new DocumentCreationError('Failed to create map document from assignments on server');
     }
-    setMapDocument(createMapDocumentResponse.response);
+    // Carry over any local comments (saved or in-flight) onto the new doc so the
+    // fork reflects the user's latest state. comment_ids are stripped because the
+    // server just duplicated comments onto the new doc with fresh ids.
+    const localComments = (syncConflictInfo.localDocument.document_comments || []).map(c => ({
+      zone: c.zone,
+      text: c.text,
+    }));
+    const newDocWithLocalComments = {
+      ...createMapDocumentResponse.response,
+      document_comments: localComments,
+    };
+    setMapDocument(newDocWithLocalComments);
     const data = await loadLocalAssignments(syncConflictInfo.localDocument.document_id);
     const response = await putUpdateAssignmentsAndVerify({
-      mapDocument: createMapDocumentResponse.response,
+      mapDocument: newDocWithLocalComments,
       zoneAssignments: data.zoneAssignments,
       shatterIds: data.shatterIds,
       childToParent: data.childToParent,
@@ -298,7 +314,7 @@ const resolveFork = async ({
       );
     }
     const updatedDocument = {
-      ...createMapDocumentResponse.response,
+      ...newDocWithLocalComments,
       updated_at: response.response.updated_at,
     };
     setMapDocument(updatedDocument);
@@ -900,10 +916,12 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
   },
   handlePutAssignmentsConflict: async (
     resolution: SyncConflictResolution,
-    syncConflictInfo: SyncConflictInfo
+    syncConflictInfo: SyncConflictInfo,
+    options: Pick<ConflictResolutionOptions, 'onNavigate' | 'onComplete'> = {}
   ) => {
     await get().resolveConflict(resolution, syncConflictInfo, {
       context: ConflictContext.Save,
+      ...options,
     });
   },
 }));

--- a/app/src/app/store/coiAssignmentsStore.ts
+++ b/app/src/app/store/coiAssignmentsStore.ts
@@ -651,14 +651,29 @@ const coiResolveFork = async ({
 }: CoiConflictDependencies) => {
   setMapLock({isLocked: true, reason: 'Creating a new plan from your changes.'});
   try {
-    const createMapDocumentResponse = await createMapDocument(syncConflictInfo.serverDocument);
+    const createMapDocumentResponse = await createMapDocument({
+      districtr_map_slug: syncConflictInfo.serverDocument.districtr_map_slug,
+      map_type: syncConflictInfo.serverDocument.map_type,
+      copy_from_doc: syncConflictInfo.serverDocument.document_id,
+    });
     if (!createMapDocumentResponse.ok) {
       throw new DocumentCreationError('Failed to create map document from assignments on server');
     }
-    setMapDocument(createMapDocumentResponse.response);
+    // Carry over any local comments (saved or in-flight) onto the new doc so the
+    // fork reflects the user's latest state. comment_ids are stripped because the
+    // server just duplicated comments onto the new doc with fresh ids.
+    const localComments = (syncConflictInfo.localDocument.document_comments || []).map(c => ({
+      zone: c.zone,
+      text: c.text,
+    }));
+    const newDocWithLocalComments = {
+      ...createMapDocumentResponse.response,
+      document_comments: localComments,
+    };
+    setMapDocument(newDocWithLocalComments);
     const data = await loadLocalCoiAssignments(syncConflictInfo.localDocument.document_id);
     const response = await putUpdateCoiAssignmentsAndVerify({
-      mapDocument: createMapDocumentResponse.response,
+      mapDocument: newDocWithLocalComments,
       communityAssignments: data.communityAssignments,
       shatterIds: data.shatterIds,
       childToParent: data.childToParent,
@@ -670,7 +685,7 @@ const coiResolveFork = async ({
       );
     }
     const updatedDocument = {
-      ...createMapDocumentResponse.response,
+      ...newDocWithLocalComments,
       updated_at: response.response.updated_at,
     };
     setMapDocument(updatedDocument);

--- a/app/src/app/store/saveShareStore.ts
+++ b/app/src/app/store/saveShareStore.ts
@@ -43,7 +43,7 @@ export const useSaveShareStore = create<SaveShareStore>((set, get) => ({
     let shareableLink = new URL(`${window.location.origin}/${routePrefix}/${publicId}`);
     if (sharingMode === 'read') {
       // Do nothing!
-    } else if (sharingMode === 'edit' && password === null) {
+    } else if (sharingMode === 'edit' && !password) {
       // Direct link to edit page
       shareableLink.pathname = `/${routePrefix}/edit/${mapDocument.document_id}`;
     } else {

--- a/app/src/app/utils/api/apiHandlers/fetchDocument.ts
+++ b/app/src/app/utils/api/apiHandlers/fetchDocument.ts
@@ -65,11 +65,22 @@ export const fetchDocument = async (
   }
 
   if (isPublic) {
+    // Community public views don't have a district-unions stats path, so fetch
+    // raw assignments for them. District public views rely on PublicSource and
+    // don't need per-geoid assignments here.
+    const isCommunityPublic = remoteMetadata.response.map_type === 'community';
+    let assignments: Assignment[] = [];
+    if (isCommunityPublic) {
+      const remoteAssignments = await getAssignments(remoteMetadata.response);
+      if (remoteAssignments.ok) {
+        assignments = remoteAssignments.response;
+      }
+    }
     return {
       ok: true,
       response: {
         document: remoteMetadata.response,
-        assignments: [],
+        assignments,
         updateLocal: false,
       },
     };

--- a/app/src/app/utils/idb/idb.ts
+++ b/app/src/app/utils/idb/idb.ts
@@ -111,10 +111,7 @@ export class DocumentsDB extends Dexie {
     // If an unrelated document is already queued (e.g., user switched docs or
     // switched between district and COI mode), flush it first so the earlier
     // assignments aren't dropped.
-    if (
-      this.pendingUpdate &&
-      this.pendingUpdate.mapDocument?.document_id !== document_id
-    ) {
+    if (this.pendingUpdate && this.pendingUpdate.mapDocument?.document_id !== document_id) {
       await this.flushPendingUpdate();
     }
 

--- a/backend/app/_sanitize.py
+++ b/backend/app/_sanitize.py
@@ -4,17 +4,13 @@ from fastapi import (
     status,
     HTTPException,
 )
-from sqlmodel import Session, select, col
+from sqlmodel import Session, select
 from app.models import (
     AssignmentsMetadata,
     CommunityMetadata,
     Document,
     MAX_COMMUNITY_NAME_LENGTH,
     sanitize_community_name,
-)
-from app.comments.models import (
-    Comment,
-    DocumentComment as FormDocumentComment,
 )
 
 
@@ -101,78 +97,12 @@ def _normalize_community_metadata_list(
     return normalized_communities
 
 
-def _load_existing_community_comments(
-    session: Session, document_id: str
-) -> list[CommentDict]:
-    """
-    Load existing comments for a document from the database.
-
-    Args:
-        session (sqlmodel.Session): The SQLModel session to use for the database query.
-        document_id (str): The ID of the document for which to load comments. Expects a UUID string.
-
-    Returns:
-        A list of dictionaries representing the existing comments for the document, where each
-        dictionary contains the zone, text, and comment_id of a comment.
-    """
-    existing_comments = session.exec(
-        select(FormDocumentComment.zone, Comment.comment)
-        .join(Comment, col(Comment.id) == col(FormDocumentComment.comment_id))
-        .where(
-            FormDocumentComment.document_id == document_id,
-            col(FormDocumentComment.zone).is_not(None),
-        )
-    ).all()
-    return [
-        {"zone": comment.zone, "text": comment.comment, "comment_id": None}
-        for comment in existing_comments
-    ]
-
-
-def _validate_community_comment_coverage(
-    community_metadata_list: list[CommunityMetadata],
-    comments: list[CommentDict],
-) -> None:
-    """
-    Validate that each community has at least one non-empty comment associated with it.
-
-    Args:
-        community_metadata_list (list[CommunityMetadata]): A list of CommunityMetadata instances
-            representing the communities defined for the document.
-        comments (list[CommentDict]): A list of dictionaries representing the
-            comments associated with the document, where each dictionary contains the zone, text,
-            and comment_id of a comment.
-    """
-    commented_zones = {
-        comment["zone"]
-        for comment in comments
-        if comment.get("zone") is not None and str(comment.get("text") or "").strip()
-    }
-    missing_comments = [
-        community.name or f"Community {community.render_order_id}"
-        for community in community_metadata_list
-        if community.id not in commented_zones
-    ]
-
-    if missing_comments:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                "Each community must include at least one non-empty comment before "
-                f"saving. Missing comments for: {', '.join(missing_comments)}"
-            ),
-        )
-
-
 def _validate_community_save_payload(
     *,
-    document_id: str,
     metadata: AssignmentsMetadata | None,
-    incoming_comments: list[CommentDict] | None,
-    session: Session,
 ) -> list[CommunityMetadata] | None:
     """
-    Validate the community metadata and comments in the save payload for a community map.
+    Validate the community metadata in the save payload for a community map.
 
     Returns:
         list[CommunityMetadata]: the validated, normalized list the caller should persist
@@ -183,38 +113,22 @@ def _validate_community_save_payload(
     Raises:
         HTTPException(400): if the payload explicitly provides an empty community_metadata_list
             (community mode requires at least one community; to exit community mode, change
-            map_type instead), or if coverage/sanitization checks fail.
+            map_type instead), or if sanitization checks fail.
     """
     incoming_list_provided = (
         metadata is not None and metadata.community_metadata_list is not None
     )
 
-    if incoming_list_provided:
-        if len(metadata.community_metadata_list) == 0:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Community mode requires at least one community. "
-                    "To exit community mode, change map_type instead of sending an empty list."
-                ),
-            )
-        final_community_metadata_list = _normalize_community_metadata_list(
-            metadata.community_metadata_list
-        )
-    else:
-        final_community_metadata_list = _normalize_community_metadata_list(
-            _load_existing_community_metadata(session, document_id)
-        )
-
-    if not final_community_metadata_list:
-        # No stored metadata and none in the payload — nothing to validate.
+    if not incoming_list_provided:
         return None
 
-    final_comments = (
-        incoming_comments
-        if incoming_comments is not None
-        else _load_existing_community_comments(session, document_id)
-    )
-    _validate_community_comment_coverage(final_community_metadata_list, final_comments)
+    if len(metadata.community_metadata_list) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Community mode requires at least one community. "
+                "To exit community mode, change map_type instead of sending an empty list."
+            ),
+        )
 
-    return final_community_metadata_list if incoming_list_provided else None
+    return _normalize_community_metadata_list(metadata.community_metadata_list)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,10 @@ import app.cms.main as cms
 import app.comments.main as comments
 from app.comments.main import sync_district_comments, sync_community_comments
 from app.comments.models import DistrictCommentInput
+from app.comments.settings import (
+    DEFAULT_MAX_COMMENT_LENGTH,
+    DEFAULT_MAX_COMMENTS_PER_DISTRICT,
+)
 import app.contiguity.main as contiguity
 import app.save_share.main as save_share
 import app.thumbnails.main as thumbnails
@@ -506,6 +510,12 @@ async def create_document(
             col(Document.document_type).label("document_type"),
             col(DistrictrMap.statefps).label("statefps"),
             literal(MAX_COMMUNITY_NAME_LENGTH).label("community_name_length_limit"),
+            coalesce(
+                col(DistrictrMap.comment_length_limit), DEFAULT_MAX_COMMENT_LENGTH
+            ).label("comment_length_limit"),
+            coalesce(
+                col(DistrictrMap.comment_count_limit), DEFAULT_MAX_COMMENTS_PER_DISTRICT
+            ).label("comment_count_limit"),
             coalesce(total_assignments).label("inserted_assignments"),
             col(Document.map_metadata),
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,6 @@ from fastapi import (
     Query,
 )
 from typing import Annotated
-import re
 import botocore.exceptions
 from sqlalchemy.exc import (
     MultipleResultsFound,
@@ -22,7 +21,7 @@ import logging
 from sqlalchemy import bindparam
 from sqlmodel import ARRAY
 from datetime import datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 import sentry_sdk
 from app.assignments import (
     duplicate_document_assignments,
@@ -148,8 +147,6 @@ def update_timestamp(
 
 
 _PARTITION_TABLES = ("assignments", "community_assignments")
-# TODO: Can we use UUID library validation or check for ways to narrow the regex?
-_UUID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
 
 
 def _validate_partition_identifiers(document_id: str, table_name: str) -> None:
@@ -158,8 +155,10 @@ def _validate_partition_identifiers(document_id: str, table_name: str) -> None:
             f"Unsupported partition table: {table_name!r}. "
             f"Expected one of {_PARTITION_TABLES}."
         )
-    if not _UUID_RE.match(document_id):
-        raise ValueError(f"document_id must be a UUID; got {document_id!r}")
+    try:
+        UUID(document_id)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise ValueError(f"document_id must be a UUID; got {document_id!r}") from exc
 
 
 def create_document_partition(
@@ -353,10 +352,7 @@ async def create_document(
     # Reject copying across map_type boundaries: source and target must match, otherwise
     # assignments can't be carried over (community_assignments and assignments have
     # different shapes) and the copy would silently produce an empty doc.
-    if (
-        copied_document is not None
-        and copied_document.map_type != document_map_type
-    ):
+    if copied_document is not None and copied_document.map_type != document_map_type:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
@@ -653,8 +649,8 @@ async def update_assignments(
             f"num_communities={data.metadata.num_communities if data.metadata else None}"
         )
 
-    # Validate community payload (name sanitization, length, comment coverage)
-    # before any mutations. Returns normalized metadata list if provided, else None.
+    # Validate community payload (name sanitization, length) before any mutations.
+    # Returns normalized metadata list if provided, else None.
     validated_community_metadata = None
     if is_community_map:
         if VERBOSE_LOGGING:
@@ -663,10 +659,7 @@ async def update_assignments(
                 f"incoming_comments={comment_dicts}"
             )
         validated_community_metadata = _validate_community_save_payload(
-            document_id=document_id,
             metadata=data.metadata,
-            incoming_comments=comment_dicts,
-            session=session,
         )
         if VERBOSE_LOGGING:
             logger.info(
@@ -747,7 +740,10 @@ async def update_assignments(
                 zone_val = assignment[1] if len(assignment) > 1 else None
                 if is_community_map and zone_val is None:
                     zone_val = 0
-                if valid_community_ids is not None and zone_val not in valid_community_ids:
+                if (
+                    valid_community_ids is not None
+                    and zone_val not in valid_community_ids
+                ):
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail=(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -404,10 +404,6 @@ async def create_document(
     create_document_partition(session, document_id, "assignments")
     create_document_partition(session, document_id, "community_assignments")
 
-    created_document = get_document(
-        document_id=DocumentID(document_id=document_id), session=session
-    )
-
     total_assignments = 0
 
     if copied_document is not None:

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -512,9 +512,7 @@ def update_or_select_district_stats(
             ).fetchall()
 
             if column_info:
-                demo_cols = [
-                    _assert_safe_ident(row.column_name) for row in column_info
-                ]
+                demo_cols = [_assert_safe_ident(row.column_name) for row in column_info]
                 json_pairs = [f"'{col}', SUM(demo.{col})" for col in demo_cols]
                 demographic_json = f"json_build_object({', '.join(json_pairs)})"
 
@@ -600,13 +598,17 @@ def update_or_select_district_stats(
                         demographic_data,
                         updated_at
                 """)
-                unassigned_result = session.execute(
-                    unassigned_insert,
-                    {
-                        "document_id": document_id,
-                        "demographic_data": json_mod.dumps(unassigned_demo),
-                    },
-                ).mappings().first()
+                unassigned_result = (
+                    session.execute(
+                        unassigned_insert,
+                        {
+                            "document_id": document_id,
+                            "demographic_data": json_mod.dumps(unassigned_demo),
+                        },
+                    )
+                    .mappings()
+                    .first()
+                )
                 if unassigned_result:
                     returned_rows.append(
                         DistrictUnionsResponse.model_validate(unassigned_result)

--- a/backend/tests/test_community_mode.py
+++ b/backend/tests/test_community_mode.py
@@ -471,32 +471,13 @@ def test_community_name_longer_than_40_chars_is_rejected_before_mutation(
 
 
 @patch("app.comments.moderation.score_text", return_value=TEST_MODERATION_SCORE)
-def test_community_save_requires_comment_for_every_community_before_mutation(
+def test_community_save_allows_partial_comment_coverage(
     _mock_score_text, client, community_document_id: str
 ):
     initial_document = client.get(f"/api/document/{community_document_id}").json()
-    initial_metadata = [build_community_metadata_list()[0]]
-    initial_comments = build_community_comments(initial_metadata)
+    metadata = build_community_metadata_list()
 
-    initial_save = client.put(
-        "/api/assignments",
-        json={
-            "document_id": community_document_id,
-            "assignments": [["202090441022004", 1]],
-            "map_type": "community",
-            "metadata": {
-                "num_communities": 1,
-                "community_metadata_list": initial_metadata,
-            },
-            "comments": initial_comments,
-            "last_updated_at": initial_document["updated_at"],
-        },
-    )
-    assert initial_save.status_code == 200, initial_save.json()
-
-    saved_document = client.get(f"/api/document/{community_document_id}").json()
-    invalid_metadata = build_community_metadata_list()
-    rejected_response = client.put(
+    response = client.put(
         "/api/assignments",
         json={
             "document_id": community_document_id,
@@ -507,27 +488,49 @@ def test_community_save_requires_comment_for_every_community_before_mutation(
             "map_type": "community",
             "metadata": {
                 "num_communities": 2,
-                "community_metadata_list": invalid_metadata,
+                "community_metadata_list": metadata,
             },
             "comments": [{"text": "Only one community comment", "zone": 1}],
-            "last_updated_at": saved_document["updated_at"],
+            "last_updated_at": initial_document["updated_at"],
         },
     )
-    assert rejected_response.status_code == 400
-    assert (
-        "Each community must include at least one non-empty comment"
-        in rejected_response.json()["detail"]
-    )
+    assert response.status_code == 200, response.json()
 
     assert get_assignments_by_geoid(client, community_document_id) == {
-        "202090441022004": 1
+        "202090441022004": 1,
+        "202090428002008": 2,
     }
     final_document = client.get(f"/api/document/{community_document_id}").json()
-    assert final_document["community_metadata_list"] == initial_metadata
+    assert final_document["community_metadata_list"] == metadata
     assert {
         comment["zone"]: comment["text"]
         for comment in final_document["document_comments"]
-    } == {1: "Community focused on watershed issues"}
+    } == {1: "Only one community comment"}
+
+
+@patch("app.comments.moderation.score_text", return_value=TEST_MODERATION_SCORE)
+def test_community_save_allows_draw_without_any_comments(
+    _mock_score_text, client, community_document_id: str
+):
+    initial_document = client.get(f"/api/document/{community_document_id}").json()
+    metadata = build_community_metadata_list()
+
+    response = client.put(
+        "/api/assignments",
+        json={
+            "document_id": community_document_id,
+            "assignments": [["202090441022004", 1]],
+            "map_type": "community",
+            "metadata": {
+                "num_communities": 2,
+                "community_metadata_list": metadata,
+            },
+            "last_updated_at": initial_document["updated_at"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    final_document = client.get(f"/api/document/{community_document_id}").json()
+    assert final_document["community_metadata_list"] == metadata
 
 
 @patch("app.comments.moderation.score_text", return_value=TEST_MODERATION_SCORE)


### PR DESCRIPTION
## Description
- Loosen community-mode save requirements. Removed the per-community comment coverage check in _sanitize.py. Saves now succeed after drawing or commenting — no cross-coverage requirement. Kept empty-list rejection and name sanitization.
- Fix map not rendering after conflict resolution. SaveConflictModal now passes onNavigate (via useRouter().push
  instead of a no-op history.pushState) and onComplete (flips appLoadingState/mapRenderingState to loaded) through handlePutAssignmentsConflict. District store signature extended to forward these options; COI store already accepted them.
- Clone comments on fork; carry over local comments. Fork handlers (resolveFork, coiResolveFork) now call
  createMapDocument with copy_from_doc so the backend's existing duplicate_document_comments path runs.
  Local/in-flight comments from localDocument.document_comments are merged onto the new doc (stale comment_ids stripped) and flow through the normal comment-save path.
- COI public views now display. CoiMapPage detects isPublicPage via isUUID and passes it through to
  useDocumentWithSync and initSubs. fetchDocument now fetches community assignments for public COI maps (district public views still skip — they use PublicSource's aggregated stats). useDocumentWithSync ingests them so CoiMap can color zones on read-only pages.
- Shareable editable link copies the UUID link. saveShareStore.generateLink checked password === null, but
  password is initialized as '' and can never be null, so the empty-password branch was unreachable. Changed to
  !password so empty-password edits copy /edit/<uuid> instead of the password-protected public URL.
- Replace UUID regex with uuid.UUID() validation. Resolved a TODO at main.py:151 — swaps a loose
  ^[0-9a-fA-F-]{36}$ regex for stdlib UUID parsing, which enforces the canonical 8-4-4-4-12 layout. Dropped the
  now-unused re import.
- Fixes population bar spacing and text aligned -- subtle shift that had snuck around

## Reviewers
<!--- Tag relevant reviewers. Expect the primary reviewer to "own" the review for this PR, -->
<!--- and the secondary to assist if the primary reviewer is delayed. -->

- Primary: @fangge518 
- Secondary: @peterrrock2 

## Checklist
  - Added/Updated related documentation (if applicable).
  - Added/Updated related unit tests (if applicable). — Replaced
  test_community_save_requires_comment_for_every_community_before_mutation with
  test_community_save_allows_partial_comment_coverage and test_community_save_allows_draw_without_any_comments.
  Full backend suite: 184 passed.

## Screenshots (if applicable):
