### PR TITLE
Fix backend dev container port 5432 conflicts.

### DIFF
--- a/.devcontainer/backend/devcontainer.json
+++ b/.devcontainer/backend/devcontainer.json
@@ -5,15 +5,11 @@
   "runServices": ["backend", "db"],
   "workspaceFolder": "/districtr-backend",
   "shutdownAction": "stopCompose",
-  "forwardPorts": [8000, 5432],
+  "forwardPorts": [8000],
   "portsAttributes": {
     "8000": {
       "label": "Backend API",
       "onAutoForward": "notify"
-    },
-    "5432": {
-      "label": "PostgreSQL",
-      "onAutoForward": "silent"
     }
   },
   "postCreateCommand": "pip install -r requirements.txt",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
A minimal change to fix a problem that when using backend dev container, the host machine cannot access the database through port 5432.

### The problem
Docker compose's db specification already publishes port 5432 to the host. Backend's forwarding of backend's port 5432 (which is not db:5432) actually creates a conflict that prevents localhost:5432 from connecting to the database.

### The fix
Removing backend's forwarding of 5432 fix the problem.

## Reviewers
<!--- Tag relevant reviewers. Expect the primary reviewer to "own" the review for this PR, -->
<!--- and the secondary to assist if the primary reviewer is delayed. -->

- Primary:
- Secondary:

## Screenshots (if applicable):

## Review required
<!--- Given agentic engineer efforts, provide a summary of what aspects of the code and UI/UX require human validation. -->
