### PR TITLE
Fix the eguia computation to use parent layer instead

### DIFF
--- a/backend/app/evaluation/context.py
+++ b/backend/app/evaluation/context.py
@@ -212,6 +212,21 @@ class IdealsForEguia:
         and bare block paths (e.g. ``200510726002341`` → ``20051``).
         """
         safe_table = assert_safe_ident(gerrydb_table)
+
+        # Guard: skip if this is not a plain table (relkind='r'). Materialized views
+        # created by create_shatterable_gerrydb_view are UNION ALL of parent + child
+        # layers; aggregating them up to county level would double-count every row.
+        relkind = session.execute(
+            sqlalchemy.text(
+                "SELECT relkind FROM pg_class "
+                "JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid "
+                "WHERE relname = :name AND nspname = 'gerrydb'"
+            ),
+            {"name": gerrydb_table},
+        ).scalar_one_or_none()
+        if relkind != "r":
+            return
+
         demo_cols = get_gerrydb_numeric_cols(session, safe_table)
 
         if not demo_cols:

--- a/backend/app/evaluation/context.py
+++ b/backend/app/evaluation/context.py
@@ -18,7 +18,7 @@ import sqlmodel
 import sqlalchemy
 
 from app.evaluation.models import CountyDemographics
-from app.models import DistrictUnionsResponse
+from app.models import DistrictUnionsResponse, DistrictrMap, Document
 from app.utils import (
     update_or_select_district_stats,
     assert_safe_ident,
@@ -102,6 +102,33 @@ class DocumentEvaluationContext:
     def num_nonempty_districts(self) -> int:
         """Number of districts with an assigned zone."""
         return sum(1 for d in self.district_stats if d.zone is not None)
+
+    @cached_property
+    def _districtr_map(self) -> DistrictrMap | None:
+        """The DistrictrMap associated with this document."""
+        return self.session.exec(
+            sqlmodel.select(DistrictrMap)
+            .join(Document, Document.districtr_map_slug == DistrictrMap.districtr_map_slug)
+            .where(Document.document_id == self.document_id)
+        ).one_or_none()
+
+    @cached_property
+    def gerrydb_table(self) -> GerrydbTableName | None:
+        """The document's gerrydb table name (may be a shatterable UNION ALL view)."""
+        m = self._districtr_map
+        return GerrydbTableName(m.gerrydb_table_name) if m and m.gerrydb_table_name else None
+
+    @cached_property
+    def parent_layer(self) -> GerrydbTableName | None:
+        """The parent-layer gerrydb table name, used for county-level aggregation."""
+        m = self._districtr_map
+        return GerrydbTableName(m.parent_layer) if m else None
+
+    @cached_property
+    def child_layer(self) -> GerrydbTableName | None:
+        """The child (block-level) gerrydb table name, or `None` for non-shatterable maps."""
+        m = self._districtr_map
+        return GerrydbTableName(m.child_layer) if m and m.child_layer else None
 
 
 @dataclasses.dataclass

--- a/backend/app/evaluation/partisans.py
+++ b/backend/app/evaluation/partisans.py
@@ -6,16 +6,13 @@ of view: positive values indicate a Dem advantage, negative values a Rep advanta
 """
 
 from typing import Tuple, TypedDict
-import sqlmodel
 import numpy as np
 from app.evaluation.context import (
     DocumentEvaluationContext,
     Election,
     ElectionPartyKey,
-    GerrydbTableName,
     IDEALS_FOR_EGUIA,
 )
-from app.models import DistrictrMap, Document
 
 
 def _wasted_votes(party1_votes: int, party2_votes: int) -> Tuple[int, int]:
@@ -186,20 +183,6 @@ def disproportionality(context: DocumentEvaluationContext) -> dict[Election, flo
             result[col] = (context.dem_seats[col] / context.num_nonempty_districts) - dem_vote_share
     return result
 
-def _get_gerrydb_table(context: DocumentEvaluationContext) -> GerrydbTableName | None:
-    """Resolve the document's gerrydb table name. Returns `None` if unavailable."""
-    doc_row = context.session.exec(
-        sqlmodel.select(
-            Document,
-            DistrictrMap.gerrydb_table_name.label("gerrydb_table_name"),
-        )
-        .join(DistrictrMap, Document.districtr_map_slug == DistrictrMap.districtr_map_slug)
-        .where(Document.document_id == context.document_id)
-    ).one()
-
-    return GerrydbTableName(doc_row.gerrydb_table_name) if doc_row.gerrydb_table_name else None
-
-
 def eguia_county(context: DocumentEvaluationContext) -> dict[Election, float]:
     """Per-election Eguia score (Dem POV).
 
@@ -209,19 +192,21 @@ def eguia_county(context: DocumentEvaluationContext) -> dict[Election, float]:
     where the second term sums over counties c in the gerrydb table, p_c is county
     population, and 1{·} is an indicator. The benchmark is the Dem seat share that would
     emerge if districts were drawn at county granularity, weighted by population — a
-    "natural ideal" that respects existing political geography. Keyed by
-    gerrydb_table_name so multi-state regions (e.g. Navajo Nation) work correctly.
+    "natural ideal" that respects existing political geography.
 
     Reference:
         Eguia, Jon X. (2022). "A Measure of Partisan Advantage in Redistricting."
         Election Law Journal, 21(1): 84–103. Doi: https://doi.org/10.1089/elj.2020.0691
     """
 
-    gerrydb_table = _get_gerrydb_table(context)
-    if not gerrydb_table:
+    # Keyed by parent_layer rather than gerrydb_table_name, since the latter may integrate
+    # both the parent layer and the child layer (e.g. block-level vs. vtd-level), which
+    # which, when aggregated, will result in double the population counts.
+    parent_layer = context.parent_layer
+    if not parent_layer:
         return {}
 
-    ideals = IDEALS_FOR_EGUIA.get(gerrydb_table, context.session)
+    ideals = IDEALS_FOR_EGUIA.get(parent_layer, context.session)
     if not ideals:
         return {}
 

--- a/backend/app/evaluation/partisans.py
+++ b/backend/app/evaluation/partisans.py
@@ -200,8 +200,8 @@ def eguia_county(context: DocumentEvaluationContext) -> dict[Election, float]:
     """
 
     # Keyed by parent_layer rather than gerrydb_table_name, since the latter may integrate
-    # both the parent layer and the child layer (e.g. block-level vs. vtd-level), which
-    # which, when aggregated, will result in double the population counts.
+    # both the parent layer and the child layer (e.g. block-level vs. vtd-level), which, 
+    # when aggregated, will result in double population counts.
     parent_layer = context.parent_layer
     if not parent_layer:
         return {}

--- a/backend/tests/test_evaluation.py
+++ b/backend/tests/test_evaluation.py
@@ -380,15 +380,15 @@ def grid_district_context():
 
 @pytest.fixture
 def eguia_context():
-    """Exercises the full Eguia path: doc_row lookup → StateIdealsForEguia miss
+    """Exercises the full Eguia path: _districtr_map lookup → IdealsForEguia miss
     → _ensure_county_data (skipping populate) → _compute_ideal over mocked
     CountyDemographics rows."""
     # Force full cache+attempt miss so _compute_ideal actually runs
     IDEALS_FOR_EGUIA._cache.pop(_GRID_GERRYDB_TABLE, None)
     IDEALS_FOR_EGUIA._attempts.pop(_GRID_GERRYDB_TABLE, None)
 
-    doc_row = MagicMock()
-    doc_row.gerrydb_table_name = _GRID_GERRYDB_TABLE
+    map_mock = MagicMock()
+    map_mock.parent_layer = _GRID_GERRYDB_TABLE
 
     county_rows = [
         MagicMock(demographic_data=data)
@@ -396,12 +396,12 @@ def eguia_context():
     ]
 
     # Three sequential session.exec() calls during eguia():
-    #   1. doc_row lookup (_get_gerrydb_table)   → .one()   returns doc_row
-    #   2. _ensure_county_data check             → .first() returns truthy (skip populate)
-    #   3. _compute_ideal SELECT                 → .all()   returns county_rows
+    #   1. _districtr_map lookup          → .one_or_none() returns map_mock
+    #   2. _ensure_county_data check      → .first() returns truthy (skip populate)
+    #   3. _compute_ideal SELECT          → .all()   returns county_rows
     mock_session = MagicMock()
     mock_session.exec.side_effect = [
-        MagicMock(**{"one.return_value": doc_row}),
+        MagicMock(**{"one_or_none.return_value": map_mock}),
         MagicMock(**{"first.return_value": county_rows[0]}),
         MagicMock(**{"all.return_value": county_rows}),
     ]
@@ -451,12 +451,9 @@ def test_grid_eguia_matches_gerrychain(eguia_context):
 
 
 def test_eguia_returns_empty_when_no_gerrydb_table():
-    """eguia() returns {} when the document has no associated gerrydb table."""
-    doc_row = MagicMock()
-    doc_row.gerrydb_table_name = None
-
+    """eguia() returns {} when no DistrictrMap is found for the document."""
     mock_session = MagicMock()
-    mock_session.exec.return_value.one.return_value = doc_row
+    mock_session.exec.return_value.one_or_none.return_value = None
 
     ctx = _StubEvaluationContext(_GRID_DISTRICT_STATS)
     ctx.session = mock_session
@@ -467,11 +464,11 @@ def test_eguia_returns_empty_when_no_gerrydb_table():
 def test_eguia_returns_empty_once_attempts_exhausted():
     """eguia() returns {} once MAX_LOAD_ATTEMPTS is reached without a successful
     ideal computation (e.g. malformed gerrydb table missing total_pop_20)."""
-    doc_row = MagicMock()
-    doc_row.gerrydb_table_name = _GRID_GERRYDB_TABLE
+    map_mock = MagicMock()
+    map_mock.parent_layer = _GRID_GERRYDB_TABLE
 
     mock_session = MagicMock()
-    mock_session.exec.return_value.one.return_value = doc_row
+    mock_session.exec.return_value.one_or_none.return_value = map_mock
 
     ctx = _StubEvaluationContext(_GRID_DISTRICT_STATS)
     ctx.session = mock_session

--- a/backend/tests/test_evaluation.py
+++ b/backend/tests/test_evaluation.py
@@ -101,6 +101,8 @@ Suite 2 — seed=99, 8x8 grid, 8 counties (2x4 blocks), 8 districts (one row eac
 
 import math
 from datetime import datetime, timezone
+import sqlalchemy
+import sqlmodel
 from unittest.mock import MagicMock
 
 import pytest
@@ -108,6 +110,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from app.evaluation.context import DocumentEvaluationContext, GerrydbTableName, IDEALS_FOR_EGUIA, IdealsForEguia
+from app.evaluation.models import CountyDemographics
 from app.evaluation.partisans import (
     competitive_metrics,
     eguia_county,
@@ -117,7 +120,7 @@ from app.evaluation.partisans import (
     disproportionality,
     seats,
 )
-from app.models import DistrictUnionsResponse
+from app.models import DistrictUnionsResponse, DistrictrMap
 
 
 class _StubEvaluationContext(DocumentEvaluationContext):
@@ -299,6 +302,8 @@ _GRID_COUNTY_DEMOGRAPHICS = {
 }
 
 _GRID_GERRYDB_TABLE = "test_table"
+_KS_PARENT_LAYER = GerrydbTableName("ks_vtds_2020")
+_KS_SHATTERABLE_VIEW = GerrydbTableName("ks_vtds_blocks_shatterable")
 
 _GRID_EXPECTED_EGUIA = {
     "pres_2016": 0.12564661366031227,
@@ -551,6 +556,90 @@ def test_grid_competitiveness_matches_gerrychain(grid_district_context):
     result = competitive_metrics(grid_district_context)
     for col, expected in _GRID_EXPECTED_COMPETITIVENESS.items():
         assert result[col] == expected, f"{col}: {result[col]} != {expected}"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: eguia county aggregation must use parent_layer (VTD base
+# table), not the shatterable UNION ALL materialized view.
+# ---------------------------------------------------------------------------
+
+def test_populate_county_data_skips_materialized_view(
+    session, gerrydb_ks_ellis_geos_view
+):
+    """_populate_county_data must be a no-op for materialized views.
+
+    The shatterable gerrydb view (ks_ellis_geos) is a UNION ALL of VTD and
+    block rows. Inserting from it would double-count every county.
+    The pg_class.relkind guard must prevent any rows from being written.
+    """
+    shatterable_view = GerrydbTableName("ks_ellis_geos")
+
+    IdealsForEguia()._populate_county_data(shatterable_view, session)
+
+    rows = session.exec(
+        sqlmodel.select(CountyDemographics).where(
+            CountyDemographics.gerrydb_table_name == shatterable_view
+        )
+    ).all()
+    assert len(rows) == 0, (
+        "county_demographics must not be populated from a materialized view"
+    )
+
+
+def test_eguia_uses_parent_layer_not_shatterable_view(
+    session, gerrydb_ks_ellis_geos_view, ks_ellis_shatterable_districtr_map
+):
+    """Regression: county_demographics must be keyed by parent_layer (VTD base
+    table), never by the shatterable UNION ALL view. Aggregating the view would
+    double-count every county because both VTD and block rows resolve to the
+    same 5-char county GEOID."""
+    parent_layer = GerrydbTableName("ks_ellis_county_vtd")
+    shatterable_view = GerrydbTableName("ks_ellis_geos")
+
+    for key in [parent_layer, shatterable_view]:
+        IDEALS_FOR_EGUIA._cache.pop(key, None)
+        IDEALS_FOR_EGUIA._attempts.pop(key, None)
+
+    try:
+        ks_map = session.exec(
+            sqlmodel.select(DistrictrMap).where(
+                DistrictrMap.gerrydb_table_name == "ks_ellis_geos"
+            )
+        ).one()
+
+        ctx = _StubEvaluationContext([
+            DistrictUnionsResponse(
+                zone=1, geometry=None,
+                demographic_data={"pres_20_dem": 100, "pres_20_rep": 200},
+                updated_at=_now,
+            )
+        ])
+        ctx.session = session
+        ctx._districtr_map = ks_map
+
+        eguia_county(ctx)
+
+        parent_rows = session.exec(
+            sqlmodel.select(CountyDemographics).where(
+                CountyDemographics.gerrydb_table_name == parent_layer
+            )
+        ).all()
+        assert len(parent_rows) > 0, (
+            "county_demographics must be populated from parent_layer (VTD base table)"
+        )
+
+        view_rows = session.exec(
+            sqlmodel.select(CountyDemographics).where(
+                CountyDemographics.gerrydb_table_name == shatterable_view
+            )
+        ).all()
+        assert len(view_rows) == 0, (
+            "county_demographics must not be populated from a materialized view"
+        )
+    finally:
+        for key in [parent_layer, shatterable_view]:
+            IDEALS_FOR_EGUIA._cache.pop(key, None)
+            IDEALS_FOR_EGUIA._attempts.pop(key, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Currently, eguia computation use the `gerrydb_table_name` from the `districtrmap` table for aggregating county demographics. For shatterable map which integrates the parent and the child layers, it will result in double the population counts. This fix switch to used the parent layer for county demographic instead.

## Reviewers
<!--- Tag relevant reviewers. Expect the primary reviewer to "own" the review for this PR, -->
<!--- and the secondary to assist if the primary reviewer is delayed. -->

- Primary: @peterrrock2 

