### PR TITLE
Add timeouts for backend db requests. Log long requests.

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,3 +1,4 @@
+from sqlalchemy import event
 from sqlmodel import create_engine, Session
 
 from app.core.config import settings
@@ -8,6 +9,17 @@ engine = create_engine(
     pool_pre_ping=True,
     pool_recycle=3600,
 )
+
+
+@event.listens_for(engine, "connect")
+def set_db_timeouts(dbapi_conn, _):
+    # Prevent runaway queries from holding pool connections indefinitely.
+    # lock_timeout: fail fast if waiting for a row lock (e.g. concurrent saves on same document).
+    # statement_timeout: hard ceiling on any single statement.
+    cursor = dbapi_conn.cursor()
+    cursor.execute("SET lock_timeout = '15s'")
+    cursor.execute("SET statement_timeout = '120s'")
+    cursor.close()
 
 
 def get_session():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,15 @@
 from fastapi import (
     FastAPI,
+    Request,
     status,
     Depends,
     HTTPException,
     Query,
 )
+from fastapi.responses import JSONResponse
 from typing import Annotated, Any
 import psutil
+import time
 
 import botocore.exceptions
 from sqlalchemy.exc import (
@@ -14,6 +17,7 @@ from sqlalchemy.exc import (
     NoResultFound,
     DataError,
     IntegrityError,
+    OperationalError,
 )
 from sqlalchemy import text
 from sqlalchemy.types import Integer
@@ -143,6 +147,28 @@ if settings.BACKEND_CORS_ORIGINS:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+
+@app.middleware("http")
+async def log_slow_requests(request: Request, call_next):
+    start = time.monotonic()
+    response = await call_next(request)
+    duration = time.monotonic() - start
+    if duration > 30:
+        logger.warning(
+            "SLOW %s %s %s %.1fs", request.method, request.url.path, response.status_code, duration
+        )
+    return response
+
+
+@app.exception_handler(OperationalError)
+async def db_operational_error_handler(request: Request, exc: OperationalError):
+    msg = str(exc.orig) if exc.orig else str(exc)
+    if "statement timeout" in msg or "lock timeout" in msg:
+        logger.warning("DB TIMEOUT %s %s — %s", request.method, request.url.path, msg)
+        return JSONResponse(status_code=504, content={"detail": "Database timeout"})
+    logger.error("DB ERROR %s %s — %s", request.method, request.url.path, msg)
+    return JSONResponse(status_code=500, content={"detail": "Database error"})
 
 
 def update_timestamp(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from sqlmodel import ARRAY
 from datetime import datetime
 from uuid import UUID, uuid4
 import sentry_sdk
+from prometheus_fastapi_instrumentator import Instrumentator
 from app.assignments import (
     duplicate_document_assignments,
     duplicate_document_community_assignments,
@@ -121,6 +122,10 @@ app.include_router(cms.router)
 app.include_router(comments.router)
 app.include_router(save_share.router)
 app.include_router(thumbnails.router)
+
+Instrumentator(
+    excluded_handlers=["/metrics", "/_debug/cache"],
+).instrument(app).expose(app, include_in_schema=False)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -28,6 +28,10 @@ primary_region = 'ewr'
   min_machines_running = 1
   processes = ['app']
 
+[metrics]
+  port = 8080
+  path = "/metrics"
+
 [[vm]]
   memory = '8gb'
   cpu_kind = 'shared'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -132,6 +132,9 @@ platformdirs==4.3.6
 pluggy==1.5.0
     # via pytest
 pre-commit==4.1.0
+prometheus-client==0.21.1
+    # via prometheus-fastapi-instrumentator
+prometheus-fastapi-instrumentator==7.0.0
 psutil==5.9.8
     # via fastapi-utils
 psycopg==3.1.18


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Occationally the API server has long hanging requests, blocking all the other requests from creating new db connection. This fix introduces db timeouts so that these requests won't run indefinitely. Also logs the long running requests for future diagnosis.

## Reviewers
<!--- Tag relevant reviewers. Expect the primary reviewer to "own" the review for this PR, -->
<!--- and the secondary to assist if the primary reviewer is delayed. -->

- Primary: @nofurtherinformation 
- Secondary:

