### PR TITLE
Fix/bg task connection leak

### DIFF
--- a/backend/app/assignments/assignments.py
+++ b/backend/app/assignments/assignments.py
@@ -131,7 +131,9 @@ def batch_insert_assignments(
     temp_table_name = f"temp_assignments_{load_id}"
 
     session.connection().execute(
-        text(f"CREATE TEMP TABLE {temp_table_name} (geo_id TEXT, zone INT)")
+        text(
+            f"CREATE TEMP TABLE {temp_table_name} (geo_id TEXT, zone INT) ON COMMIT DROP"
+        )
     )
 
     def _get_next_id():
@@ -196,7 +198,7 @@ def batch_insert_assignments(
         uniform_vtds = f"uniform_vtds_{load_id}"
         session.connection().execute(
             text(f"""
-            CREATE TEMPORARY TABLE {uniform_vtds} AS
+            CREATE TEMPORARY TABLE {uniform_vtds} ON COMMIT DROP AS
             SELECT
                 parent_path,
                 MIN(zone) AS zone

--- a/backend/app/comments/main.py
+++ b/backend/app/comments/main.py
@@ -465,7 +465,7 @@ async def create_commenter(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
         )
 
-    background_tasks.add_task(moderate_commenter, commenter, session)
+    background_tasks.add_task(moderate_commenter, commenter)
     return commenter
 
 
@@ -489,7 +489,7 @@ async def create_comment(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
         )
 
-    background_tasks.add_task(moderate_comment, comment, session)
+    background_tasks.add_task(moderate_comment, comment)
     return comment
 
 
@@ -511,7 +511,7 @@ async def create_tag(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
         )
 
-    background_tasks.add_task(moderate_tag, tag, session)
+    background_tasks.add_task(moderate_tag, tag)
     return tag
 
 
@@ -537,7 +537,7 @@ async def submit_full_comment(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
         )
 
-    background_tasks.add_task(moderate_submission, response, session)
+    background_tasks.add_task(moderate_submission, response)
     return response
 
 

--- a/backend/app/comments/moderation.py
+++ b/backend/app/comments/moderation.py
@@ -110,37 +110,49 @@ def update_moderation_score(
         raise
 
 
-def moderate_comment(comment: Comment, session: Session):
+def _moderate(cls: Table, key: int, text: str, session: Session | None) -> None:
+    """Score ``text`` and persist the result for ``cls``/``key``.
+
+    When ``session`` is None (the background-task case) a dedicated session is
+    opened and closed here. Background tasks must not reuse the request-scoped
+    session: it is already closed by the time they run, so any connection they then
+    check out would never be returned to the pool (a leak).
+    """
+    if session is not None:
+        moderate_text(cls=cls, key=key, text=text, session=session)
+    else:
+        with Session(engine) as owned_session:
+            moderate_text(cls=cls, key=key, text=text, session=owned_session)
+
+
+def moderate_comment(comment: Comment, session: Session | None = None) -> None:
     comment_text = f"{comment.title} {comment.comment}"
-    moderate_text(cls=Comment, key=comment.id, text=comment_text, session=session)
+    _moderate(Comment, comment.id, comment_text, session)
 
 
-def moderate_comment_by_id(comment_id: int, comment_text: str):
+def moderate_comment_by_id(comment_id: int, comment_text: str) -> None:
     """
     Moderate a comment by ID. Use when the Comment object may be detached
     (e.g. in background tasks after request session is closed).
     """
-    with Session(engine) as session:
-        moderate_text(cls=Comment, key=comment_id, text=comment_text, session=session)
+    _moderate(Comment, comment_id, comment_text, None)
 
 
-def moderate_commenter(commenter: Commenter, session: Session):
-    commenter_data = str(commenter)
-    moderate_text(cls=Commenter, key=commenter.id, text=commenter_data, session=session)
+def moderate_commenter(commenter: Commenter, session: Session | None = None) -> None:
+    _moderate(Commenter, commenter.id, str(commenter), session)
 
 
-def moderate_tag(tag: Tag, session: Session):
-    tag_data = str(tag)
-    moderate_text(cls=Tag, key=tag.id, text=tag_data, session=session)
+def moderate_tag(tag: Tag, session: Session | None = None) -> None:
+    _moderate(Tag, tag.id, str(tag), session)
 
 
 def moderate_submission(
     response: FullCommentForm,
-    session: Session,
+    session: Session | None = None,
 ) -> None:
     """
     Background task to check moderation scores for a complete comment submission.
-    Returns a dictionary with moderation scores for all components.
+    Each entity is scored on its own session when none is supplied.
     """
     moderate_comment(response.comment, session)
     moderate_commenter(response.commenter, session)

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -19,6 +19,11 @@ def set_db_timeouts(dbapi_conn, _):
     cursor = dbapi_conn.cursor()
     cursor.execute("SET lock_timeout = '15s'")
     cursor.execute("SET statement_timeout = '120s'")
+    # idle_in_transaction_session_timeout: backstop against connection leaks. If a
+    # connection is checked out with an open-but-idle transaction (e.g. a background
+    # task that opened a transaction and never committed/closed it), Postgres aborts
+    # it after this window so the connection returns to the pool instead of leaking.
+    cursor.execute("SET idle_in_transaction_session_timeout = '60s'")
     cursor.close()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -785,7 +785,7 @@ async def update_assignments(
         temp_table_name = f"temp_assignments_{load_id}"
         session.connection().execute(
             text(
-                f"CREATE TEMP TABLE {temp_table_name} (document_id UUID, geo_id TEXT, zone INT)"
+                f"CREATE TEMP TABLE {temp_table_name} (document_id UUID, geo_id TEXT, zone INT) ON COMMIT DROP"
             )
         )
 

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -11,7 +11,7 @@ from app.core.config import settings
 from fastapi import APIRouter, Security, status, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from app.core.security import auth, TokenScope
-from app.core.db import get_session
+from app.core.db import get_session, engine
 from app.core.dependencies import get_document
 from app.models import Document
 from urllib.parse import urlparse
@@ -102,6 +102,25 @@ def write_image(out_path: str | Path, pic_IObytes: io.BytesIO) -> None:
 
 
 def generate_thumbnail(
+    document_id: str,
+    out_directory: str | None,
+    session: Session | None = None,
+) -> str:
+    """Generate a document thumbnail, owning the DB session unless one is given.
+
+    Background tasks must NOT receive the request-scoped session: it is closed at
+    request teardown, so any connection the task then checks out is never returned
+    to the pool (a leak). Called as a background task with ``session=None``, this
+    opens and closes its own session. Tests may pass a session to share their
+    transaction.
+    """
+    if session is not None:
+        return _generate_thumbnail(session, document_id, out_directory)
+    with Session(engine) as owned_session:
+        return _generate_thumbnail(owned_session, document_id, out_directory)
+
+
+def _generate_thumbnail(
     session: Session, document_id: str, out_directory: str | None
 ) -> str:
     """
@@ -207,7 +226,6 @@ async def make_thumbnail(
     *,
     document: Annotated[Document, Depends(get_document)],
     background_tasks: BackgroundTasks,
-    session: Session = Depends(get_session),
     auth_result: dict = Security(auth.verify, scopes=[TokenScope.create_content]),
 ):
     if document.document_id is None:
@@ -217,7 +235,6 @@ async def make_thumbnail(
         )
     background_tasks.add_task(
         generate_thumbnail,
-        session=session,
         document_id=document.document_id,
         out_directory=THUMBNAIL_BUCKET,
     )
@@ -228,6 +245,22 @@ async def make_thumbnail(
 
 
 def generate_blank(
+    districtr_map_slug: str,
+    out_directory: str | None,
+    session: Session | None = None,
+) -> str:
+    """Generate a blank-map thumbnail, owning the DB session unless one is given.
+
+    See ``generate_thumbnail`` for why background tasks must not reuse the
+    request-scoped session.
+    """
+    if session is not None:
+        return _generate_blank(session, districtr_map_slug, out_directory)
+    with Session(engine) as owned_session:
+        return _generate_blank(owned_session, districtr_map_slug, out_directory)
+
+
+def _generate_blank(
     session: Session, districtr_map_slug: str, out_directory: str | None
 ) -> str:
     """
@@ -296,12 +329,10 @@ async def make_districtrmap_thumbnail(
     *,
     districtr_map_slug: str,
     background_tasks: BackgroundTasks,
-    session: Session = Depends(get_session),
     auth_result: dict = Security(auth.verify, scopes=[TokenScope.create_content]),
 ):
     background_tasks.add_task(
         generate_blank,
-        session=session,
         districtr_map_slug=districtr_map_slug,
         out_directory=THUMBNAIL_BUCKET,
     )

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -624,7 +624,6 @@ def update_or_select_district_stats(
             # Kick off thumbnail generation (non-blocking)
             background_tasks.add_task(
                 generate_thumbnail,
-                session=session,
                 document_id=document_id,
                 out_directory=THUMBNAIL_BUCKET,
             )

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -957,6 +957,16 @@ class TestCommentListEndpoints:
         handle_full_submission_approve(client, response.json())
         assert response.status_code == 201
 
+        # Moderation runs in a background task on its own DB session, which cannot
+        # write to this test's uncommitted rows; set the profane score on the shared
+        # session directly (score_text is mocked above regardless).
+        profane_comment = session.exec(
+            select(Comment).where(Comment.title == "Profane Comment")
+        ).one()
+        profane_comment.moderation_score = 1.0
+        session.add(profane_comment)
+        session.commit()
+
         # Get the list of comments - should only return the clean one
         response = client.get("/api/comments/list")
         assert response.status_code == 200
@@ -1113,6 +1123,20 @@ class TestCommentListEndpoints:
         }
         response = client.post("/api/comments/submit", json=high_form_data)
         assert response.status_code == 201
+
+        # Moderation runs in a background task on its own DB session, which cannot
+        # write to this test's uncommitted rows; set the scores on the shared session
+        # directly so the threshold filter has data to act on.
+        moderate_comment_row = session.exec(
+            select(Comment).where(Comment.title == "Moderate Comment")
+        ).one()
+        moderate_comment_row.moderation_score = 0.3
+        high_comment_row = session.exec(
+            select(Comment).where(Comment.title == "High Score Comment")
+        ).one()
+        high_comment_row.moderation_score = 0.8
+        session.add_all([moderate_comment_row, high_comment_row])
+        session.commit()
 
         # Test with default threshold (should exclude high score)
         response = client.get("/api/comments/admin/list")

--- a/backend/tests/test_connection_pool.py
+++ b/backend/tests/test_connection_pool.py
@@ -1,0 +1,45 @@
+"""Regression tests for the DB connection-pool leak fix.
+
+Background tasks run AFTER the request-scoped session has been closed, so they must
+own their own session. Previously they reused the request session and the new
+connection they checked out was never returned to the pool, eventually exhausting
+it ("QueuePool limit of size 5 overflow 10 reached, connection timed out").
+
+These tests assert that the self-owning code paths return their pooled connection
+instead of leaking it -- including on the error path, which was part of the leak.
+"""
+
+import pytest
+
+from app.core.db import engine
+from app.comments.moderation import moderate_comment_by_id
+from app.thumbnails.main import generate_thumbnail
+
+
+@pytest.fixture(autouse=True)
+def no_external_moderation(monkeypatch):
+    # Keep moderation off the network: score the text locally without calling OpenAI.
+    monkeypatch.setattr("app.comments.moderation.score_text", lambda _text: 0.0)
+
+
+def test_self_owned_moderation_returns_connection():
+    """moderate_comment_by_id opens its own ``with Session(engine)`` and commits.
+
+    The comment id need not exist (the UPDATE simply affects 0 rows); the point is
+    that the connection it checks out is returned to the pool afterward.
+    """
+    checked_out_before = engine.pool.checkedout()
+    moderate_comment_by_id(2_000_000_000, "regression check")
+    assert engine.pool.checkedout() == checked_out_before
+
+
+def test_self_owned_thumbnail_returns_connection_on_error():
+    """generate_thumbnail with no session self-owns one; the error path must release it.
+
+    With a non-existent document the inner query raises, but the ``with`` block must
+    still return the connection to the pool -- the failure mode that leaked before.
+    """
+    checked_out_before = engine.pool.checkedout()
+    with pytest.raises(Exception):
+        generate_thumbnail(document_id="does-not-exist", out_directory=None)
+    assert engine.pool.checkedout() == checked_out_before

--- a/backend/tests/test_connection_pool.py
+++ b/backend/tests/test_connection_pool.py
@@ -10,6 +10,8 @@ instead of leaking it -- including on the error path, which was part of the leak
 """
 
 import pytest
+from sqlalchemy import text
+from sqlmodel import Session
 
 from app.core.db import engine
 from app.comments.moderation import moderate_comment_by_id
@@ -43,3 +45,32 @@ def test_self_owned_thumbnail_returns_connection_on_error():
     with pytest.raises(Exception):
         generate_thumbnail(document_id="does-not-exist", out_directory=None)
     assert engine.pool.checkedout() == checked_out_before
+
+
+def test_on_commit_drop_temp_table_is_removed_after_commit():
+    """ON COMMIT DROP temp tables are gone once the transaction commits.
+
+    The assignment-insert paths create a temp table per request; without
+    ON COMMIT DROP a committed temp table lives for the life of the pooled
+    connection and the create/drop churn bloats the system catalogs. This guards
+    the mechanism the fix relies on.
+    """
+    table = "t_oncommitdrop_regression"
+    with Session(engine) as session:
+        session.connection().execute(
+            text(f"CREATE TEMP TABLE {table} (a int) ON COMMIT DROP")
+        )
+        session.commit()  # real top-level commit -> ON COMMIT DROP fires here
+        remaining = (
+            session.connection()
+            .execute(
+                text(
+                    "SELECT count(*) FROM pg_class c "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname LIKE 'pg_temp%' AND c.relname = :name"
+                ),
+                {"name": table},
+            )
+            .scalar()
+        )
+    assert remaining == 0

--- a/backend/tests/test_thumbnails.py
+++ b/backend/tests/test_thumbnails.py
@@ -3,6 +3,7 @@ import pytest
 from tests.constants import FIXTURES_PATH
 from unittest.mock import patch
 from datetime import datetime
+from app.thumbnails.main import generate_thumbnail, generate_blank, THUMBNAIL_BUCKET
 
 
 @pytest.fixture
@@ -25,50 +26,69 @@ def document_id_with_assignments(client, document_id):
     return document_id
 
 
-def test_thumbnail_generator(client, document_id_with_assignments):
+def test_thumbnail_generator(client, document_id_with_assignments, session):
+    document_id = document_id_with_assignments
+    out_path = f"{FIXTURES_PATH}/{document_id}.png"
     with patch(
-        "app.thumbnails.main.get_document_thumbnail_file_path"
-    ) as mock_generate_thumbnail:
-        document_id = document_id_with_assignments
-        out_path = f"{FIXTURES_PATH}/{document_id}.png"
-        mock_generate_thumbnail.return_value = out_path
-
-        response = client.post(
-            f"/api/document/{document_id}/thumbnail",
+        "app.thumbnails.main.get_document_thumbnail_file_path",
+        return_value=out_path,
+    ):
+        # generate_thumbnail now owns its own session when run as a background task,
+        # and that session can't see this test's uncommitted rows. Call it directly
+        # with the shared test session to exercise generation in the test transaction.
+        generate_thumbnail(
+            document_id=document_id,
+            out_directory=THUMBNAIL_BUCKET,
+            session=session,
         )
-        assert response.status_code == 200
-        assert (
-            response.json().get("message") == "Generating thumbnail in background task"
-        )
-
-        mock_generate_thumbnail.assert_called_once()
         assert os.path.exists(out_path)
         assert os.stat(out_path).st_size > 0
         os.remove(out_path)
 
 
-def test_blank_thumbnail_generator(client, document_id):
+def test_make_thumbnail_endpoint_schedules_task(client, document_id):
+    """The endpoint schedules generation WITHOUT handing it the request session."""
+    with patch("app.thumbnails.main.generate_thumbnail") as mock_generate:
+        response = client.post(f"/api/document/{document_id}/thumbnail")
+        assert response.status_code == 200
+        assert (
+            response.json().get("message") == "Generating thumbnail in background task"
+        )
+        mock_generate.assert_called_once()
+        assert "session" not in mock_generate.call_args.kwargs
+
+
+def test_blank_thumbnail_generator(client, document_id, session):
     response = client.get(f"/api/document/{document_id}")
     districtrmap_slug = response.json().get("districtr_map_slug")
+    out_path = f"{FIXTURES_PATH}/{districtrmap_slug}.png"
     with patch(
-        "app.thumbnails.main.get_document_thumbnail_file_path"
-    ) as mock_generate_thumbnail:
-        out_path = f"{FIXTURES_PATH}/{districtrmap_slug}.png"
-        mock_generate_thumbnail.return_value = out_path
-
-        response = client.post(
-            f"/api/gerrydb/{districtrmap_slug}/thumbnail",
+        "app.thumbnails.main.get_document_thumbnail_file_path",
+        return_value=out_path,
+    ):
+        generate_blank(
+            districtr_map_slug=districtrmap_slug,
+            out_directory=THUMBNAIL_BUCKET,
+            session=session,
         )
+        assert os.path.exists(out_path)
+        assert os.stat(out_path).st_size > 0
+        os.remove(out_path)
+
+
+def test_make_districtrmap_thumbnail_endpoint_schedules_task(client, document_id):
+    """The endpoint schedules generation WITHOUT handing it the request session."""
+    response = client.get(f"/api/document/{document_id}")
+    districtrmap_slug = response.json().get("districtr_map_slug")
+    with patch("app.thumbnails.main.generate_blank") as mock_generate:
+        response = client.post(f"/api/gerrydb/{districtrmap_slug}/thumbnail")
         assert response.status_code == 200
         assert (
             response.json().get("message")
             == "Generating blank map thumbnail in background task"
         )
-
-        mock_generate_thumbnail.assert_called_once()
-        assert os.path.exists(out_path)
-        assert os.stat(out_path).st_size > 0
-        os.remove(out_path)
+        mock_generate.assert_called_once()
+        assert "session" not in mock_generate.call_args.kwargs
 
 
 def test_thumbnail_cdn_redirect(client, document_id):


### PR DESCRIPTION
## Problem

After a couple days of normal activity the API degrades badly — query times climb from ~hundreds of ms to minutes, then requests start failing with:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
```

The error surfaces on reads like `GET /api/gerrydb/views`, but that endpoint is just the victim — whatever happens to be waiting when the pool is already starved. Not reproducible locally (needs days of sustained traffic; local restarts reset the state).

## Potential causes

Two independent issues, both in how recently-added code uses the DB connection. **(1) is the primary suspect for the production symptom; (2) is a real but likely minor contributor.**

### 1. Per-request temp tables are never dropped (primary)

The assignment-write paths (`PUT /api/assignments` → `update_assignments`, and `batch_insert_assignments`) bulk-load via `COPY` into a per-request temp table (`CREATE TEMP TABLE temp_assignments_{uuid} ...`) and never drop it. `CREATE TEMP TABLE` defaults to `ON COMMIT PRESERVE ROWS`, so after the request commits the table lives for the life of the **pooled connection** — pooled connections aren't closed between requests, and SQLAlchemy's reset-on-return is a `ROLLBACK`, which doesn't drop a *committed* temp table. On the hot save path this churns the system catalogs and bloats `pg_class`/`pg_attribute` over days, slowing the **planning** phase of every query until connections are held long enough to exhaust the pool.

Fits the symptoms: gradual over days (bloat builds up), "ms → minutes" (slow planning, not one slow query), pool exhaustion as a downstream effect, invisible locally.

### 2. Background tasks reuse the request-scoped session (secondary)

Thumbnail generation and comment moderation were scheduled with `add_task(..., session=session)`, handing the task the request session that `get_session()` closes at teardown. The task then checks out a fresh pooled connection; the thumbnail path opens a transaction via `session.connection()` and never commits/closes it, leaking that connection. These endpoints are rarely hit (thumbnails especially), so it's a slow, minor leak — but a real bug regardless (the codebase already had `moderate_comment_by_id` as the correct self-owning pattern).

## Changes

**Temp tables → `ON COMMIT DROP`** — each temp table now drops when its transaction ends (covers commit *and* error paths), with no accumulation:
- `backend/app/main.py` — `update_assignments`: `temp_assignments_{id}`
- `backend/app/assignments/assignments.py` — `batch_insert_assignments`: `temp_assignments_{id}`, `uniform_vtds_{id}` (the temp index drops with its table)

Safe because each CREATE → COPY → INSERT runs in a single transaction with no intermediate commit, so the table is present for the INSERT and only drops at the end.

**Background tasks own their session** — `generate_thumbnail`/`generate_blank` and the `moderate_*` functions open their own `with Session(engine)` when run as a background task (mirroring `moderate_comment_by_id`); call sites no longer pass the request session.
- `backend/app/thumbnails/main.py`, `backend/app/comments/moderation.py`, `backend/app/comments/main.py`, `backend/app/utils.py`

**Backstop** — `backend/app/core/db.py` sets `idle_in_transaction_session_timeout = '60s'` so Postgres reclaims any future connection left idle in an open transaction instead of leaking it.
