### PR TITLE
Bugfix for shatter + click paint issue

### DIFF
--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -311,6 +311,15 @@ export const useMapStore = createWithDevWrapperAndSubscribe<MapStore>('Districtr
       const {setMapOptions, mapMode} = useMapControlsStore.getState();
       const focusedParentId = focusFeatures?.[0]?.id?.toString();
 
+      // Commit any paint still staged in accumulatedAssignments before healing:
+      // the heal below reads zoneAssignments and discards the staged map, so an
+      // unflushed click-paint would otherwise be reverted and lost.
+      if (mapMode === MAP_MODES.COI) {
+        useCoiAssignmentsStore.getState().ingestAccumulatedAssignments();
+      } else {
+        useAssignmentsStore.getState().ingestAccumulatedAssignments();
+      }
+
       set({
         captiveIds: new Set<string>(),
         focusFeatures: [],

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -110,7 +110,7 @@ export const handleFeatureSelection = (
 ) => {
   const {activeTool, selectedZone, setIsPainting} = useMapControlsStore.getState();
   if (MUTATION_TOOLS.includes(activeTool) && !canMutateAssignments()) return;
-  const {mutateZoneAssignments} = useAssignmentsStore.getState();
+  const {mutateZoneAssignments, ingestAccumulatedAssignments} = useAssignmentsStore.getState();
   switch (activeTool) {
     case ACTIVE_TOOLS.SHATTER:
       const documentId = mapStore.mapDocument?.document_id;
@@ -128,6 +128,9 @@ export const handleFeatureSelection = (
           activeTool === ACTIVE_TOOLS.BRUSH ? selectedZone : null
         );
         setIsPainting(false);
+        // Click-paints run after mouseup has already flipped isPainting to false,
+        // so the isPainting-subscription flush never fires for them — ingest directly.
+        ingestAccumulatedAssignments();
       }
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
- **Bug:** After breaking/shattering a parent unit, a single-click paint (no drag) on a child unit would visually apply but never log: no undo entry was recorded, clicking "return to districts" healed the parent and reverted the paint, and saving did not persist the change.
- **Root cause:** Paints are staged in `accumulatedAssignments` and only committed to `zoneAssignments` by `ingestAccumulatedAssignments()`, which is triggered by the `isPainting` `true → false` transition (`subscriptions.tsx`). For a stationary click the DOM order is `mousedown → mouseup → click`, so the flush fires on `mouseup` — *before* the `click` handler has accumulated anything — and the `setIsPainting(false)` inside `handleFeatureSelection` is a no-op (already `false`), so the staged paint is never ingested. Because `handleShatter` pauses the temporal recorder and the resume lives in the ingest, the paint also never reached undo history. `exitBlockView` then healed from stale `zoneAssignments` (all children still in the parent's original zone) and cleared `accumulatedAssignments`, destroying the only record of the paint. Drag-paints were unaffected since they accumulate during `mousemove` while `isPainting` is still `true` — hence the intermittent repro.
- **Fix (`mapEvents.ts`):** `handleFeatureSelection` now calls `ingestAccumulatedAssignments()` directly after a click-paint, mirroring what COI mode already does in `handleCoiFeatureSelection` (`CoiMapEvents.ts`).
- **Defense in depth (`mapStore.ts`):** `exitBlockView` flushes any still-staged paint before running the heal check, in both districts and COI modes. The flush runs while `captiveIds` is still populated, so the ingest skips its internal heal pass and the existing focused-parent heal remains the single heal, now reading fresh `zoneAssignments`.
- Both ingest functions early-return when nothing is staged, so the normal drag-paint path (already flushed on mouseup) is unaffected.
- Side benefit: this also closes a quiet data-loss hole in normal (non-break) painting, where a save immediately after a lone click-paint would silently miss it.

## Reviewers
<!--- Tag relevant reviewers. Expect the primary reviewer to "own" the review for this PR, -->
<!--- and the secondary to assist if the primary reviewer is delayed. -->

- Primary: @fangge518 
- Secondary:

## Checklist
<!--- Complete this checklist before asking for reviews. You can simply click the checkboxes once the markdown is rendered. -->
<!--- If not applicable, simply leave a reason why under the bullet point. -->
- [ ] Added/Updated related documentation (if applicable).
  - N/A — behavior fix only, no user-facing or API documentation affected.
- [ ] Added/Updated related unit tests (if applicable).
  - N/A — no unit-test harness covers the maplibre event/store interplay; verified manually (see below). A Playwright e2e covering shatter → click-paint → return-to-districts would be a good follow-up.

## Screenshots (if applicable):

N/A — no visual changes. Repro for reviewers: break a parent unit, single-click one child to a different zone **without dragging**, click "return to districts". Before: paint reverts, parent heals, save misses the change. After: paint persists, parent stays broken, the click appears as one undo step, and save includes it.

## Review required
<!--- Given agentic engineer efforts, provide a summary of what aspects of the code and UI/UX require human validation. -->

- Manual validation of the break/shatter flow: click-paint (no drag), drag-paint, and mixed sequences, followed by "return to districts" and save — confirm no double-ingest artifacts and that intentional heals (all children genuinely painted to one zone) still occur.
- Confirm undo behavior after shatter: the shatter + first click-paint should collapse into the expected undo step (`pendingShatterUndoState` path).
- Same checks in COI/community mode, which shares `exitBlockView` (its click handler already ingested directly, so the new flush there should be a no-op).