### PR TITLE
Version check component and api route

### DIFF
--- a/.github/workflows/fly-deploy-app.yml
+++ b/.github/workflows/fly-deploy-app.yml
@@ -33,6 +33,7 @@ jobs:
             NEXT_PUBLIC_S3_BUCKET_URL_MIRROR1=https://tilesets2.cdn.districtr.org
             NEXT_PUBLIC_S3_BUCKET_URL_MIRROR2=https://tilesets3.cdn.districtr.org
             NEXT_PUBLIC_API_URL=${{ steps.deploy-env.outputs.api_url }}
+            NEXT_PUBLIC_BUILD_TAG=${{ github.sha }}
             EOF
         working-directory: app
       - uses: superfly/flyctl-actions/setup-flyctl@1.5

--- a/app/src/app/api/version/route.ts
+++ b/app/src/app/api/version/route.ts
@@ -1,0 +1,24 @@
+import {unstable_noStore as noStore} from 'next/cache';
+
+/**
+ * Reports the build tag of the currently deployed frontend.
+ *
+ * NEXT_PUBLIC_BUILD_TAG is the git SHA written to .env.production by the
+ * deploy workflow. The same value is inlined into the client bundle at build
+ * time, so a client whose inlined tag differs from this response is running a
+ * bundle from before the latest deploy (see VersionCheck.tsx). Returns
+ * `{version: null}` in local dev, which disables the check.
+ */
+export const GET = async () => {
+  noStore();
+  return new Response(
+    JSON.stringify({
+      version: process.env.NEXT_PUBLIC_BUILD_TAG ?? null,
+    }),
+    {
+      headers: {
+        'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
+      },
+    }
+  );
+};

--- a/app/src/app/components/VersionCheck.tsx
+++ b/app/src/app/components/VersionCheck.tsx
@@ -1,0 +1,84 @@
+'use client';
+import React, {useEffect, useState} from 'react';
+import {Dialog, Button, Text, Flex} from '@radix-ui/themes';
+import {useVisibilityState} from '../hooks/useVisibilityState';
+
+// Inlined into the client bundle at build time from .env.production (the git
+// SHA stamped by the deploy workflow). The /api/version route reports the
+// running server's value, so a mismatch means this tab loaded its bundle
+// before the latest deploy. Undefined in local dev, which disables the check.
+const CLIENT_VERSION = process.env.NEXT_PUBLIC_BUILD_TAG;
+const CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+async function fetchServerVersion(): Promise<string | null> {
+  try {
+    const response = await fetch('/api/version', {cache: 'no-store'});
+    if (!response.ok) return null;
+    const data = await response.json();
+    return data.version ?? null;
+  } catch {
+    // Transient network failures are not evidence of staleness.
+    return null;
+  }
+}
+
+/**
+ * Detects when the deployed frontend is newer than the bundle this tab is
+ * running, and blocks further interaction until the user reloads. Stale tabs
+ * are not hypothetical here: editing sessions are long-lived, and a stale
+ * client can speak an outdated API contract (e.g. JSON vs msgpack saves).
+ *
+ * Checks on mount, when the tab becomes visible again, on window focus
+ * (catches clicks between side-by-side windows, which never fire
+ * visibilitychange), and on an interval. Polling pauses while the tab is
+ * hidden.
+ * The dialog intentionally has no dismiss affordance — onOpenChange is not
+ * wired, so ESC and backdrop clicks are no-ops and reloading is the only way
+ * forward.
+ */
+export const VersionCheck: React.FC = () => {
+  const [stale, setStale] = useState(false);
+  const {isVisible} = useVisibilityState();
+
+  useEffect(() => {
+    if (!CLIENT_VERSION || !isVisible) return;
+    let cancelled = false;
+
+    const check = async () => {
+      const serverVersion = await fetchServerVersion();
+      if (!cancelled && serverVersion && serverVersion !== CLIENT_VERSION) {
+        setStale(true);
+      }
+    };
+
+    // Effect re-runs each time the tab becomes visible, so this covers both
+    // initial mount and returning to the tab.
+    check();
+    const interval = setInterval(check, CHECK_INTERVAL_MS);
+    window.addEventListener('focus', check);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      window.removeEventListener('focus', check);
+    };
+  }, [isVisible]);
+
+  if (!stale) return null;
+
+  return (
+    <Dialog.Root open>
+      <Dialog.Content>
+        <Dialog.Title>Districtr has been updated</Dialog.Title>
+        <Text size="3" className="block mb-4">
+          A new version of Districtr was released after this page loaded. Please reload the page to
+          keep working — your saved work will be right where you left it.
+        </Text>
+        <Flex justify="end">
+          <Button size="3" onClick={() => window.location.reload()}>
+            Reload now
+          </Button>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type {Metadata} from 'next';
 import {Nunito} from 'next/font/google';
 import {Theme} from '@radix-ui/themes';
 import {FeedbackForm} from './components/FeedbackForm';
+import {VersionCheck} from './components/VersionCheck';
 import '@radix-ui/themes/styles.css';
 import './globals.css';
 
@@ -55,6 +56,7 @@ export default function RootLayout({
         <Theme accentColor="indigo" grayColor="gray" radius="large" scaling="95%">
           <main>{children}</main>
           <FeedbackForm />
+          <VersionCheck />
         </Theme>
       </body>
     </html>


### PR DESCRIPTION
<!-- Title: Feat: Version skew detection — force reload of stale frontend tabs -->

## Description
<!--- Describe your changes in detail -->

After #550 switched `PUT /api/assignments` from JSON to msgpack, users with tabs open from before the deploy hit `Could not decode msgpack body: unpack(b) received extra data` on every save — the stale bundle sends JSON, whose first byte (`{` = 0x7b) decodes as the msgpack integer 123, leaving the rest as "extra data". This PR adds version-skew detection so future deploys can't strand stale tabs against a changed API contract:

- **Build stamping**: `fly-deploy-app.yml` writes `NEXT_PUBLIC_BUILD_TAG=${{ github.sha }}` into `.env.production`. The same SHA is inlined into the client bundle at build time and loaded by `next start` at runtime (the file survives into the runtime image — `.dockerignore` only excludes `.env*.local`), so client and server versions come from one source of truth and are stable across server restarts.
- **`GET /api/version`** (Next.js route handler, `no-store`): reports the running server's build tag. Returns `{version: null}` in local dev, which disables the check entirely.
- **`<VersionCheck />`** (mounted in the root layout): compares the bundle's inlined tag against the endpoint on mount, when the tab becomes visible (via the existing `useVisibilityState` hook), on window focus, and every 5 minutes (polling pauses while hidden). On mismatch it shows a non-dismissible dialog — ESC/backdrop are no-ops — so reloading is the only way forward.

Limitations worth knowing:
- This protects **future** deploys only; tabs that are stale today don't have this code. A JSON fallback on the assignments endpoint would be the complementary fix for those. However, since we are in beta, it would be reasonable to simply move forward.
- The tag only bumps when `app/**` changes (that's what triggers the frontend deploy). API contract changes must touch both `app/` and `backend/` in one merge for stale tabs to get prompted — as #550 did.

## Reviewers

- Primary: @fangge518 
- Secondary:

## Checklist
- [ ] Added/Updated related documentation (if applicable).
  - Behavior documented in code comments on `VersionCheck.tsx` and `api/version/route.ts`; no user-facing docs affected.
- [ ] Added/Updated related unit tests (if applicable).
  - No unit tests: the interesting behavior (build-time env inlining vs. runtime env, deploy stamping) only exists in a production build/deploy; the client logic is a thin fetch-and-compare. Manual validation steps below.

## Screenshots (if applicable):

<!-- Stale-version dialog: blocking modal titled "Districtr has been updated" with a single "Reload now" button. -->

## Review required
- **Deploy plumbing** is the riskiest part and can't be tested locally: confirm on the dev deploy that `GET /api/version` returns the commit SHA (not `null`) and that no reload prompt appears immediately after deploy (which would indicate client/server tag mismatch from the build — e.g., `.env.production` not reaching the build or runtime image).
- **Skew simulation**: after this lands on dev, keep a tab open, push any trivial `app/**` change, and verify the dialog appears within ~5 minutes or on refocusing the tab — and that reloading clears it.
- **UX call**: the dialog is intentionally non-dismissible. If reviewers prefer a softer "remind me later" affordance, that's a one-line change in `VersionCheck.tsx`.