### PR TITLE
Eval page more polish

### DIFF
--- a/app/src/app/components/EvalPanel/BasicsSection.tsx
+++ b/app/src/app/components/EvalPanel/BasicsSection.tsx
@@ -12,6 +12,7 @@ import {useZoomToDistrict} from '@/app/hooks/useZoomToDistrict';
 type DeviationView = 'top_to_bottom' | 'max_absolute' | 'both';
 
 function formatDeviation(value: number): string {
+  if (value > 1) return 'over 100%';
   const pct = value * 100;
   const formatted = pct.toFixed(3);
   return formatted === '0.000' ? 'under 0.001%' : `${formatted}%`;

--- a/app/src/app/components/EvalPanel/CountySplitsSection.tsx
+++ b/app/src/app/components/EvalPanel/CountySplitsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
+import {useState} from 'react';
 import * as Accordion from '@radix-ui/react-accordion';
-import {Flex, Text, Table, Heading, Switch} from '@radix-ui/themes';
+import {Flex, Text, Table, Heading, Switch, Select} from '@radix-ui/themes';
 import {TriangleRightIcon} from '@radix-ui/react-icons';
 import {DocumentEvaluation} from '@utils/api/apiHandlers/getEvaluation';
 import {useMapStore} from '@store/mapStore';
@@ -25,6 +26,7 @@ export const CountySplitsSection: React.FC<CountySplitsSectionProps> = ({evaluat
   const mapOptions = useMapControlsStore(state => state.mapOptions);
   const setMapOptions = useMapControlsStore(state => state.setMapOptions);
   const setHoveredCountyGeoid = useMapControlsStore(state => state.setHoveredCountyGeoid);
+  const [showMode, setShowMode] = useState<'overly-split-only' | 'all'>('overly-split-only');
 
   const countyPieces = evaluation.county_pieces;
   const idealPop = evaluation.ideal_population ?? null;
@@ -41,10 +43,16 @@ export const CountySplitsSection: React.FC<CountySplitsSectionProps> = ({evaluat
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const splitCounties = allEntries.filter(e => e.actual >= 2).length;
-  const unnecessarySplits =
+  const overlySplitSet =
     idealPop !== null
-      ? allEntries.filter(e => e.actual > Math.ceil(e.pop / idealPop)).length
-      : null;
+      ? new Set(allEntries.filter(e => e.actual > Math.ceil(e.pop / idealPop)).map(e => e.geoid))
+      : new Set<string>();
+  const unnecessarySplits = idealPop !== null ? overlySplitSet.size : null;
+
+  const displayedEntries =
+    showMode === 'overly-split-only'
+      ? allEntries.filter(e => overlySplitSet.has(e.geoid))
+      : allEntries;
 
   // Derived unit assignment counts
   const unitSplitCount = assignedUnits?.split_count ?? 0;
@@ -183,106 +191,112 @@ export const CountySplitsSection: React.FC<CountySplitsSectionProps> = ({evaluat
             </Table.Root>
           </div>
 
-          <Text size="2" weight="bold" mb="2" mt="4" as="p">
-            Overly Split Counties
-          </Text>
+          <Flex align="center" gap="2" mb="2" mt="4" justify="end">
+            <Text size="2" weight="bold">
+              Counties
+            </Text>
+            <Flex align="center" gap="1" style={{marginLeft: 'auto'}}>
+              <Text size="1" color="gray">
+                Show
+              </Text>
+              <Select.Root
+                size="1"
+                value={showMode}
+                onValueChange={v => setShowMode(v as 'overly-split-only' | 'all')}
+              >
+                <Select.Trigger />
+                <Select.Content>
+                  <Select.Item value="overly-split-only">unnecessarily split counties</Select.Item>
+                  <Select.Item value="all">all counties</Select.Item>
+                </Select.Content>
+              </Select.Root>
+            </Flex>
+          </Flex>
           {idealPop !== null && (
             <Text size="2" mb="2" as="p">
               The ideal district population for this plan is{' '}
               <strong>{idealPop.toLocaleString()}</strong>.
             </Text>
           )}
-          {(() => {
-            const unnecessarySplitEntries =
-              idealPop !== null
-                ? allEntries.filter(e => e.actual > Math.ceil(e.pop / idealPop))
-                : [];
-            if (idealPop === null) {
-              return (
-                <Text size="2" color="gray" mb="3" as="p">
-                  Population targets not yet available.
-                </Text>
-              );
-            }
-            if (unnecessarySplitEntries.length === 0) {
-              return (
-                <Text size="2" color="gray" mb="3" as="p">
-                  No counties are split more than necessary.
-                </Text>
-              );
-            }
+          {idealPop === null ? (
+            <Text size="2" color="gray" mb="3" as="p">
+              Population targets not yet available.
+            </Text>
+          ) : displayedEntries.length === 0 ? (
+            <Text size="2" color="gray" mb="3" as="p">
+              No counties are split more than necessary.
+            </Text>
+          ) : (
             // See https://github.com/radix-ui/themes/issues/584 and /767 —
             // Table.Root wraps in ScrollArea (overflow:scroll) which breaks position:sticky.
             // Workaround: use Radix CSS classes on our own scroll div + plain <table>.
-            return (
-              <div
-                className={`rt-TableRoot rt-r-size-1 rt-variant-ghost${unnecessarySplitEntries.length > 15 ? ' max-h-[400px] overflow-y-auto pr-[6px] print:max-h-none print:overflow-visible print:pr-0' : ''}`}
-                style={{
-                  width: 'fit-content',
-                  borderRight: '1px solid var(--gray-a5)',
-                }}
-              >
-                <table className="rt-TableRootTable">
-                  <Table.Header
-                    style={{
-                      position: 'sticky',
-                      top: 0,
-                      zIndex: 1,
-                      backgroundColor: 'var(--color-panel-solid)',
-                    }}
-                  >
-                    <Table.Row>
-                      <Table.ColumnHeaderCell justify="center">County Name</Table.ColumnHeaderCell>
-                      <Table.ColumnHeaderCell justify="center">
-                        County
-                        <br />
-                        Population
-                      </Table.ColumnHeaderCell>
-                      <Table.ColumnHeaderCell justify="center">
-                        How Many
-                        <br />
-                        Districts&apos; Worth
-                      </Table.ColumnHeaderCell>
-                      <Table.ColumnHeaderCell justify="center">
-                        Pieces in
-                        <br />
-                        This Plan
-                      </Table.ColumnHeaderCell>
-                    </Table.Row>
-                  </Table.Header>
-                  <Table.Body>
-                    {unnecessarySplitEntries.map(({geoid, pop, actual, name}) => {
-                      const worth = pop / idealPop;
-                      return (
-                        <Table.Row
-                          key={geoid}
-                          tabIndex={0}
-                          onMouseEnter={() => setHoveredCountyGeoid(geoid)}
-                          onMouseLeave={() => setHoveredCountyGeoid(null)}
-                          onFocus={() => setHoveredCountyGeoid(geoid)}
-                          onBlur={() => setHoveredCountyGeoid(null)}
-                          style={{cursor: 'default'}}
-                        >
-                          <Table.Cell justify="center">
-                            <Text size="2">{name}</Text>
-                          </Table.Cell>
-                          <Table.Cell justify="center">
-                            <Text size="2">{pop.toLocaleString()}</Text>
-                          </Table.Cell>
-                          <Table.Cell justify="center">
-                            <Text size="2">{worth.toFixed(2)}</Text>
-                          </Table.Cell>
-                          <Table.Cell justify="center">
-                            <Text size="2">{actual}</Text>
-                          </Table.Cell>
-                        </Table.Row>
-                      );
-                    })}
-                  </Table.Body>
-                </table>
-              </div>
-            );
-          })()}
+            <div
+              className={`rt-TableRoot rt-r-size-1 rt-variant-ghost${displayedEntries.length > 15 ? ' max-h-[400px] overflow-y-auto pr-[6px] print:max-h-none print:overflow-visible print:pr-0' : ''}`}
+              style={{width: 'fit-content', borderRight: '1px solid var(--gray-a5)'}}
+            >
+              <table className="rt-TableRootTable">
+                <Table.Header
+                  style={{
+                    position: 'sticky',
+                    top: 0,
+                    zIndex: 1,
+                    backgroundColor: 'var(--color-panel-solid)',
+                  }}
+                >
+                  <Table.Row>
+                    <Table.ColumnHeaderCell justify="center">County Name</Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell justify="center">
+                      County
+                      <br />
+                      Population
+                    </Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell justify="center">
+                      How Many
+                      <br />
+                      Districts&apos; Worth
+                    </Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell justify="center">
+                      Pieces in
+                      <br />
+                      This Plan
+                    </Table.ColumnHeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {displayedEntries.map(({geoid, pop, actual, name}) => {
+                    const worth = idealPop !== null ? pop / idealPop : null;
+                    const isOverlySplit = overlySplitSet.has(geoid);
+                    return (
+                      <Table.Row
+                        key={geoid}
+                        tabIndex={0}
+                        onMouseEnter={() => setHoveredCountyGeoid(geoid)}
+                        onMouseLeave={() => setHoveredCountyGeoid(null)}
+                        onFocus={() => setHoveredCountyGeoid(geoid)}
+                        onBlur={() => setHoveredCountyGeoid(null)}
+                        style={{cursor: 'default'}}
+                      >
+                        <Table.Cell justify="center">
+                          <Text size="2">{name}</Text>
+                        </Table.Cell>
+                        <Table.Cell justify="center">
+                          <Text size="2">{pop.toLocaleString()}</Text>
+                        </Table.Cell>
+                        <Table.Cell justify="center">
+                          <Text size="2">{worth !== null ? worth.toFixed(2) : '—'}</Text>
+                        </Table.Cell>
+                        <Table.Cell justify="center">
+                          <Text size="2" color={isOverlySplit ? 'red' : undefined}>
+                            {actual}
+                          </Text>
+                        </Table.Cell>
+                      </Table.Row>
+                    );
+                  })}
+                </Table.Body>
+              </table>
+            </div>
+          )}
         </Accordion.Content>
       </Accordion.Item>
     </Accordion.Root>

--- a/app/src/app/components/EvalPanel/EvalPanel.tsx
+++ b/app/src/app/components/EvalPanel/EvalPanel.tsx
@@ -66,7 +66,16 @@ export const EvalPanel: React.FC = () => {
         </Flex>
       )}
 
-      {evaluation && (
+      {evaluation && Object.keys(evaluation).length === 0 && (
+        <Flex p="5">
+          <Text size="3">
+            This plan is empty. Please add at least one district in the draw mode to see its
+            evaluation metrics.
+          </Text>
+        </Flex>
+      )}
+
+      {evaluation && Object.keys(evaluation).length > 0 && (
         <Flex direction="column" gap="5" pl="2" pr="5" pb="5">
           <BasicsSection evaluation={evaluation} />
           <PartisanSection evaluation={evaluation} />

--- a/app/src/app/components/EvalPanel/PartisanSection.tsx
+++ b/app/src/app/components/EvalPanel/PartisanSection.tsx
@@ -134,124 +134,135 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                 )}{' '}
                 over these elections.
               </Text>
-              <Flex direction="column" align="center" gap="2" mb="2">
-                <Text size="2" weight="bold">
-                  Votes vs. Seats by Election (among the two major parties)
+              <Text size="2" weight="bold" mb="2" as="p">
+                Votes vs. Seats by Election (among the two major parties)
+              </Text>
+              <Flex justify="start" align="center" gap="2" mb="2">
+                <Text size="1" color="gray">
+                  Point of View
                 </Text>
-                <Flex align="center" gap="2">
-                  <Text size="1" color="gray">
-                    Point of View
-                  </Text>
-                  <SegmentedControl.Root size="1" value={pov} onValueChange={v => setPov(v as Pov)}>
-                    <SegmentedControl.Item value="dem">Democrat</SegmentedControl.Item>
-                    <SegmentedControl.Item value="rep">Republican</SegmentedControl.Item>
-                  </SegmentedControl.Root>
-                </Flex>
+                <SegmentedControl.Root size="1" value={pov} onValueChange={v => setPov(v as Pov)}>
+                  <SegmentedControl.Item value="dem">Democrat</SegmentedControl.Item>
+                  <SegmentedControl.Item value="rep">Republican</SegmentedControl.Item>
+                </SegmentedControl.Root>
               </Flex>
-              <Table.Root size="1" mb="3">
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeaderCell justify="center">Election</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Total
-                      <br />
-                      Votes
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center" style={{color: povColor}}>
-                      {pov === 'dem' ? 'Dem' : 'Rep'} Vote
-                      <br />
-                      Share
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center" style={{color: povColor}}>
-                      {pov === 'dem' ? 'Dem' : 'Rep'}
-                      <br />
-                      Districts
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center" style={{color: povColor}}>
-                      {pov === 'dem' ? 'Dem' : 'Rep'} Seat
-                      <br />
-                      Share
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Disproportionality
-                    </Table.ColumnHeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  {elections.map(key => {
-                    const seats = evaluation.seats?.[key];
-                    const seatTotal = seats?.total ?? null;
-                    const partySeatCount = seats?.[pov] ?? null;
-                    const seatPct =
-                      seatTotal && partySeatCount != null ? partySeatCount / seatTotal : null;
-                    const votes = evaluation.votes?.[key];
-                    const voteShare = evaluation.vote_shares?.[key]?.[pov] ?? null;
-                    const rawDisp = evaluation.disproportionality?.[key] ?? null;
-                    const disp = rawDisp !== null ? (pov === 'rep' ? -rawDisp : rawDisp) : null;
-                    return (
-                      <Table.Row key={key}>
-                        <Table.Cell justify="center">
-                          <Text size="2" weight="bold">
-                            {formatElectionKey(key)}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell justify="center">
-                          <Text size="2">{votes != null ? votes.total.toLocaleString() : '—'}</Text>
-                        </Table.Cell>
-                        <Table.Cell
-                          justify="center"
-                          style={{
-                            backgroundColor:
-                              voteShare != null
-                                ? voteShare > 0.5
-                                  ? povBg((voteShare - 0.5) * 1.5)
-                                  : NEUTRAL
-                                : undefined,
-                          }}
-                        >
-                          <Text size="2">
-                            {voteShare != null ? `${(voteShare * 100).toFixed(1)}%` : '—'}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell justify="center">
-                          <Text size="2">
-                            {partySeatCount != null && seatTotal
-                              ? `${partySeatCount}/${seatTotal}`
-                              : '—'}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell
-                          justify="center"
-                          style={
-                            seatPct !== null
-                              ? {
-                                  backgroundColor:
-                                    seatPct > 0.5 ? povBg((seatPct - 0.5) * 1.5) : NEUTRAL,
-                                }
-                              : {}
-                          }
-                        >
-                          <Text size="2">
-                            {seatPct !== null ? `${(seatPct * 100).toFixed(1)}%` : '—'}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell
-                          justify="center"
-                          style={{
-                            backgroundColor: scaledBg(rawDisp ?? undefined, METRIC_CUTOFF.disp),
-                          }}
-                        >
-                          <Text size="2">
-                            {disp !== null && numDistricts !== null
-                              ? dispLabel(rawDisp!, numDistricts)
-                              : '—'}
-                          </Text>
-                        </Table.Cell>
-                      </Table.Row>
-                    );
-                  })}
-                </Table.Body>
-              </Table.Root>
+              <div style={{width: 'fit-content', overflowX: 'auto', maxWidth: '100%'}}>
+                <Table.Root size="1" mb="3">
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.ColumnHeaderCell justify="center">Election</Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center">
+                        Total
+                        <br />
+                        Votes
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell
+                        justify="center"
+                        style={{color: povColor, width: '8ch'}}
+                      >
+                        {pov === 'dem' ? 'Dem' : 'Rep'} Vote
+                        <br />
+                        Share
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell
+                        justify="center"
+                        style={{color: povColor, width: '8ch'}}
+                      >
+                        {pov === 'dem' ? 'Dem' : 'Rep'}
+                        <br />
+                        Districts
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell
+                        justify="center"
+                        style={{color: povColor, width: '8ch'}}
+                      >
+                        {pov === 'dem' ? 'Dem' : 'Rep'} Seat
+                        <br />
+                        Share
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center" style={{minWidth: '22ch'}}>
+                        Disproportionality
+                      </Table.ColumnHeaderCell>
+                    </Table.Row>
+                  </Table.Header>
+                  <Table.Body>
+                    {elections.map(key => {
+                      const seats = evaluation.seats?.[key];
+                      const seatTotal = seats?.total ?? null;
+                      const partySeatCount = seats?.[pov] ?? null;
+                      const seatPct =
+                        seatTotal && partySeatCount != null ? partySeatCount / seatTotal : null;
+                      const votes = evaluation.votes?.[key];
+                      const voteShare = evaluation.vote_shares?.[key]?.[pov] ?? null;
+                      const rawDisp = evaluation.disproportionality?.[key] ?? null;
+                      const disp = rawDisp !== null ? (pov === 'rep' ? -rawDisp : rawDisp) : null;
+                      return (
+                        <Table.Row key={key}>
+                          <Table.Cell justify="center">
+                            <Text size="2" weight="bold">
+                              {formatElectionKey(key)}
+                            </Text>
+                          </Table.Cell>
+                          <Table.Cell justify="center">
+                            <Text size="2">
+                              {votes != null ? votes.total.toLocaleString() : '—'}
+                            </Text>
+                          </Table.Cell>
+                          <Table.Cell
+                            justify="center"
+                            style={{
+                              backgroundColor:
+                                voteShare != null
+                                  ? voteShare > 0.5
+                                    ? povBg((voteShare - 0.5) * 1.5)
+                                    : NEUTRAL
+                                  : undefined,
+                            }}
+                          >
+                            <Text size="2">
+                              {voteShare != null ? `${(voteShare * 100).toFixed(1)}%` : '—'}
+                            </Text>
+                          </Table.Cell>
+                          <Table.Cell justify="center">
+                            <Text size="2">
+                              {partySeatCount != null && seatTotal
+                                ? `${partySeatCount}/${seatTotal}`
+                                : '—'}
+                            </Text>
+                          </Table.Cell>
+                          <Table.Cell
+                            justify="center"
+                            style={
+                              seatPct !== null
+                                ? {
+                                    backgroundColor:
+                                      seatPct > 0.5 ? povBg((seatPct - 0.5) * 1.5) : NEUTRAL,
+                                  }
+                                : {}
+                            }
+                          >
+                            <Text size="2">
+                              {seatPct !== null ? `${(seatPct * 100).toFixed(1)}%` : '—'}
+                            </Text>
+                          </Table.Cell>
+                          <Table.Cell
+                            justify="center"
+                            style={{
+                              backgroundColor: scaledBg(rawDisp ?? undefined, METRIC_CUTOFF.disp),
+                            }}
+                          >
+                            <Text size="2">
+                              {disp !== null && numDistricts !== null
+                                ? dispLabel(rawDisp!, numDistricts)
+                                : '—'}
+                            </Text>
+                          </Table.Cell>
+                        </Table.Row>
+                      );
+                    })}
+                  </Table.Body>
+                </Table.Root>
+              </div>
             </>
           )}
 
@@ -265,7 +276,7 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                 The following scores can all be found in the political science literature, but are
                 not necessarily endorsed by leading scholars at this time.
               </Text>
-              <Flex justify="center" align="center" gap="2" mb="2">
+              <Flex justify="start" align="center" gap="2" mb="2">
                 <Text size="1" color="gray">
                   Point of View
                 </Text>
@@ -274,126 +285,130 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                   <SegmentedControl.Item value="rep">Republican</SegmentedControl.Item>
                 </SegmentedControl.Root>
               </Flex>
-              <Table.Root size="1" mb="3">
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeaderCell justify="center">Election</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Dispropor-
-                      <br />
-                      tionality
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Efficiency
-                      <br />
-                      Gap
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Mean
-                      <br />
-                      Median
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Partisan
-                      <br />
-                      Bias
-                    </Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell justify="center">
-                      Eguia's
-                      <br />
-                      Metric
-                    </Table.ColumnHeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  {elections.map(key => (
-                    <Table.Row key={key}>
-                      <Table.Cell justify="center">
-                        <Text size="2" weight="bold">
-                          {formatElectionKey(key)}
-                        </Text>
-                      </Table.Cell>
-                      <Table.Cell
-                        justify="center"
-                        style={{
-                          backgroundColor: scaledBg(
-                            evaluation.disproportionality?.[key],
-                            METRIC_CUTOFF.disp
-                          ),
-                        }}
-                      >
-                        <Text size="2">
-                          {formatNumber(
-                            povSign(evaluation.disproportionality?.[key]),
-                            NUMBER_FORMATS.SIGNED_PCT
-                          )}
-                        </Text>
-                      </Table.Cell>
-                      <Table.Cell
-                        justify="center"
-                        style={{
-                          backgroundColor: scaledBg(
-                            evaluation.efficiency_gap?.[key],
-                            METRIC_CUTOFF.efficiency_gap
-                          ),
-                        }}
-                      >
-                        <Text size="2">
-                          {formatNumber(
-                            povSign(evaluation.efficiency_gap?.[key]),
-                            NUMBER_FORMATS.SIGNED_PCT
-                          )}
-                        </Text>
-                      </Table.Cell>
-                      <Table.Cell
-                        justify="center"
-                        style={{
-                          backgroundColor: scaledBg(
-                            evaluation.mean_median?.[key],
-                            METRIC_CUTOFF.mean_median
-                          ),
-                        }}
-                      >
-                        <Text size="2">
-                          {formatNumber(
-                            povSign(evaluation.mean_median?.[key]),
-                            NUMBER_FORMATS.SIGNED_PCT
-                          )}
-                        </Text>
-                      </Table.Cell>
-                      <Table.Cell
-                        justify="center"
-                        style={{
-                          backgroundColor: scaledBg(
-                            evaluation.partisan_bias?.[key],
-                            METRIC_CUTOFF.partisan_bias
-                          ),
-                        }}
-                      >
-                        <Text size="2">
-                          {formatNumber(
-                            povSign(evaluation.partisan_bias?.[key]),
-                            NUMBER_FORMATS.SIGNED_PCT
-                          )}
-                        </Text>
-                      </Table.Cell>
-                      <Table.Cell
-                        justify="center"
-                        style={{
-                          backgroundColor: scaledBg(evaluation.eguia?.[key], METRIC_CUTOFF.eguia),
-                        }}
-                      >
-                        <Text size="2">
-                          {formatNumber(
-                            povSign(evaluation.eguia?.[key]),
-                            NUMBER_FORMATS.SIGNED_PCT
-                          )}
-                        </Text>
-                      </Table.Cell>
+              <div style={{overflowX: 'auto', maxWidth: '100%'}}>
+                <Table.Root size="1" mb="3" style={{tableLayout: 'fixed', width: '58ch'}}>
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.ColumnHeaderCell justify="center" style={{width: '10ch'}}>
+                        Election
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center" style={{width: '9ch'}}>
+                        Dispropor-
+                        <br />
+                        tionality
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center" style={{width: '9ch'}}>
+                        Efficiency
+                        <br />
+                        Gap
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center" style={{width: '9ch'}}>
+                        Mean
+                        <br />
+                        Median
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center" style={{width: '9ch'}}>
+                        Partisan
+                        <br />
+                        Bias
+                      </Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell justify="center" style={{width: '9ch'}}>
+                        Eguia's
+                        <br />
+                        Metric
+                      </Table.ColumnHeaderCell>
                     </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table.Root>
+                  </Table.Header>
+                  <Table.Body>
+                    {elections.map(key => (
+                      <Table.Row key={key}>
+                        <Table.Cell justify="center">
+                          <Text size="2" weight="bold">
+                            {formatElectionKey(key)}
+                          </Text>
+                        </Table.Cell>
+                        <Table.Cell
+                          justify="center"
+                          style={{
+                            backgroundColor: scaledBg(
+                              evaluation.disproportionality?.[key],
+                              METRIC_CUTOFF.disp
+                            ),
+                          }}
+                        >
+                          <Text size="2">
+                            {formatNumber(
+                              povSign(evaluation.disproportionality?.[key]),
+                              NUMBER_FORMATS.SIGNED_PCT
+                            )}
+                          </Text>
+                        </Table.Cell>
+                        <Table.Cell
+                          justify="center"
+                          style={{
+                            backgroundColor: scaledBg(
+                              evaluation.efficiency_gap?.[key],
+                              METRIC_CUTOFF.efficiency_gap
+                            ),
+                          }}
+                        >
+                          <Text size="2">
+                            {formatNumber(
+                              povSign(evaluation.efficiency_gap?.[key]),
+                              NUMBER_FORMATS.SIGNED_PCT
+                            )}
+                          </Text>
+                        </Table.Cell>
+                        <Table.Cell
+                          justify="center"
+                          style={{
+                            backgroundColor: scaledBg(
+                              evaluation.mean_median?.[key],
+                              METRIC_CUTOFF.mean_median
+                            ),
+                          }}
+                        >
+                          <Text size="2">
+                            {formatNumber(
+                              povSign(evaluation.mean_median?.[key]),
+                              NUMBER_FORMATS.SIGNED_PCT
+                            )}
+                          </Text>
+                        </Table.Cell>
+                        <Table.Cell
+                          justify="center"
+                          style={{
+                            backgroundColor: scaledBg(
+                              evaluation.partisan_bias?.[key],
+                              METRIC_CUTOFF.partisan_bias
+                            ),
+                          }}
+                        >
+                          <Text size="2">
+                            {formatNumber(
+                              povSign(evaluation.partisan_bias?.[key]),
+                              NUMBER_FORMATS.SIGNED_PCT
+                            )}
+                          </Text>
+                        </Table.Cell>
+                        <Table.Cell
+                          justify="center"
+                          style={{
+                            backgroundColor: scaledBg(evaluation.eguia?.[key], METRIC_CUTOFF.eguia),
+                          }}
+                        >
+                          <Text size="2">
+                            {formatNumber(
+                              povSign(evaluation.eguia?.[key]),
+                              NUMBER_FORMATS.SIGNED_PCT
+                            )}
+                          </Text>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))}
+                  </Table.Body>
+                </Table.Root>
+              </div>
             </>
           )}
 


### PR DESCRIPTION
## Problems

Described in https://github.com/districtr/districtr-v2/issues/580#issuecomment-4782840570

## Changes

- **Empty plan**: show a placeholder message instead of partial metrics when the plan has no assignments
- **Deviation clamping**: cap top-to-bottom deviation display at "over 100%" for plans with extreme imbalance
- **Table width stability**: fix column width jitter when toggling Point of View in the partisanship tables (`width` on toggle-affected headers; `table-layout: fixed` for the metrics table)
- **Table alignment**: left-align the "Votes vs. Seats" title and both POV toggles
- **Counties table**: rename "Overly Split Counties" to "Counties"; add a Show dropdown ("unnecessarily split counties" / "all counties", defaulting to the former); highlight the "Pieces in This Plan" cell in red for unnecessarily split counties in both views