### PR TITLE
Fix evaluation table border clipping at sticky header corners

### DIFF
--- a/app/src/app/components/EvalPanel/CompactnessSection.tsx
+++ b/app/src/app/components/EvalPanel/CompactnessSection.tsx
@@ -238,7 +238,7 @@ export const CompactnessSection: React.FC<CompactnessSectionProps> = ({evaluatio
                   a plain <table> inside. Sub-components have no context dep on Table.Root. */}
               <div
                 className="rt-TableRoot rt-r-size-1 rt-variant-surface"
-                style={{width: 'fit-content'}}
+                style={{width: 'fit-content', overflow: 'hidden'}}
               >
                 <div
                   className={

--- a/app/src/app/components/EvalPanel/CountySplitsSection.tsx
+++ b/app/src/app/components/EvalPanel/CountySplitsSection.tsx
@@ -232,7 +232,7 @@ export const CountySplitsSection: React.FC<CountySplitsSectionProps> = ({evaluat
             // Workaround: use Radix CSS classes on our own scroll div + plain <table>.
             <div
               className="rt-TableRoot rt-r-size-1 rt-variant-surface"
-              style={{width: 'fit-content'}}
+              style={{width: 'fit-content', overflow: 'hidden'}}
             >
               <div
                 className={

--- a/app/src/app/components/RecentMapsList.tsx
+++ b/app/src/app/components/RecentMapsList.tsx
@@ -402,7 +402,7 @@ const RecentMapCard: React.FC<{
     tab === MAP_TABS.COMMUNITY
       ? (data.community_metadata_list?.length ?? data.num_communities ?? 0)
       : (data.num_districts ?? 0);
-  const slug = data.districtr_map_slug
+  const slug = data.districtr_map_slug;
   const zoneLabel = MAP_TAB_LABEL_PLURAL[tab];
   const geoLabel = data.parent_geo_unit_type || data.gerrydb_table || data.districtr_map_slug;
   const route = routeForTab(tab);

--- a/app/src/app/components/Toolbar/SaveShareModal/MapDetailsSection.tsx
+++ b/app/src/app/components/Toolbar/SaveShareModal/MapDetailsSection.tsx
@@ -43,47 +43,47 @@ export const MapDetailsSection: React.FC<{
           value={accordionOpen}
           onValueChange={value => setAccordionOpen(value)}
         >
-        <Accordion.Item value="group">
-          <Accordion.AccordionTrigger className="AccordionTrigger w-full mt-2" asChild>
-            <Button className="w-full" variant="ghost">
-              <Flex direction="row" gap="2" align="center" justify="start" className="w-full">
-                <Text>Advanced</Text>
-                {accordionOpen === 'group' ? <ChevronUpIcon /> : <ChevronDownIcon />}
-              </Flex>
-            </Button>
-          </Accordion.AccordionTrigger>
-          <Accordion.AccordionContent className="AccordionContent">
-            <Grid columns="2" gap="2">
+          <Accordion.Item value="group">
+            <Accordion.AccordionTrigger className="AccordionTrigger w-full mt-2" asChild>
+              <Button className="w-full" variant="ghost">
+                <Flex direction="row" gap="2" align="center" justify="start" className="w-full">
+                  <Text>Advanced</Text>
+                  {accordionOpen === 'group' ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                </Flex>
+              </Button>
+            </Accordion.AccordionTrigger>
+            <Accordion.AccordionContent className="AccordionContent">
+              <Grid columns="2" gap="2">
+                <Box>
+                  <Text>Group</Text>
+                  <TextField.Root
+                    className="flex-1 w-full"
+                    value={mapMetadata.group ?? ''}
+                    placeholder="Group"
+                    disabled={!isEditing}
+                    onChange={e => onChange({group: e.target.value})}
+                  />
+                </Box>
+                <Box>
+                  <Text>Tags (coming soon)</Text>
+                  <TextField.Root
+                    className="flex-1 w-full"
+                    value={mapMetadata.tags ?? ''}
+                    placeholder="Tags"
+                    disabled={true}
+                  />
+                </Box>
+              </Grid>
               <Box>
-                <Text>Group</Text>
-                <TextField.Root
+                <Text>Comments</Text>
+                <TextArea
                   className="flex-1 w-full"
-                  value={mapMetadata.group ?? ''}
-                  placeholder="Group"
+                  value={mapMetadata.description ?? ''}
+                  placeholder="Comments or description"
+                  onChange={e => onChange({description: e.target.value})}
                   disabled={!isEditing}
-                  onChange={e => onChange({group: e.target.value})}
                 />
               </Box>
-              <Box>
-                <Text>Tags (coming soon)</Text>
-                <TextField.Root
-                  className="flex-1 w-full"
-                  value={mapMetadata.tags ?? ''}
-                  placeholder="Tags"
-                  disabled={true}
-                />
-              </Box>
-            </Grid>
-            <Box>
-              <Text>Comments</Text>
-              <TextArea
-                className="flex-1 w-full"
-                value={mapMetadata.description ?? ''}
-                placeholder="Comments or description"
-                onChange={e => onChange({description: e.target.value})}
-                disabled={!isEditing}
-              />
-            </Box>
             </Accordion.AccordionContent>
           </Accordion.Item>
         </Accordion.Root>


### PR DESCRIPTION
Clip rounded table corners on the outer wrapper instead of the inner `<table>`, since overriding the inner table to `overflow: visible` (needed for sticky headers) let the header background bleed past the border radius.