### PR TITLE
Encrypt S3 bucket name in Pulumi stack configs

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -4,17 +4,16 @@
 secretsprovider: awskms://alias/districtr-pulumi-secrets?region=us-east-2
 config:
   aws:region: us-east-2
-
   districtr-infra:appDomain: dev.districtr.org
   districtr-infra:apiDomain: api.dev.districtr.org
   districtr-infra:corsOrigins: https://dev.districtr.org
-  districtr-infra:s3BucketName: districtr-v2-dev
+  districtr-infra:s3BucketName:
+    secure: v1:NvATpjb2PUlKwXAz:1KdAv/sq7vkzINPAPM9twpRm7+/8c1GwvnlYKYsB7gr/DyMSjT5dsDZL
   districtr-infra:cdnUrl: https://tilesets1.cdn.districtr.org
   districtr-infra:auth0Domain: districtr-qa.us.auth0.com
   districtr-infra:auth0ApiAudience: https://districtr-v2-api-dev.fly.dev
   districtr-infra:auth0Issuer: https://districtr-qa.us.auth0.com
   districtr-infra:alarmEmail: dhalpern@uchicago.edu
-
   districtr-infra:secretKey:
     secure: v1:JPIYNwHinzVBFMeH:7SXhe/J8zN6jZb/LKisf6a9LKf3AANZZt3Ecu3H8mBgPX+rExXAOJZXlXi4gAerH1CU3t7dgCHlrW82LS2UQNFekHDWUTLat6qStQlz6YH0=
   districtr-infra:auth0SessionSecret:

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -9,14 +9,13 @@ config:
   districtr-infra:extraDomains:
     - www.beta.districtr.org
   districtr-infra:corsOrigins: https://beta.districtr.org,https://www.beta.districtr.org
-
-  districtr-infra:s3BucketName: districtr-v2-prod
+  districtr-infra:s3BucketName:
+    secure: v1:MS8AzWKQiTmtjfkB:oz6SV4+k43qsx7zvx/cdwVO4Be+fhIJd1wMaghY7OLAHbWwTV3gzHrTg
   districtr-infra:cdnUrl: https://tilesets1.cdn.districtr.org
   districtr-infra:auth0Domain: districtr.us.auth0.com
   districtr-infra:auth0ApiAudience: https://districtr-v2-api.fly.dev
   districtr-infra:auth0Issuer: https://districtr.us.auth0.com/
   districtr-infra:alarmEmail: dhalpern@uchicago.edu
-
   districtr-infra:secretKey:
     secure: v1:dHM/3HqOvfLfoMgx:48kANUBIY2+yLOYo3BgQLly0YEOXYmw6K45Y9BabOph74VwoWV+oZ/mcvHcuD9GY1xz/vpwZcFJJQRxVwfH9sDeY+39I9ap/8xPDpQARDMs=
   districtr-infra:auth0SessionSecret:

--- a/infra/config.ts
+++ b/infra/config.ts
@@ -25,7 +25,7 @@ export const config = {
   corsOrigins: cfg.require("corsOrigins"),
 
   // Existing object storage / CDN — not managed by this project.
-  s3BucketName: cfg.require("s3BucketName"),
+  s3BucketName: cfg.requireSecret("s3BucketName"),
   cdnUrl: cfg.require("cdnUrl"),
 
   // Auth0 (non-secret identifiers)


### PR DESCRIPTION
## Summary
- Moves `s3BucketName` from plaintext to KMS-encrypted secret in both `Pulumi.dev.yaml` and `Pulumi.prod.yaml`
- Updates `config.ts` to use `cfg.requireSecret` instead of `cfg.require` to match

## Background
The new aws-backed service should use the existing, cross-account S3 bucket (graphs, thumbnails, tilesets) the fly servers currently reads/writes. It was previously set to placeholder values (`districtr-v2-dev`, `districtr-v2-prod`) that don't exist.