### PR TITLE
Prefer custom (modifiable-district) maps in the CSV importer

### DIFF
--- a/app/src/app/components/Static/PlaceMap/PlaceMap.tsx
+++ b/app/src/app/components/Static/PlaceMap/PlaceMap.tsx
@@ -24,7 +24,7 @@ export const PlaceSelector: React.FC<{onChange: (abbr: string) => void}> = ({onC
         {US_STATE_META.sort((a, b) => a.NAME.localeCompare(b.NAME))
           .map(place => ({
             ...place,
-            slug: place.NAME.toLowerCase().replaceAll(' ', '-'),
+            slug: place.SLUG ?? place.NAME.toLowerCase().replaceAll(' ', '-'),
           }))
           .map((place: (typeof US_STATE_META)[number] & {slug: string}, i: number) => (
             <Select.Item value={place.slug} key={i}>

--- a/app/src/app/components/Uploader/Uploader.tsx
+++ b/app/src/app/components/Uploader/Uploader.tsx
@@ -26,18 +26,13 @@ export const Uploader: React.FC<{
 
   useEffect(() => {
     // Custom (num_districts_modifiable) maps live in the 'custom' group, not
-    // 'states', so they don't clutter the public map picker. Fetch both so
-    // map inference can prefer custom maps with congressional as fallback.
-    Promise.all([getAvailableDistrictrMaps({}), getAvailableDistrictrMaps({group: 'custom'})]).then(
-      ([states, custom]) => {
-        if (states.ok || custom.ok) {
-          setAvailableMaps([
-            ...(custom.ok ? custom.response : []),
-            ...(states.ok ? states.response : []),
-          ]);
-        }
+    // 'states', so they don't clutter the public map picker. CSV imports
+    // target custom maps exclusively.
+    getAvailableDistrictrMaps({group: 'custom'}).then(custom => {
+      if (custom.ok) {
+        setAvailableMaps(custom.response);
       }
-    );
+    });
   }, []);
 
   useEffect(() => {

--- a/app/src/app/components/Uploader/Uploader.tsx
+++ b/app/src/app/components/Uploader/Uploader.tsx
@@ -25,9 +25,19 @@ export const Uploader: React.FC<{
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    getAvailableDistrictrMaps({}).then(result => {
-      if (result.ok) setAvailableMaps(result.response);
-    });
+    // Custom (num_districts_modifiable) maps live in the 'custom' group, not
+    // 'states', so they don't clutter the public map picker. Fetch both so
+    // map inference can prefer custom maps with congressional as fallback.
+    Promise.all([getAvailableDistrictrMaps({}), getAvailableDistrictrMaps({group: 'custom'})]).then(
+      ([states, custom]) => {
+        if (states.ok || custom.ok) {
+          setAvailableMaps([
+            ...(custom.ok ? custom.response : []),
+            ...(states.ok ? states.response : []),
+          ]);
+        }
+      }
+    );
   }, []);
 
   useEffect(() => {

--- a/app/src/app/constants/meta/usStates.ts
+++ b/app/src/app/constants/meta/usStates.ts
@@ -11,6 +11,7 @@ export const US_STATE_META: Array<{
   {FIPS: '08', NAME: 'Colorado', ABBR: 'CO'},
   {FIPS: '09', NAME: 'Connecticut', ABBR: 'CT'},
   {FIPS: '10', NAME: 'Delaware', ABBR: 'DE'},
+  {FIPS: '11', NAME: 'Washington, DC', ABBR: 'DC'},
   {FIPS: '12', NAME: 'Florida', ABBR: 'FL'},
   {FIPS: '13', NAME: 'Georgia', ABBR: 'GA'},
   {FIPS: '15', NAME: 'Hawaii', ABBR: 'HI'},

--- a/app/src/app/constants/meta/usStates.ts
+++ b/app/src/app/constants/meta/usStates.ts
@@ -2,6 +2,9 @@ export const US_STATE_META: Array<{
   FIPS: string;
   NAME: string;
   ABBR: string;
+  // Only set where the CMS place slug isn't NAME kebab-cased (insular
+  // areas: "Washington, DC" / "Puerto Rico" don't reduce to "dc" / "pr").
+  SLUG?: string;
 }> = [
   {FIPS: '01', NAME: 'Alabama', ABBR: 'AL'},
   {FIPS: '02', NAME: 'Alaska', ABBR: 'AK'},
@@ -11,7 +14,7 @@ export const US_STATE_META: Array<{
   {FIPS: '08', NAME: 'Colorado', ABBR: 'CO'},
   {FIPS: '09', NAME: 'Connecticut', ABBR: 'CT'},
   {FIPS: '10', NAME: 'Delaware', ABBR: 'DE'},
-  {FIPS: '11', NAME: 'Washington, DC', ABBR: 'DC'},
+  {FIPS: '11', NAME: 'Washington, DC', ABBR: 'DC', SLUG: 'dc'},
   {FIPS: '12', NAME: 'Florida', ABBR: 'FL'},
   {FIPS: '13', NAME: 'Georgia', ABBR: 'GA'},
   {FIPS: '15', NAME: 'Hawaii', ABBR: 'HI'},
@@ -54,7 +57,7 @@ export const US_STATE_META: Array<{
   {FIPS: '54', NAME: 'West Virginia', ABBR: 'WV'},
   {FIPS: '55', NAME: 'Wisconsin', ABBR: 'WI'},
   {FIPS: '56', NAME: 'Wyoming', ABBR: 'WY'},
-  {FIPS: '72', NAME: 'Puerto Rico', ABBR: 'PR'},
+  {FIPS: '72', NAME: 'Puerto Rico', ABBR: 'PR', SLUG: 'pr'},
 ] as const;
 
 export const FIPS_TO_ABBR = Object.fromEntries(US_STATE_META.map(s => [s.FIPS, s.ABBR]));

--- a/app/src/app/utils/api/upload.ts
+++ b/app/src/app/utils/api/upload.ts
@@ -85,24 +85,18 @@ const partitionRows = (rows: string[][]): PartitionResult => {
   return {assignments, skippedGeoIds, stateFipsSet};
 };
 
-// Slug patterns must stay in sync with how maps are named in the DB
-// A mismatch will silently break CSV import for that state.
+// CSV imports target the state's custom (modifiable-district) map by naming
+// convention: every deployed environment must have a visible custom module
+// for the importer to work. There is no fallback to fixed-district maps —
+// their locked num_districts silently clamps uploaded plans. The v1 slug is
+// accepted while environments that predate the v2 catalog remain in service.
 const inferMapForCsv = (fips: string, availableMaps: DistrictrMap[]): DistrictrMap | null => {
   const abbr = FIPS_TO_ABBR[fips];
   if (!abbr) return null;
   const lower = abbr.toLowerCase();
-  // Prefer custom_districts maps (num_districts_modifiable=true) so the zone count
-  // from the CSV drives the district count instead of locking to a fixed map.
-  // Fall back to congressional, then name-matching, then state senate for at-large states.
   return (
+    availableMaps.find(m => m.districtr_map_slug === `${lower}_custom_districts_v2`) ??
     availableMaps.find(m => m.districtr_map_slug === `${lower}_custom_districts`) ??
-    availableMaps.find(m => m.districtr_map_slug === `${lower}_congressional_districts`) ??
-    availableMaps.find(
-      m =>
-        m.districtr_map_slug.startsWith(`${lower}_`) &&
-        m.name.toLowerCase().includes('congressional')
-    ) ??
-    availableMaps.find(m => m.districtr_map_slug === `${lower}_state_senate_districts`) ??
     null
   );
 };
@@ -187,7 +181,7 @@ export const processFile = ({
         const stateName = FIPS_TO_NAME[fips] ?? `FIPS ${fips}`;
         setError({
           ok: false,
-          detail: {message: `No map found for ${stateName}`},
+          detail: {message: `No custom districts map available for ${stateName}`},
         });
         return;
       }

--- a/app/src/app/utils/api/upload.ts
+++ b/app/src/app/utils/api/upload.ts
@@ -87,16 +87,15 @@ const partitionRows = (rows: string[][]): PartitionResult => {
 
 // Slug patterns must stay in sync with how maps are named in the DB
 // A mismatch will silently break CSV import for that state.
-const inferCongressionalMap = (
-  fips: string,
-  availableMaps: DistrictrMap[]
-): DistrictrMap | null => {
+const inferMapForCsv = (fips: string, availableMaps: DistrictrMap[]): DistrictrMap | null => {
   const abbr = FIPS_TO_ABBR[fips];
   if (!abbr) return null;
   const lower = abbr.toLowerCase();
-  // Prefer the canonical congressional slug, then name-matching, then state senate
-  // as a fallback for at-large states (AK, DE, ND, SD, WY) that have no congressional map.
+  // Prefer custom_districts maps (num_districts_modifiable=true) so the zone count
+  // from the CSV drives the district count instead of locking to a fixed map.
+  // Fall back to congressional, then name-matching, then state senate for at-large states.
   return (
+    availableMaps.find(m => m.districtr_map_slug === `${lower}_custom_districts`) ??
     availableMaps.find(m => m.districtr_map_slug === `${lower}_congressional_districts`) ??
     availableMaps.find(
       m =>
@@ -183,12 +182,12 @@ export const processFile = ({
       }
 
       const fips = [...stateFipsSet][0];
-      const districtrMap = inferCongressionalMap(fips, availableMaps);
+      const districtrMap = inferMapForCsv(fips, availableMaps);
       if (!districtrMap) {
         const stateName = FIPS_TO_NAME[fips] ?? `FIPS ${fips}`;
         setError({
           ok: false,
-          detail: {message: `No congressional map found for ${stateName}`},
+          detail: {message: `No map found for ${stateName}`},
         });
         return;
       }

--- a/backend/app/assignments/assignments.py
+++ b/backend/app/assignments/assignments.py
@@ -25,11 +25,23 @@ class DuplicateGeoIdError(ValueError):
     pass
 
 
+# Same global bound as the metadata endpoint's num_districts validation.
+MAX_DISTRICTS = 538
+
+# A numeric zone label is treated as accidental (and remapped) when it exceeds
+# OUTLIER_FACTOR times the plan's reference label — see _detect_outlier_labels.
+OUTLIER_FACTOR = 5
+MAX_OUTLIERS = 2
+
+
 @dataclass
 class BatchInsertResult:
     inserted: int
     skipped_geo_ids: list[str] = field(default_factory=list)
     zone_label_remapping: dict[str, int] = field(default_factory=dict)
+    # Highest zone id actually assigned; drives the document's num_districts
+    # on maps with num_districts_modifiable.
+    max_assigned_zone: int | None = None
 
 
 def _is_whole_pos_number(s: str) -> bool:
@@ -43,27 +55,62 @@ def _is_whole_pos_number(s: str) -> bool:
         return False
 
 
+def _detect_outlier_labels(raw_zones: set[str], default_num_districts: int) -> set[str]:
+    """Numeric zone labels that are almost certainly accidental, e.g. '196' in
+    a plan whose other labels are 1..10.
+
+    User labels carry meaning, so this is deliberately conservative. Only the
+    MAX_OUTLIERS largest labels can be flagged, and each only when it exceeds
+    OUTLIER_FACTOR times a reference: the larger of the next-largest remaining
+    label and the map's default district count. Anchoring the reference on the
+    next-largest label means that when three or more labels are similarly
+    large, the plan's labels are genuinely spread out and nothing is flagged.
+    """
+    numeric = sorted(
+        {round(float(z)) for z in raw_zones if _is_whole_pos_number(z)}, reverse=True
+    )
+    reference = max(
+        numeric[MAX_OUTLIERS] if len(numeric) > MAX_OUTLIERS else 0,
+        default_num_districts,
+    )
+    cutoff = OUTLIER_FACTOR * reference
+    outlier_values = {n for n in numeric[:MAX_OUTLIERS] if n > cutoff}
+    return {
+        z
+        for z in raw_zones
+        if _is_whole_pos_number(z) and round(float(z)) in outlier_values
+    }
+
+
 def _build_zone_mapping(
-    raw_zones: set[str], num_districts: int | None
+    raw_zones: set[str], zone_cap: int, outlier_reference: int | None = None
 ) -> tuple[dict[str, int], set[str]]:
     """Map raw zone strings to integer zone IDs.
 
     Whole-number strings (e.g. '2', '2.0') are parsed directly; all other
-    strings (e.g. 'District 1', '01') and out-of-bounds numbers (e.g. '5' on a
-    3-district map) are remapped to unused integer slots in [1, num_districts].
-    Raises ValueError if the total number of distinct zones exceeds num_districts.
+    strings (e.g. 'District 1', '01') and numbers above zone_cap (e.g. '5' with
+    a cap of 3) are remapped to unused integer slots in [1, zone_cap].
+    Raises ValueError if the total number of distinct zones exceeds zone_cap.
+
+    When outlier_reference is given (the map's default district count, on
+    modifiable maps where labels drive the document's district count), numeric
+    labels flagged by _detect_outlier_labels are remapped like non-numeric ones.
 
     Returns:
         (mapping, remapped_keys) where remapped_keys is the set of labels that
-        were assigned a new slot — non-numeric strings, empty string, and
-        out-of-bounds numbers.
+        were assigned a new slot — non-numeric strings, empty string,
+        above-cap numbers, and detected outliers.
     """
+    outliers: set[str] = set()
+    if outlier_reference is not None:
+        outliers = _detect_outlier_labels(raw_zones, outlier_reference)
+
     numeric_map: dict[str, int] = {}
     string_labels: list[str] = []
     for z in raw_zones:
-        if _is_whole_pos_number(z):
+        if _is_whole_pos_number(z) and z not in outliers:
             n = round(float(z))
-            if num_districts is None or n <= num_districts:
+            if n <= zone_cap:
                 numeric_map[z] = n
             else:
                 string_labels.append(z)
@@ -72,14 +119,13 @@ def _build_zone_mapping(
 
     used_ids = set(numeric_map.values())
     total_zones = len(used_ids) + len(string_labels)
-    if num_districts is not None and total_zones > num_districts:
+    if total_zones > zone_cap:
         raise ValueError(
             f"Too many districts: CSV contains {total_zones} distinct districts "
-            f"but the map only has {num_districts} districts"
+            f"but the map only has {zone_cap} districts"
         )
 
-    cap = num_districts or total_zones
-    available = [i for i in range(1, cap + 1) if i not in used_ids][
+    available = [i for i in range(1, zone_cap + 1) if i not in used_ids][
         : len(string_labels)
     ]
     mapping = {**numeric_map, **dict(zip(string_labels, available))}
@@ -243,13 +289,36 @@ def batch_insert_assignments(
 
     G = get_graph(districtr_map.gerrydb_table_name)
 
-    num_districts = districtr_map.num_districts
+    if districtr_map.num_districts_modifiable:
+        # The uploaded plan drives the district count, so distinct zones are
+        # capped only by the global bound rather than the map's default.
+        zone_cap = MAX_DISTRICTS
+    elif districtr_map.num_districts is None:
+        # Broken map row: a fixed-district map without a district count can
+        # neither bound nor display zones. RuntimeError (not ValueError) so it
+        # surfaces as a 500 rather than being blamed on the upload.
+        raise RuntimeError(
+            f"Data issue: map {districtr_map.districtr_map_slug!r} has "
+            "num_districts_modifiable=False but num_districts is NULL"
+        )
+    else:
+        zone_cap = districtr_map.num_districts
 
     raw_zones: set[str] = set()
     for record in assignments:
         raw_zones.add(record[1])
 
-    zone_mapping, remapped_keys = _build_zone_mapping(raw_zones, num_districts)
+    zone_mapping, remapped_keys = _build_zone_mapping(
+        raw_zones,
+        zone_cap,
+        # Only modifiable maps grow their district count from labels, so only
+        # they are exposed to accidental labels inflating it (e.g. '196').
+        outlier_reference=(
+            (districtr_map.num_districts or 2)
+            if districtr_map.num_districts_modifiable
+            else None
+        ),
+    )
 
     skipped_geo_ids: list[str] = []
     seen_geo_ids: set[str] = set()
@@ -310,4 +379,5 @@ def batch_insert_assignments(
         inserted=inserted,
         skipped_geo_ids=skipped_geo_ids,
         zone_label_remapping=zone_label_remapping,
+        max_assigned_zone=max(valid_zone_ids, default=None),
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -454,6 +454,19 @@ async def create_document(
             total_assignments = insert_result.inserted
             skipped_geo_ids = insert_result.skipped_geo_ids
             zone_label_remapping = insert_result.zone_label_remapping
+            # On modifiable maps the uploaded plan can grow the district count
+            # beyond the map's default, but never shrink it — a partial plan
+            # keeps the default and the user can still lower it manually.
+            if (
+                districtr_map.num_districts_modifiable
+                and insert_result.max_assigned_zone is not None
+                and insert_result.max_assigned_zone > (districtr_map.num_districts or 2)
+            ):
+                new_document.num_districts = insert_result.max_assigned_zone
+                session.add(new_document)
+                # The response select below reads through session.connection(),
+                # which does not autoflush.
+                session.flush()
             for original_label, new_zone in zone_label_remapping.items():
                 display_label = original_label if original_label else "(blank)"
                 label_comment = Comment(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -70,7 +70,10 @@ class DistrictrMap(TimeStampMixin, SQLModel, table=True):
     # We'll want to enforce the constraint tha the gerrydb_table_name is either in
     # GerrydbTable.name or a materialized view of two GerryDBTables some other way.
     gerrydb_table_name: str | None = Field(nullable=True)
-    # Null means default number of districts? Should we have a sensible default?
+    # On fixed maps (num_districts_modifiable=False) this is the exact district
+    # count and must not be NULL (batch_insert_assignments raises on such rows).
+    # On modifiable/custom maps it is the default and floor for new documents:
+    # a CSV upload can grow a document's count beyond it but never below it.
     num_districts: int | None = Field(nullable=True, default=None)
     # If False, users cannot change the number of districts on the frontend.
     num_districts_modifiable: bool = Field(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -454,6 +454,29 @@ def simple_parent_child_geos_districtr_map_fixture(
     return inserted_districtr_map
 
 
+@pytest.fixture(name="simple_shatterable_fixed_districtr_map")
+def simple_shatterable_fixed_districtr_map_fixture(
+    session: Session, simple_shatterable_districtr_map
+):
+    """Same layers/graph as simple_geos but num_districts_modifiable=False."""
+    inserted_districtr_map = create_districtr_map(
+        session,
+        name="Simple shatterable layer (fixed districts)",
+        districtr_map_slug="simple_geos_fixed",
+        gerrydb_table_name="simple_geos",
+        num_districts=3,
+        num_districts_modifiable=False,
+        tiles_s3_path="tilesets/simple_shatterable_layer.pmtiles",
+        parent_layer="simple_parent_geos",
+        child_layer="simple_child_geos",
+    )
+    create_parent_child_edges(
+        session=session, districtr_map_uuid=inserted_districtr_map
+    )
+    session.commit()
+    return inserted_districtr_map
+
+
 @pytest.fixture(name="simple_child_geos_nonshatterable_districtr_map")
 def simple_child_geos_nonshatterable_districtr_map_fixture(
     session: Session, simple_child_geos_gerrydb

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import pytest
 
-from app.assignments.assignments import _heal_or_fill
+from app.assignments.assignments import _detect_outlier_labels, _heal_or_fill
 
 
 @pytest.fixture
@@ -76,3 +76,40 @@ def test_no_child_nodes_unaffected(two_parent_graph):
     two_parent_graph.add_node("standalone")
     result = _heal_or_fill({"standalone": 3}, two_parent_graph)
     assert result == {"standalone": 3}
+
+
+# --- outlier label detection ---
+
+
+def test_outlier_single_huge_label_flagged():
+    # A lone zone labeled '196' on a map defaulting to 8 districts is accidental.
+    assert _detect_outlier_labels({"196"}, 8) == {"196"}
+
+
+def test_outlier_partial_plan_label_trusted():
+    # 'district 5 of 8' style partial plans are within the reference — trusted.
+    assert _detect_outlier_labels({"5"}, 8) == set()
+
+
+def test_outlier_among_dense_labels_flagged():
+    labels = {str(i) for i in range(1, 11)} | {"196"}
+    assert _detect_outlier_labels(labels, 8) == {"196"}
+
+
+def test_two_outliers_flagged():
+    labels = {str(i) for i in range(1, 11)} | {"150", "196"}
+    assert _detect_outlier_labels(labels, 8) == {"150", "196"}
+
+
+def test_spread_out_labels_trusted():
+    # Three similarly large labels anchor the reference — genuinely spread out.
+    assert _detect_outlier_labels({"100", "200", "300"}, 8) == set()
+
+
+def test_dense_plan_untouched():
+    labels = {str(i) for i in range(1, 18)}
+    assert _detect_outlier_labels(labels, 8) == set()
+
+
+def test_non_numeric_labels_ignored_by_detection():
+    assert _detect_outlier_labels({"District A", "District B"}, 8) == set()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1057,14 +1057,15 @@ def test_zone_label_remapping_returned_and_excludes_numeric(
 
 
 def test_zone_label_remapping_returned_and_excludes_numeric_with_out_of_bounds(
-    client, simple_shatterable_districtr_map, mock_grid_graph_file
+    client, simple_shatterable_fixed_districtr_map, mock_grid_graph_file
 ):
-    # Zone "1" is in-bounds (num_districts=3) — must NOT appear in remapping.
-    # Zone "5" exceeds num_districts=3, so it gets reassigned — must appear.
+    # On a fixed-districts map: zone "1" is in-bounds (num_districts=3) — must
+    # NOT appear in remapping. Zone "5" exceeds num_districts=3, so it gets
+    # reassigned — must appear.
     response = client.post(
         "/api/create_document",
         json={
-            "districtr_map_slug": "simple_geos",
+            "districtr_map_slug": "simple_geos_fixed",
             "assignments": [
                 ["000010000000001", "1"],
                 ["000010000000003", "1"],
@@ -1078,6 +1079,28 @@ def test_zone_label_remapping_returned_and_excludes_numeric_with_out_of_bounds(
     assert "5" in remapping
     assert remapping["5"] != 5
     assert "1" not in remapping
+
+
+def test_out_of_bounds_zone_accepted_on_modifiable_map(
+    client, simple_shatterable_districtr_map, mock_grid_graph_file
+):
+    # On a modifiable map, zone "5" beyond the default num_districts=3 is kept
+    # as-is (no remapping) and the document's num_districts grows to match.
+    response = client.post(
+        "/api/create_document",
+        json={
+            "districtr_map_slug": "simple_geos",
+            "assignments": [
+                ["000010000000001", "1"],
+                ["000010000000003", "1"],
+                ["000010000000006", "5"],
+            ],
+        },
+    )
+    data = response.json()
+    assert response.status_code == 201, data.get("detail")
+    assert data.get("zone_label_remapping", {}) == {}
+    assert data["num_districts"] == 5
 
 
 def test_zone_label_remapping_excludes_labels_with_no_valid_geoids(
@@ -1126,9 +1149,101 @@ def test_zone_label_remapping_blank_label(
 
 
 def test_new_document_from_block_assignments_too_many_unique_zones(
+    client, simple_shatterable_fixed_districtr_map, mock_grid_graph_file
+):
+    # 5 distinct zones with num_districts=3 on a fixed map → ValueError → 422.
+    response = client.post(
+        "/api/create_document",
+        json={
+            "districtr_map_slug": "simple_geos_fixed",
+            "assignments": [
+                ["000010000000001", "1"],
+                ["000010000000002", "2"],
+                ["000010000000003", "3"],
+                ["000010000000004", "4"],
+                ["000010000000005", "1"],
+                ["000010000000006", "5"],
+            ],
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_fixed_map_without_num_districts_raises(
+    client, session, simple_shatterable_districtr_map, mock_grid_graph_file
+):
+    # A fixed-district map with num_districts=NULL is broken data; uploading
+    # assignments to it must fail loudly rather than silently uncapping zones.
+    create_districtr_map(
+        session,
+        name="Broken fixed map",
+        districtr_map_slug="simple_geos_broken",
+        gerrydb_table_name="simple_geos",
+        num_districts=None,
+        num_districts_modifiable=False,
+        parent_layer="simple_parent_geos",
+        child_layer="simple_child_geos",
+    )
+    session.commit()
+    with pytest.raises(RuntimeError, match="num_districts is NULL"):
+        client.post(
+            "/api/create_document",
+            json={
+                "districtr_map_slug": "simple_geos_broken",
+                "assignments": [["000010000000001", "1"]],
+            },
+        )
+
+
+def test_partial_plan_keeps_default_num_districts_on_modifiable_map(
     client, simple_shatterable_districtr_map, mock_grid_graph_file
 ):
-    # 5 distinct zones with num_districts=3 → ValueError → 422.
+    # A partial plan using fewer zones than the map's default (num_districts=3)
+    # must not shrink the document's district count below that default.
+    response = client.post(
+        "/api/create_document",
+        json={
+            "districtr_map_slug": "simple_geos",
+            "assignments": [
+                ["000010000000001", "1"],
+                ["000010000000003", "2"],
+            ],
+        },
+    )
+    data = response.json()
+    assert response.status_code == 201, data.get("detail")
+    assert data["num_districts"] == 3
+
+
+def test_outlier_zone_label_remapped_on_modifiable_map(
+    client, simple_shatterable_districtr_map, mock_grid_graph_file
+):
+    # A lone accidental label ('196' on a default-3 map) is remapped instead of
+    # inflating the district count; the original label is reported so it can be
+    # preserved as a district comment.
+    response = client.post(
+        "/api/create_document",
+        json={
+            "districtr_map_slug": "simple_geos",
+            "assignments": [
+                ["000010000000001", "1"],
+                ["000010000000003", "196"],
+            ],
+        },
+    )
+    data = response.json()
+    assert response.status_code == 201, data.get("detail")
+    assert data["num_districts"] == 3
+    remapping = data.get("zone_label_remapping", {})
+    assert "196" in remapping
+    assert remapping["196"] <= 3
+
+
+def test_many_unique_zones_accepted_on_modifiable_map(
+    client, simple_shatterable_districtr_map, mock_grid_graph_file
+):
+    # 5 distinct zones exceed the modifiable map's default num_districts=3;
+    # the upload succeeds and the document's num_districts follows the CSV.
     response = client.post(
         "/api/create_document",
         json={
@@ -1143,7 +1258,9 @@ def test_new_document_from_block_assignments_too_many_unique_zones(
             ],
         },
     )
-    assert response.status_code == 422
+    data = response.json()
+    assert response.status_code == 201, data.get("detail")
+    assert data["num_districts"] == 5
 
 
 def test_new_document_from_block_assignments_no_children(


### PR DESCRIPTION
Part of #605. Built on the v2 modules from #621 (merged).

**Problem:** the CSV uploader infers the target map module from the state FIPS in the uploaded GEOIDs and always lands on the state's congressional map. Those maps have a fixed `num_districts`, so an uploaded plan with a different number of zones (e.g. a state-legislative plan) gets clamped to the congressional district count.

**Fix:**

- The importer's map lookup in `upload.ts` now targets only the state's custom (modifiable-district) map — `{state}_custom_districts_v2`, falling back to the v1 `{state}_custom_districts` slug while pre-v2 environments remain in service — and errors clearly when neither is visible. No fallback to congressional or state-senate maps: their fixed `num_districts` clamping uploads was the bug. The uploader accordingly fetches only the `custom` map group.
- Uploads to a modifiable-district map are no longer clamped to that map's fixed `num_districts`; only the global 538-zone bound applies, and the document's `num_districts` is set to the highest assigned zone after insert.

**Also in this branch:**

- Custom maps' default `num_districts` acts as a **floor**: partial plans keep the default district count and can only grow it, never shrink it.
- **Outlier label detection**: an accidental numeric zone label (>5x a reference value, at most two per upload) is remapped to a low slot instead of inflating the district count; reported and preserved as a district comment. Partial and genuinely spread-out plans are untouched.
- Small fixes: a fixed-district map with `num_districts=NULL` now raises (500) instead of silently uncapping zones; `parseGeoid` classifies split block groups (`-datadem-N`) as `bg` instead of unrecognized; added DC to `US_STATE_META`, closing a gap that broke DC CSV resolution, lowercased DC's community-map label, and (via a companion fix) a dropdown 404 shared with Puerto Rico.

**Scope note:** this branch is importer logic, plus the `US_STATE_META` fix above and its one-line follow-on in the homepage place-picker (`PlaceMap.tsx`) — both discovered testing the importer change live. The `{state}_custom_districts` config and `load_data.py` changes this branch once carried shipped in #621 (v2-based custom maps, group auto-creation, `num_districts_modifiable` pass-through) and were dropped here at the rebase, which also absorbs #625's assignments-table departitioning.

**Deployment constraint:** the module lookup goes through the visible-filtered views API, so this must not reach an environment without a visible custom module per state. AWS dev has the v2 modules visible; Fly dev previews resolve to the v1 custom maps loaded there; prod's v2 modules are loaded but hidden pending the v1→v2 launch flip — promote to prod only after that flip.

## Tested

**Before merge — Fly deployment preview.** Fly's dev DB carries only v1 custom maps today — every check below resolves the *v1* custom slug, not `_v2`. This still exercises the importer logic fully.

- [x] Uploaded a CA block CSV; document landed on `CA Districts` (`ca_custom_districts`, the v1 slug) with the district count following the CSV zones, adjustable.
- [x] A CSV with more zones than the state's congressional count (17-district CO plan) opens with all 17, instead of the previous "Too many districts" error; fewer zones (4-district CO plan) keeps the default 8, reducible manually.
- [x] A CSV with an accidental zone label (e.g. "196" alongside zones 1-8): upload succeeds, count stays at default, "196" reported as remapped and saved as a district comment.

**After merge — AWS dev/prod.** Both AWS backends carry the v2 catalog (unlike Fly); dev is already flipped to v2-visible, prod's is loaded but hidden pending the launch flip.

- [ ] The same CA CSV upload lands on `ca_custom_districts_v2` on dev.districtr.org.
- [ ] `/place/dc`'s community-map button reads "Washington, DC" (was lowercased pre-fix).
- [ ] After the prod launch flip: repeat the CA CSV check against prod.

