### PR TITLE
Untrack `.beads/interactions.jsonl` (runtime log, already gitignored)

### DIFF
--- a/app/src/app/components/AppNotification.tsx
+++ b/app/src/app/components/AppNotification.tsx
@@ -99,10 +99,10 @@ export const AppNotification = () => {
             key={seq}
             className={`flex flex-col rounded-lg border p-4 text-white shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] data-[swipe=cancel]:translate-x-0 data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[state=closed]:animate-hide data-[state=open]:animate-slideIn data-[swipe=end]:animate-swipeOut data-[swipe=cancel]:transition-[transform_200ms_ease-out] ${toastClass}`}
             open={uiActive}
-            onOpenChange={(openChange) => {
-              setUiActive(openChange)
+            onOpenChange={openChange => {
+              setUiActive(openChange);
               if (!openChange) {
-                setNotification({})
+                setNotification({});
               }
             }}
           >

--- a/app/src/app/components/Topbar/MapActionsDropdown.tsx
+++ b/app/src/app/components/Topbar/MapActionsDropdown.tsx
@@ -98,9 +98,7 @@ export const MapActionsDropdown: React.FC<{
               onSelect={() => save()}
             >
               Save map
-              <Text size="1">
-                (autosave on)
-              </Text>
+              <Text size="1">(autosave on)</Text>
               {isOutdated && <CloudNotSavedIcon className="size-4" />}
             </DropdownMenu.Item>
           )}


### PR DESCRIPTION
`.beads/.gitignore` declares `interactions.jsonl` runtime-only, but the file was committed in #500, and gitignore has no effect on already-tracked files — so local bd activity shows up as a dirty tracked file that can ride along in unrelated commits.

**Fix:** `git rm --cached` the file; the existing ignore entry takes over from there. Each clone keeps its local copy untouched (git deletes it from the index only, not the working tree).