### PR TITLE
Perf/stress test findings revisions

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -6,6 +6,10 @@ from app.core.config import settings
 engine = create_engine(
     str(settings.SQLALCHEMY_DATABASE_URI),
     echo=settings.ECHO_DB,
+    # 60/task; RDS max_connections ~900 caps us at ~14 tasks. Keep in step
+    # with the anyio threadpool limiter (app/main.py lifespan).
+    pool_size=40,
+    max_overflow=20,
     pool_pre_ping=True,
     pool_recycle=3600,
 )

--- a/backend/app/evaluation/graph.py
+++ b/backend/app/evaluation/graph.py
@@ -53,7 +53,9 @@ def get_gerrydb_graph(file_path: str) -> Graph:
         return pickle.load(f)
 
 
-_GRAPH_CACHE_MAX_SIZE = 10
+# Must exceed the distinct-map working set or evictions force multi-second
+# cold S3 reloads; each cached graph costs real memory, so raise with care.
+_GRAPH_CACHE_MAX_SIZE = 15
 
 
 @lru_cache(maxsize=_GRAPH_CACHE_MAX_SIZE)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, Response
 from typing import Annotated, Any
+import anyio
 import msgpack
 import psutil
 import time
@@ -116,6 +117,9 @@ if settings.ENVIRONMENT in ("production", "qa"):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Sync-route concurrency; default 40 would cap below the DB pool
+    # (60/task, app/core/db.py). Needs a running event loop, hence lifespan.
+    anyio.to_thread.current_default_thread_limiter().total_tokens = 80
     yield
 
 

--- a/backend/stress_test/runner/provision.sh
+++ b/backend/stress_test/runner/provision.sh
@@ -20,6 +20,14 @@ REPO_SHA="${REPO_SHA:?Set REPO_SHA to the pinned commit containing backend/stres
 # Backend S3 bucket (pulumi config s3BucketName / task env R2_BUCKET_NAME);
 # artifacts live under stress-test/.
 RESULTS_BUCKET="${RESULTS_BUCKET:?Set RESULTS_BUCKET to the backend S3 bucket name}"
+# Easy slip: the ALB access-logs bucket, which the IAM policy can't write to.
+case "$RESULTS_BUCKET" in
+  *alb-logs*)
+    echo "RESULTS_BUCKET ($RESULTS_BUCKET) looks like the ALB access-logs bucket;" \
+      "use the backend data bucket (pulumi config s3BucketName, e.g. districtr-cdn-data-f1eb3d1)" >&2
+    exit 1
+    ;;
+esac
 
 export AWS_DEFAULT_REGION="$REGION"
 

--- a/backend/stress_test/runner/run.sh
+++ b/backend/stress_test/runner/run.sh
@@ -13,6 +13,14 @@ RUN_ID="${RUN_ID:?Set RUN_ID}"
 SCALE="${SCALE:-0.01}"
 WINDOW_SECONDS="${WINDOW_SECONDS:-900}"
 RESULTS_BUCKET="${RESULTS_BUCKET:?Set RESULTS_BUCKET to the backend S3 bucket name}"
+# Same guard as provision.sh: the ALB access-logs bucket is not writable here.
+case "$RESULTS_BUCKET" in
+  *alb-logs*)
+    echo "RESULTS_BUCKET ($RESULTS_BUCKET) looks like the ALB access-logs bucket;" \
+      "use the backend data bucket (e.g. districtr-cdn-data-f1eb3d1)" >&2
+    exit 1
+    ;;
+esac
 BASE_URL="${BASE_URL:-https://api.beta.districtr.org}"
 CLUSTER="${CLUSTER:-districtr-prod}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-2}"

--- a/infra/backend.ts
+++ b/infra/backend.ts
@@ -169,6 +169,24 @@ export function createBackend(
     },
   });
 
+  // The workload is I/O-bound, so CPU stays low while requests queue and the
+  // policy above never fires. ECS scales out when either policy demands it.
+  new aws.appautoscaling.Policy(`${name}-backend-req-scaling-policy`, {
+    policyType: "TargetTrackingScaling",
+    serviceNamespace: scalingTarget.serviceNamespace,
+    scalableDimension: scalingTarget.scalableDimension,
+    resourceId: scalingTarget.resourceId,
+    targetTrackingScalingPolicyConfiguration: {
+      predefinedMetricSpecification: {
+        predefinedMetricType: "ALBRequestCountPerTarget",
+        resourceLabel: pulumi.interpolate`${alb.alb.arnSuffix}/${alb.backendTargetGroup.arnSuffix}`,
+      },
+      targetValue: config.backendRequestsPerTarget,
+      scaleOutCooldown: 60,
+      scaleInCooldown: 300,
+    },
+  });
+
   return {service};
 }
 

--- a/infra/config.ts
+++ b/infra/config.ts
@@ -60,6 +60,8 @@ export const config = {
   backendMemory: cfg.getNumber("backendMemory") ?? 8192,
   backendMinCount: cfg.getNumber("backendMinCount") ?? (isProd ? 2 : 1),
   backendMaxCount: cfg.getNumber("backendMaxCount") ?? (isProd ? 6 : 2),
+  // ALB requests/min per backend task before scale-out.
+  backendRequestsPerTarget: cfg.getNumber("backendRequestsPerTarget") ?? 600,
   frontendCpu: cfg.getNumber("frontendCpu") ?? (isProd ? 1024 : 512),
   frontendMemory: cfg.getNumber("frontendMemory") ?? 2048,
   frontendMinCount: cfg.getNumber("frontendMinCount") ?? (isProd ? 2 : 1),


### PR DESCRIPTION
<!--- Title: Raise backend concurrency ceilings from stress test run1 findings -->

## Description

Stress test `run1` (2026-07-15, 12,750 simulated users vs api.beta.districtr.org) failed 94% of requests while compute sat idle (ECS CPU 15%, RDS 17%). Every failure was config, not hardware: autoscaling watched CPU (which an I/O-bound workload never raises), each task's DB pool defaulted to 15 connections, and the anyio threadpool capped sync routes at 40.

- **Autoscale on request count** (`infra/backend.ts`, `infra/config.ts`): adds a second target-tracking policy on `ALBRequestCountPerTarget` alongside the existing CPU policy — ECS scales out when either fires. Target is 600 req/min/task, overridable per stack via the new `backendRequestsPerTarget` config. Run1's traffic (~390 req/min/target) would have triggered scale-out immediately; instead the fleet stayed at 2 tasks the whole run.
- **Raise per-task DB pool** (`backend/app/core/db.py`): `pool_size=40, max_overflow=20` (60/task vs SQLAlchemy's default 15, which was run1's hard concurrency wall). At 60/task, RDS `max_connections` (~900) allows ~14 tasks — above the current max of 6.
- **Raise anyio threadpool limiter to 80** (`backend/app/main.py`): the default 40 tokens would have capped sync-route concurrency below the new pool; the extra 20 threads cover non-DB work (S3 graph loads, evals).
- **Graph LRU cache 10 → 15** (`backend/app/evaluation/graph.py`): run1 touched ~11 distinct maps against a maxsize of 10, so evictions forced multi-second cold S3 reloads.
- **Guard `RESULTS_BUCKET` in the stress runner** (`backend/stress_test/runner/provision.sh`, `run.sh`): fail fast if it matches `*alb-logs*` — run1's IAM policy was accidentally provisioned against the ALB access-logs bucket.

## Reviewers

- Primary: @fangge518 
- Secondary:
