### PR TITLE
Departition assignments tables + fix stress-test viewer traffic model

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -86,12 +86,8 @@ def include_object(object, name, type_, reflected, compare_to):
 
     if name and (
         name in POST_GIS_ALPINE_RESERVED_TABLES
-        or re.match(r"document.assignments_.+", name)
-        or re.match(r"document.community_assignments_.+", name)
         or re.match(r"parentchildedges_.+", name)
         or re.match(r".*_districtr_view+", name)
-        # For whatever reason alembic fails to recognize it already exists
-        or name == "document_geo_id_unique"
     ):
         return False
     return True

--- a/backend/app/alembic/versions/7e57b49573e0_departition_assignments_tables.py
+++ b/backend/app/alembic/versions/7e57b49573e0_departition_assignments_tables.py
@@ -1,0 +1,116 @@
+"""departition assignments tables
+
+Replace per-document LIST partitioning of document.assignments and
+document.community_assignments with plain tables. CREATE TABLE ... PARTITION OF
+takes an ACCESS EXCLUSIVE lock on the parent, so every document creation (and
+the reset endpoint's DROP+CREATE) globally blocked all assignment reads and
+writes — the lock convoy behind the July 2026 stress-test collapses (~93%
+failure with app and DB CPU idle; RDS lock waits concentrated on
+get_assignments). Plain tables take row locks only.
+
+Alternatives measured against the resulting big table (260k rows dev / EXPLAIN
+ANALYZE on the largest document, 38k rows): the composite-PK lookup resolves a
+document in ~4ms of a ~115ms get_assignments query — the rest is the
+parentchildedges LEFT JOIN — so fixed HASH partitioning was rejected (it would
+shave microseconds off the cheap part while reintroducing partition machinery).
+A nested-loop join via the existing (child_path, districtr_map) index was also
+tested: 140ms, worse than the planner's hash join. If get_assignments ever
+needs to be faster, denormalize parent_path onto assignments; don't partition.
+
+Revision ID: 7e57b49573e0
+Revises: 3e2c40e7d148
+Create Date: 2026-07-16 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7e57b49573e0"
+down_revision: Union[str, None] = "3e2c40e7d148"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Serialize against all app writers for the whole transaction. Without
+    # this, a write committing between the INSERT..SELECT and the DROP would
+    # be silently lost.
+    op.execute("LOCK TABLE document.assignments IN ACCESS EXCLUSIVE MODE")
+    op.execute("LOCK TABLE document.community_assignments IN ACCESS EXCLUSIVE MODE")
+
+    op.execute(
+        """
+        CREATE TABLE document.assignments_new (
+            document_id UUID NOT NULL,
+            geo_id VARCHAR NOT NULL,
+            zone INTEGER
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO document.assignments_new (document_id, geo_id, zone)
+        SELECT document_id, geo_id, zone FROM document.assignments
+        """
+    )
+    # CASCADE drops every per-document partition (public."document.assignments_<uuid>")
+    op.execute("DROP TABLE document.assignments CASCADE")
+    op.execute("ALTER TABLE document.assignments_new RENAME TO assignments")
+    # PK added after the bulk load: one fast index build instead of
+    # incremental maintenance. Old PK was named document_geo_id_unique.
+    op.execute(
+        """
+        ALTER TABLE document.assignments
+        ADD CONSTRAINT assignments_pkey PRIMARY KEY (document_id, geo_id)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE document.community_assignments_new (
+            document_id UUID NOT NULL,
+            community_id SMALLINT NOT NULL,
+            geo_id VARCHAR NOT NULL
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO document.community_assignments_new (document_id, community_id, geo_id)
+        SELECT document_id, community_id, geo_id FROM document.community_assignments
+        """
+    )
+    op.execute("DROP TABLE document.community_assignments CASCADE")
+    op.execute("ALTER TABLE document.community_assignments_new RENAME TO community_assignments")
+    op.execute(
+        """
+        ALTER TABLE document.community_assignments
+        ADD CONSTRAINT community_assignments_pkey
+        PRIMARY KEY (document_id, community_id, geo_id)
+        """
+    )
+    # Intentionally not recreated:
+    #  - ix_document_community_assignments_community_id / _geo_id: every query
+    #    filters on document_id first, so the PK prefix covers them; dropping
+    #    them removes index write amplification on the full-rewrite save path.
+
+    # Legacy DB UDFs that emit CREATE TABLE ... PARTITION OF — unused by app
+    # code and broken against plain tables. Their .sql source files stay on
+    # disk: b7adbf498feb / fa7d5c356d1f read them at upgrade time on fresh DBs.
+    op.execute("DROP FUNCTION IF EXISTS create_document(TEXT)")
+    op.execute("DROP FUNCTION IF EXISTS create_assignment_partition_sql(TEXT)")
+
+    # Fresh tables have no planner stats until autoanalyze runs.
+    op.execute("ANALYZE document.assignments")
+    op.execute("ANALYZE document.community_assignments")
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Irreversible: restoring per-document LIST partitioning would require "
+        "one CREATE TABLE ... PARTITION OF per existing document, recreating "
+        "the design this migration removes. Roll back via DB snapshot."
+    )

--- a/backend/app/alembic/versions/7e57b49573e0_departition_assignments_tables.py
+++ b/backend/app/alembic/versions/7e57b49573e0_departition_assignments_tables.py
@@ -1,0 +1,106 @@
+"""departition assignments tables
+
+Replace per-document LIST partitioning of document.assignments and
+document.community_assignments with plain tables. CREATE TABLE ... PARTITION OF
+takes an ACCESS EXCLUSIVE lock on the parent, so every document creation (and
+the reset endpoint's DROP+CREATE) globally blocked all assignment reads and
+writes — the lock convoy that collapsed stress runs 1 and 2 (see
+backend/stress_test/RUN2_FINDINGS.md). Plain tables take row locks only.
+
+Revision ID: 7e57b49573e0
+Revises: 3e2c40e7d148
+Create Date: 2026-07-16 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7e57b49573e0"
+down_revision: Union[str, None] = "3e2c40e7d148"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Serialize against all app writers for the whole transaction. Without
+    # this, a write committing between the INSERT..SELECT and the DROP would
+    # be silently lost.
+    op.execute("LOCK TABLE document.assignments IN ACCESS EXCLUSIVE MODE")
+    op.execute("LOCK TABLE document.community_assignments IN ACCESS EXCLUSIVE MODE")
+
+    op.execute(
+        """
+        CREATE TABLE document.assignments_new (
+            document_id UUID NOT NULL,
+            geo_id VARCHAR NOT NULL,
+            zone INTEGER
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO document.assignments_new (document_id, geo_id, zone)
+        SELECT document_id, geo_id, zone FROM document.assignments
+        """
+    )
+    # CASCADE drops every per-document partition (public."document.assignments_<uuid>")
+    op.execute("DROP TABLE document.assignments CASCADE")
+    op.execute("ALTER TABLE document.assignments_new RENAME TO assignments")
+    # PK added after the bulk load: one fast index build instead of
+    # incremental maintenance. Old PK was named document_geo_id_unique.
+    op.execute(
+        """
+        ALTER TABLE document.assignments
+        ADD CONSTRAINT assignments_pkey PRIMARY KEY (document_id, geo_id)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE document.community_assignments_new (
+            document_id UUID NOT NULL,
+            community_id SMALLINT NOT NULL,
+            geo_id VARCHAR NOT NULL
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO document.community_assignments_new (document_id, community_id, geo_id)
+        SELECT document_id, community_id, geo_id FROM document.community_assignments
+        """
+    )
+    op.execute("DROP TABLE document.community_assignments CASCADE")
+    op.execute("ALTER TABLE document.community_assignments_new RENAME TO community_assignments")
+    op.execute(
+        """
+        ALTER TABLE document.community_assignments
+        ADD CONSTRAINT community_assignments_pkey
+        PRIMARY KEY (document_id, community_id, geo_id)
+        """
+    )
+    # Intentionally not recreated:
+    #  - ix_document_community_assignments_community_id / _geo_id: every query
+    #    filters on document_id first, so the PK prefix covers them; dropping
+    #    them removes index write amplification on the full-rewrite save path.
+
+    # Legacy DB UDFs that emit CREATE TABLE ... PARTITION OF — unused by app
+    # code and broken against plain tables. Their .sql source files stay on
+    # disk: b7adbf498feb / fa7d5c356d1f read them at upgrade time on fresh DBs.
+    op.execute("DROP FUNCTION IF EXISTS create_document(TEXT)")
+    op.execute("DROP FUNCTION IF EXISTS create_assignment_partition_sql(TEXT)")
+
+    # Fresh tables have no planner stats until autoanalyze runs.
+    op.execute("ANALYZE document.assignments")
+    op.execute("ANALYZE document.community_assignments")
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Irreversible: restoring per-document LIST partitioning would require "
+        "one CREATE TABLE ... PARTITION OF per existing document, recreating "
+        "the design this migration removes. Roll back via DB snapshot."
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,7 +28,7 @@ import logging
 from sqlalchemy import bindparam
 from sqlmodel import ARRAY
 from datetime import datetime
-from uuid import UUID, uuid4
+from uuid import uuid4
 import sentry_sdk
 from prometheus_fastapi_instrumentator import Instrumentator
 from app.assignments import (
@@ -192,67 +192,6 @@ def update_timestamp(
     )
     updated_at = session.connection().execute(update_stmt).scalar_one()
     return updated_at
-
-
-_PARTITION_TABLES = ("assignments", "community_assignments")
-
-
-def _validate_partition_identifiers(document_id: str, table_name: str) -> None:
-    if table_name not in _PARTITION_TABLES:
-        raise ValueError(
-            f"Unsupported partition table: {table_name!r}. "
-            f"Expected one of {_PARTITION_TABLES}."
-        )
-    try:
-        UUID(document_id)
-    except (ValueError, TypeError, AttributeError) as exc:
-        raise ValueError(f"document_id must be a UUID; got {document_id!r}") from exc
-
-
-def create_document_partition(
-    session: Session, document_id: str, table_name: str
-) -> None:
-    """
-    Create a partition for a document in the specified table (assignments or community_assignments).
-
-    Args:
-        session (Session): The database session to use for executing the SQL statement.
-        document_id (str): The ID of the document for which to create the partition.
-        table_name (str): Must be one of "assignments" or "community_assignments".
-    """
-    _validate_partition_identifiers(document_id, table_name)
-    partition_name = f"document.{table_name}_{document_id}"
-    stmt = text(f"""
-        CREATE TABLE "{partition_name}"
-        PARTITION OF document.{table_name}
-        FOR VALUES IN ('{document_id}')
-    """)
-    session.connection().execute(stmt)
-
-
-def reset_document_partition(
-    session: Session, document_id: str, table_name: str
-) -> None:
-    """
-    Drop and recreate a partition for a document in the specified table
-    (assignments or community_assignments).
-
-    Args:
-        session (Session): The database session to use for executing the SQL statements.
-        document_id (str): The ID of the document for which to reset the partition.
-        table_name (str): Must be one of "assignments" or "community_assignments".
-    """
-    _validate_partition_identifiers(document_id, table_name)
-    partition_name = f"document.{table_name}_{document_id}"
-    session.connection().execute(
-        text(f'DROP TABLE IF EXISTS "{partition_name}" CASCADE;')
-    )
-    stmt = text(f"""
-        CREATE TABLE "{partition_name}"
-        PARTITION OF document.{table_name}
-        FOR VALUES IN ('{document_id}')
-    """)
-    session.connection().execute(stmt)
 
 
 def duplicate_document_comments(
@@ -457,11 +396,6 @@ async def create_document(
     )
     session.add(new_document)
     session.flush()  # Flush to get the public_id assigned
-    # Under most circumstances, we DO NOT want to use f-strings in SQL statements.
-    # However, in this case, we are using a dynamic table name, and SQLAlchemy / Postgres do not
-    # support bind params for identifiers or partition values, so we need to use f-strings.
-    create_document_partition(session, document_id, "assignments")
-    create_document_partition(session, document_id, "community_assignments")
 
     total_assignments = 0
     skipped_geo_ids: list[str] = []
@@ -1092,8 +1026,13 @@ async def reset_map(
     document: Annotated[Document, Depends(get_document)],
     session: Session = Depends(get_session),
 ):
-    reset_document_partition(session, document.document_id, "assignments")
-    reset_document_partition(session, document.document_id, "community_assignments")
+    for table in ("document.assignments", "document.community_assignments"):
+        session.connection().execute(
+            text(f"DELETE FROM {table} WHERE document_id = :document_id").bindparams(
+                bindparam(key="document_id", type_=UUIDType)
+            ),
+            {"document_id": document.document_id},
+        )
 
     # Reset color scheme
     stmt = text(
@@ -1107,7 +1046,7 @@ async def reset_map(
     session.commit()
 
     return {
-        "message": "Assignments partition reset",
+        "message": "Assignments reset",
         "document_id": document.document_id,
     }
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -381,11 +381,6 @@ class DocumentCreatePublic(DocumentPublic):
 
 
 class Assignments(SQLModel, table=True):
-    # this is the empty parent table; not a partition itself
-    __table_args__ = (
-        UniqueConstraint("document_id", "geo_id", name="document_geo_id_unique"),
-        {"postgresql_partition_by": "LIST (document_id)"},
-    )
     metadata = MetaData(schema=DOCUMENT_SCHEMA)
     document_id: str = Field(sa_column=Column(UUIDType, primary_key=True))
     geo_id: str = Field(primary_key=True)
@@ -394,23 +389,6 @@ class Assignments(SQLModel, table=True):
 
 class CommunityAssignments(SQLModel, table=True):
     __tablename__ = "community_assignments"
-    __table_args__ = (
-        Index(
-            "ix_document_community_assignments_community_id",
-            "community_id",
-        ),
-        Index(
-            "ix_document_community_assignments_geo_id",
-            "geo_id",
-        ),
-        UniqueConstraint(
-            "document_id",
-            "community_id",
-            "geo_id",
-            name="document_community_geo_id_unique",
-        ),
-        {"postgresql_partition_by": "LIST (document_id)"},
-    )
     metadata = MetaData(schema=DOCUMENT_SCHEMA)
     document_id: str = Field(sa_column=Column(UUIDType, primary_key=True))
     community_id: int = Field(

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import random
 from sqlalchemy import text
 from sqlmodel import Session
+from uuid import UUID
 from app.core.config import settings
 from fastapi import APIRouter, Security, status, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import RedirectResponse
@@ -159,18 +160,19 @@ def _generate_thumbnail(
     [count] = results.one()
 
     if count == 0:
+        validated_id = str(UUID(str(document_id)))
         sql = f"""
             SELECT ST_Collect(geometry) AS geom, zone
             FROM gerrydb.{parent_layer} geos
-            LEFT JOIN "document.assignments_{document_id}" assigned ON geos.path = assigned.geo_id
+            LEFT JOIN document.assignments assigned ON geos.path = assigned.geo_id AND assigned.document_id = '{validated_id}'
             GROUP BY zone
         """
         if child_layer is not None:
             sql += f"""UNION
             (SELECT ST_Collect(geometry) AS geom, zone
-            FROM "document.assignments_{document_id}" assigned
+            FROM document.assignments assigned
             INNER JOIN gerrydb.{child_layer} blocks ON blocks.path = assigned.geo_id
-            WHERE zone IS NOT NULL
+            WHERE assigned.document_id = '{validated_id}' AND zone IS NOT NULL
             GROUP BY zone)"""
     else:
         sql = f"""

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -992,7 +992,7 @@ def stress_test_seed(
 )
 @with_session
 def stress_test_cleanup(session: Session, manifests: tuple[str, ...], yes: bool):
-    """Delete stress-test documents (rows + assignment partitions): everything
+    """Delete stress-test documents (rows + assignment rows): everything
     listed in the given manifests, then — belt and suspenders — any leftover
     document whose metadata name starts with [STRESS-TEST], after confirmation."""
     ids: list[str] = []

--- a/backend/stress_test/client.py
+++ b/backend/stress_test/client.py
@@ -8,6 +8,7 @@ import msgpack
 DOCUMENT = "/api/document/{id}"
 ASSIGNMENTS_GET = "/api/get_assignments/{id}"
 EVALUATION = "/api/document/{id}/evaluation"
+STATS = "/api/document/{id}/stats"
 CREATE_DOCUMENT = "/api/create_document"
 ASSIGNMENTS_PUT = "/api/assignments"
 
@@ -55,6 +56,18 @@ class StressClient:
             f"/api/document/{document_id}/evaluation",
             headers=self.headers,
             name=EVALUATION,
+            catch_response=True,
+        ) as resp:
+            if resp.status_code != 200:
+                resp.failure(f"HTTP {resp.status_code}")
+                return None
+            return resp.json()
+
+    def get_document_stats(self, document_id: str) -> dict | None:
+        with self.http.get(
+            f"/api/document/{document_id}/stats",
+            headers=self.headers,
+            name=STATS,
             catch_response=True,
         ) as resp:
             if resp.status_code != 200:

--- a/backend/stress_test/locustfile.py
+++ b/backend/stress_test/locustfile.py
@@ -159,7 +159,7 @@ class Viewer(SessionUser):
         self.sleep_until(self.start_offset())
         document_id = self.rng.choice(VIEW_DOCS)
         if self.api.get_document(document_id):
-            self.api.get_assignments(document_id)
+            self.api.get_document_stats(document_id)
         raise StopUser
 
 
@@ -173,7 +173,6 @@ class EvalUser(SessionUser):
         self.sleep_until(self.start_offset())
         document_id = self.rng.choice(VIEW_DOCS)
         if self.api.get_document(document_id):
-            self.api.get_assignments(document_id)
             self.api.get_evaluation(document_id)
         raise StopUser
 

--- a/backend/stress_test/seed.py
+++ b/backend/stress_test/seed.py
@@ -146,24 +146,16 @@ def find_stress_documents(session: Session) -> list[tuple[str, str]]:
 
 
 def delete_documents(session: Session, document_ids: list[str]) -> int:
-    """Fully delete documents: drop their assignments/community_assignments
-    partitions (as the reset endpoint does), delete dependent rows, then the
+    """Fully delete documents: delete assignment rows and dependent rows, then the
     document rows themselves (document.evaluation cascades via FK). Ids not in
-    the DB are no-ops. Commits per chunk to keep the DDL lock count per
-    transaction small. Returns the number of document rows deleted."""
-    ids = [str(UUID(d)) for d in document_ids]  # validate before f-string DDL
+    the DB are no-ops. Commits per chunk for transactional hygiene. Returns the
+    number of document rows deleted."""
+    ids = [str(UUID(d)) for d in document_ids]  # validate
     deleted = 0
     chunk_size = 50
     for start in range(0, len(ids), chunk_size):
         chunk = ids[start : start + chunk_size]
         conn = session.connection()
-        for document_id in chunk:
-            for table in ("assignments", "community_assignments"):
-                conn.execute(
-                    text(
-                        f'DROP TABLE IF EXISTS "document.{table}_{document_id}" CASCADE'
-                    )
-                )
         params = {"ids": chunk}
         id_filter = "document_id = ANY(CAST(:ids AS uuid[]))"
         conn.execute(
@@ -181,6 +173,8 @@ def delete_documents(session: Session, document_ids: list[str]) -> int:
             "document.district_unions",
             "document.map_document_user_session",
             "document.map_document_token",
+            "document.assignments",
+            "document.community_assignments",
         ):
             conn.execute(text(f"DELETE FROM {table} WHERE {id_filter}"), params)
         result = conn.execute(

--- a/backend/tests/test_fl_metrics_integration.py
+++ b/backend/tests/test_fl_metrics_integration.py
@@ -529,15 +529,12 @@ def fl_map(integration_engine, fl_view) -> str:
 
 
 def _count_document_assignments(engine, document_id: str) -> int:
-    """Count rows in the per-document assignment partition table."""
-    partition = f"document.assignments_{document_id}"
+    """Count rows in the document assignments table."""
     with Session(engine) as session:
-        try:
-            return session.execute(
-                text(f'SELECT COUNT(*) FROM public."{partition}"')
-            ).scalar_one()
-        except Exception:
-            return 0
+        return session.execute(
+            text("SELECT COUNT(*) FROM document.assignments WHERE document_id = :d"),
+            {"d": document_id},
+        ).scalar_one()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION

## Description

Stress testing against beta showed ~93% request failure at 12,750 simulated users with both app and DB CPU idle. Root cause: `create_document` ran `CREATE TABLE ... PARTITION OF document.assignments` per document, which takes an ACCESS EXCLUSIVE lock on the parent table — so every document creation (and every reset, which did DROP+CREATE) globally blocked all assignment reads and writes. Under load this became a lock convoy: connections piled up on the parent-table lock, pools exhausted, and everything hit the 120s ALB timeout. Confirmed via RDS Performance Insights (lock waits concentrated on `get_assignments`) and a viewers-only run where removing writes dropped failures from ~92% to ~34%.

- **Migration `7e57b49573e0`**: converts `document.assignments` and `document.community_assignments` from per-document LIST partitions to plain tables (copy → drop old parents CASCADE → rename → rebuild composite PKs post-load → ANALYZE). Reads/writes now take row locks only; document creation does no DDL. Also drops the legacy `create_document(TEXT)` / `create_assignment_partition_sql(TEXT)` DB functions, which are unused and would break against plain tables. **Irreversible** — downgrade raises; rollback is a DB snapshot. Run at low traffic: the migration holds an exclusive lock for the copy + index build (~1s at 260k rows locally; pre-flight row counts on beta/prod before deploying). Fixed HASH partitioning was measured and rejected: the composite-PK lookup is ~4ms of a ~115ms `get_assignments` query (the rest is the `parentchildedges` join), so partitioning the cheap part buys nothing.
- **`main.py`**: partition create/reset helpers deleted; the reset endpoint is now a parameterized row `DELETE` (response shape unchanged, message text updated).
- **`models.py` / alembic `env.py`**: dropped the partition declarations, the phantom `document_geo_id_unique` UniqueConstraint (it was actually the PK in the live DB), the duplicate `community_assignments` unique constraint, and the autogenerate exclusion hacks. The two `community_assignments` secondary indexes are intentionally not recreated — every query filters `document_id` first, so the PK prefix covers them and the save path sheds index write amplification.
- **`thumbnails/main.py`**: was the only code addressing partitions by name; now queries the parent table (document_id predicate in the LEFT JOIN's ON clause to preserve unassigned-geo rows).
- **Stress harness traffic model fix**: the Viewer and EvalUser classes called `get_assignments` (306 KB, heaviest read endpoint), but real viewers call `/api/document/{id}/stats` (~1 KB) and eval users call `/evaluation`. 12,500 of 12,750 simulated users were driving synthetic load, inflating every prior run. Viewer → `get_document` + `/stats`; EvalUser → `get_document` + `/evaluation`; editor path unchanged. Stress seed/cleanup now deletes rows instead of dropping partitions.

## Reviewers

- Primary:
- Secondary:

## Checklist

- [x] Added/Updated related documentation (if applicable).
  - Migration docstring documents the lock rationale and the alternatives measured; endpoint behavior unchanged.
- [x] Added/Updated related unit tests (if applicable).
  - No new tests: the test suite builds its DB via `alembic upgrade head`, so the migration is exercised from scratch; existing reset/copy/shatter/export/thumbnail tests cover every touched path (293 passed, 117 skipped).

## Screenshots (if applicable):

N/A — backend/schema only.

## Review required

- **The migration** (`7e57b49573e0_departition_assignments_tables.py`) is the high-stakes piece: it rewrites both assignment tables under an exclusive lock and is irreversible. Verify the copy-swap-drop sequence and the deploy plan (low-traffic window; old tasks briefly 500 on create/reset until the rolling deploy replaces them).
- **Intentional index/constraint removals** on `community_assignments` — confirm no out-of-band query depends on bare `geo_id`/`community_id` lookups.
- **Thumbnail SQL rewrite** — the document_id predicate moved into the LEFT JOIN's ON clause; covered by `test_thumbnails`, but worth a second pair of eyes.