### PR TITLE
Overlays update - CLI and FE county mask

### DIFF
--- a/app/src/app/components/Map/CoiMapEvents.ts
+++ b/app/src/app/components/Map/CoiMapEvents.ts
@@ -20,6 +20,7 @@ import {
   EMPTY_FEATURE_ARRAY,
   POINT_SELECT_TOOLS,
   TOOLTIP_TOOLS,
+  getSelectingClickLayer,
   mapEventHandlers,
 } from '@/app/utils/events/mapEvents';
 
@@ -101,7 +102,7 @@ export const handleCoiMapClick = throttle((e: MapLayerMouseEvent | MapLayerTouch
 
   if (selectingLayerId) {
     const features = mapRef.queryRenderedFeatures(e.point, {
-      layers: [`overlay-click-${selectingLayerId}`],
+      layers: [getSelectingClickLayer(selectingLayerId)],
     });
     if (features.length > 0) {
       setPaintConstraint(selectingLayerId, features[0].id as string);
@@ -143,7 +144,7 @@ export const handleCoiMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerT
   const isBrushingTool = sourceLayer && ALL_BRUSHING_TOOLS.includes(activeTool);
   if (selectingLayerId) {
     const features = mapRef.queryRenderedFeatures(e.point, {
-      layers: [`overlay-click-${selectingLayerId}`],
+      layers: [getSelectingClickLayer(selectingLayerId)],
     });
     if (features.length > 0) {
       setHoverFeatures([features[0]]);

--- a/app/src/app/components/Map/PolygonLayers/CountyLayers.tsx
+++ b/app/src/app/components/Map/PolygonLayers/CountyLayers.tsx
@@ -11,10 +11,7 @@ import {
   HIGHLIGHT_LINE_COLOR,
   HIGHLIGHT_LINE_WIDTH,
 } from '@/app/constants/map/layerStyle';
-import {
-  HIGHLIGHT_FILL_COLOR,
-  SELECTED_LINE_STYLE,
-} from '@/app/constants/map/overlayLayerStyles';
+import {HIGHLIGHT_FILL_COLOR, SELECTED_LINE_STYLE} from '@/app/constants/map/overlayLayerStyles';
 import {
   CANONICAL_LAYER_IDS,
   COUNTY_SOURCE_ID,

--- a/app/src/app/components/Map/PolygonLayers/CountyLayers.tsx
+++ b/app/src/app/components/Map/PolygonLayers/CountyLayers.tsx
@@ -1,5 +1,6 @@
 'use client';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {useOverlayStore} from '@/app/store/overlayStore';
 import {GEODATA_URL} from '@/app/utils/api/constants';
 import {FilterSpecification} from 'maplibre-gl';
 import {useMemo} from 'react';
@@ -11,6 +12,10 @@ import {
   HIGHLIGHT_LINE_WIDTH,
 } from '@/app/constants/map/layerStyle';
 import {
+  HIGHLIGHT_FILL_COLOR,
+  SELECTED_LINE_STYLE,
+} from '@/app/constants/map/overlayLayerStyles';
+import {
   CANONICAL_LAYER_IDS,
   COUNTY_SOURCE_ID,
   MAP_LAYER_ANCHOR_IDS,
@@ -19,6 +24,9 @@ import {
 export const CountyLayers = ({layerBeforeId}: {layerBeforeId: string}) => {
   const mapOptions = useMapControlsStore(state => state.mapOptions);
   const hoveredCountyGeoid = useMapControlsStore(state => state.hoveredCountyGeoid);
+  const paintConstraint = useOverlayStore(state => state.paintConstraint);
+  const countyMaskId =
+    paintConstraint?.overlayId === COUNTY_SOURCE_ID ? paintConstraint.featureId : null;
 
   const countyFilter = useMemo(() => {
     // If stateFipsSet is set and not empty, match any of its values
@@ -41,6 +49,7 @@ export const CountyLayers = ({layerBeforeId}: {layerBeforeId: string}) => {
         id={COUNTY_SOURCE_ID}
         type="vector"
         url={`pmtiles://${GEODATA_URL}/basemaps/tiger/tiger2023/tl_2023_us_county_full.pmtiles`}
+        promoteId="GEOID"
       >
         <Layer
           id={CANONICAL_LAYER_IDS.COUNTIES.BOUNDARY}
@@ -83,6 +92,47 @@ export const CountyLayers = ({layerBeforeId}: {layerBeforeId: string}) => {
               : ['==', ['get', 'GEOID'], SENTINEL_EMPTY_VALUE]
           }
         />
+        {/* Hover highlight while choosing a county paint mask (feature-state hover) */}
+        <Layer
+          id={CANONICAL_LAYER_IDS.COUNTIES.HOVER_FILL}
+          beforeId={MAP_LAYER_ANCHOR_IDS.hover}
+          type="fill"
+          source-layer="tl_2023_us_county"
+          paint={HIGHLIGHT_FILL_COLOR}
+          filter={countyFilter}
+        />
+        {/* Dim everything outside the active county paint mask.
+            NOTE: must be direct children of <Source> (no fragment) so
+            react-map-gl can inject the source prop. */}
+        {countyMaskId && (
+          <Layer
+            id={CANONICAL_LAYER_IDS.COUNTIES.MASK}
+            beforeId={MAP_LAYER_ANCHOR_IDS.hover}
+            type="fill"
+            source-layer="tl_2023_us_county"
+            paint={{
+              'fill-color': '#FFFFFF',
+              'fill-opacity': 0.75,
+            }}
+            filter={
+              [
+                'all',
+                countyFilter,
+                ['!', ['==', ['get', 'GEOID'], countyMaskId]],
+              ] as FilterSpecification
+            }
+          />
+        )}
+        {countyMaskId && (
+          <Layer
+            id={CANONICAL_LAYER_IDS.COUNTIES.SELECTED}
+            beforeId={MAP_LAYER_ANCHOR_IDS.hover}
+            type="line"
+            source-layer="tl_2023_us_county"
+            paint={SELECTED_LINE_STYLE}
+            filter={['==', ['get', 'GEOID'], countyMaskId]}
+          />
+        )}
         <Layer
           id={CANONICAL_LAYER_IDS.COUNTIES.LABELS}
           beforeId={mapOptions.prominentCountyNames ? undefined : MAP_LAYER_ANCHOR_IDS.counties}

--- a/app/src/app/components/sidebar/OverlayMetadataModal.tsx
+++ b/app/src/app/components/sidebar/OverlayMetadataModal.tsx
@@ -1,0 +1,203 @@
+'use client';
+import React, {useState} from 'react';
+import {
+  Dialog,
+  Flex,
+  Text,
+  Heading,
+  Separator,
+  Spinner,
+  Callout,
+  IconButton,
+} from '@radix-ui/themes';
+import {InfoCircledIcon, Cross2Icon} from '@radix-ui/react-icons';
+import {useMapStore} from '@/app/store/mapStore';
+import {fastUniqBy} from '@/app/utils/arrays';
+import type {Overlay} from '@/app/utils/api/apiHandlers/types';
+
+/**
+ * Provenance metadata published alongside overlay geojsons as
+ * `overlay_metadata.json`, keyed by `{state}_{dataset}`. Fields vary by
+ * source: census entries carry `vintage`; plan entries carry `plan_name`,
+ * `year`, and `modified`.
+ */
+interface OverlayMetadataEntry {
+  name: string;
+  description: string;
+  source: string;
+  retrieved: string;
+  vintage?: string;
+  plan_name?: string;
+  year?: string;
+  modified?: string;
+}
+
+type OverlayMetadata = Record<string, OverlayMetadataEntry>;
+
+// Counties are always available and are not stored as a DB overlay, so we
+// render them from a static entry rather than the fetched metadata.
+const COUNTY_ENTRY: OverlayMetadataEntry = {
+  name: 'Counties',
+  description: 'Show county boundaries and labels',
+  source: 'Census FTP (TIGER/Line 2023)',
+  vintage: '2023 TIGER/Line',
+  retrieved: '',
+};
+
+/**
+ * The metadata KEY for an overlay is the basename of its source URL minus the
+ * `.geojson` extension (e.g. `.../overlays/al_cd.geojson` -> `al_cd`).
+ */
+const getOverlayKey = (source: string | null): string | null => {
+  if (!source) return null;
+  const basename = source.split('/').pop();
+  if (!basename) return null;
+  return basename.replace(/\.geojson$/, '');
+};
+
+/**
+ * Derive the base URL where `overlay_metadata.json` lives by stripping the
+ * basename off any overlay's source URL.
+ */
+const getMetadataUrl = (source: string): string => {
+  const base = source.slice(0, source.lastIndexOf('/'));
+  return `${base}/overlay_metadata.json`;
+};
+
+const ProvenanceRow: React.FC<{label: string; value?: string}> = ({label, value}) => {
+  if (!value) return null;
+  return (
+    <Flex gap="2" align="start">
+      <Text size="1" color="gray" style={{minWidth: '110px'}}>
+        {label}
+      </Text>
+      <Text size="1">{value}</Text>
+    </Flex>
+  );
+};
+
+const OverlaySection: React.FC<{entry: OverlayMetadataEntry}> = ({entry}) => (
+  <Flex direction="column" gap="1">
+    <Text size="2" weight="bold">
+      {entry.name}
+    </Text>
+    {entry.description && (
+      <Text size="1" color="gray">
+        {entry.description}
+      </Text>
+    )}
+    <Flex direction="column" gap="1" mt="1">
+      <ProvenanceRow label="Source" value={entry.source} />
+      <ProvenanceRow label="Vintage" value={entry.vintage} />
+      <ProvenanceRow label="Plan" value={entry.plan_name} />
+      <ProvenanceRow label="Election year" value={entry.year} />
+      <ProvenanceRow label="Retrieved" value={entry.retrieved} />
+      <ProvenanceRow label="Last modified" value={entry.modified} />
+    </Flex>
+  </Flex>
+);
+
+export const OverlayMetadataModal: React.FC = () => {
+  const overlays = useMapStore(state => state.mapDocument?.overlays ?? []);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [metadata, setMetadata] = useState<OverlayMetadata | null>(null);
+
+  const handleOpenChange = async (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) return;
+    const firstWithSource = overlays.find(o => o.source);
+    if (!firstWithSource?.source) {
+      // Nothing to fetch; the static county entry still renders.
+      setMetadata({});
+      setError(false);
+      return;
+    }
+    setLoading(true);
+    setError(false);
+    try {
+      const response = await fetch(getMetadataUrl(firstWithSource.source));
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data: OverlayMetadata = await response.json();
+      setMetadata(data);
+    } catch {
+      setError(true);
+      setMetadata({});
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const uniqueOverlays = fastUniqBy(overlays as Overlay[], 'name');
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Trigger>
+        <IconButton
+          variant="ghost"
+          color="gray"
+          size="1"
+          className="cursor-pointer"
+          title="About these boundaries"
+          aria-label="About these boundaries"
+        >
+          <InfoCircledIcon />
+        </IconButton>
+      </Dialog.Trigger>
+      <Dialog.Content className="max-w-[500px]">
+        <Flex align="start" justify="between">
+          <Dialog.Title className="m-0 flex-1">
+            <Heading size="4">About these boundaries</Heading>
+          </Dialog.Title>
+          <Dialog.Close
+            className="rounded-full size-[24px] hover:bg-red-100 p-1"
+            aria-label="Close"
+          >
+            <Cross2Icon />
+          </Dialog.Close>
+        </Flex>
+        {loading ? (
+          <Flex align="center" justify="center" p="4">
+            <Spinner />
+          </Flex>
+        ) : (
+          <Flex direction="column" gap="3" mt="3">
+            {error && (
+              <Callout.Root color="amber" size="1">
+                <Callout.Icon>
+                  <InfoCircledIcon />
+                </Callout.Icon>
+                <Callout.Text>
+                  Detailed provenance is unavailable right now. Showing what we have.
+                </Callout.Text>
+              </Callout.Root>
+            )}
+            <OverlaySection entry={COUNTY_ENTRY} />
+            {uniqueOverlays.map(overlay => {
+              const key = getOverlayKey(overlay.source);
+              const entry = key ? metadata?.[key] : undefined;
+              return (
+                <React.Fragment key={overlay.overlay_id}>
+                  <Separator size="4" />
+                  <OverlaySection
+                    entry={
+                      entry ?? {
+                        name: overlay.name,
+                        description: overlay.description ?? '',
+                        source: '',
+                        retrieved: '',
+                      }
+                    }
+                  />
+                </React.Fragment>
+              );
+            })}
+          </Flex>
+        )}
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default OverlayMetadataModal;

--- a/app/src/app/components/sidebar/OverlayMetadataModal.tsx
+++ b/app/src/app/components/sidebar/OverlayMetadataModal.tsx
@@ -56,11 +56,11 @@ const getOverlayKey = (source: string | null): string | null => {
 };
 
 // Enacted-plan datasets (from the source-URL suffix, e.g. `al_cd` -> "cd") are
-// grouped under a "Legislative Districts" heading in the panel and this modal.
-export const LEGISLATIVE_DATASETS = new Set(['cd', 'sldu', 'sldl', 'sld']);
+// grouped under a "Enacted Districts" heading in the panel and this modal.
+export const ENACTED_DATASETS = new Set(['cd', 'sldu', 'sldl', 'sld']);
 export const datasetKey = (source: string | null) => getOverlayKey(source)?.split('_').pop() ?? '';
 export const isLegislativeOverlay = (overlay: Overlay) =>
-  LEGISLATIVE_DATASETS.has(datasetKey(overlay.source));
+  ENACTED_DATASETS.has(datasetKey(overlay.source));
 
 /**
  * Derive the base URL where `overlay_metadata.json` lives by stripping the
@@ -198,7 +198,7 @@ export const OverlayMetadataModal: React.FC = () => {
             {legislativeOverlays.length > 0 && (
               <>
                 <Text size="2" weight="bold">
-                  Legislative Districts
+                  Enacted Districts
                 </Text>
                 {legislativeOverlays.map(overlay => (
                   <OverlaySection key={overlay.overlay_id} entry={entryFor(overlay)} />

--- a/app/src/app/components/sidebar/OverlayMetadataModal.tsx
+++ b/app/src/app/components/sidebar/OverlayMetadataModal.tsx
@@ -55,6 +55,13 @@ const getOverlayKey = (source: string | null): string | null => {
   return basename.replace(/\.geojson$/, '');
 };
 
+// Enacted-plan datasets (from the source-URL suffix, e.g. `al_cd` -> "cd") are
+// grouped under a "Legislative Districts" heading in the panel and this modal.
+export const LEGISLATIVE_DATASETS = new Set(['cd', 'sldu', 'sldl', 'sld']);
+export const datasetKey = (source: string | null) => getOverlayKey(source)?.split('_').pop() ?? '';
+export const isLegislativeOverlay = (overlay: Overlay) =>
+  LEGISLATIVE_DATASETS.has(datasetKey(overlay.source));
+
 /**
  * Derive the base URL where `overlay_metadata.json` lives by stripping the
  * basename off any overlay's source URL.
@@ -130,6 +137,20 @@ export const OverlayMetadataModal: React.FC = () => {
   };
 
   const uniqueOverlays = fastUniqBy(overlays as Overlay[], 'name');
+  const legislativeOverlays = uniqueOverlays.filter(isLegislativeOverlay);
+  const otherOverlays = uniqueOverlays.filter(o => !isLegislativeOverlay(o));
+
+  const entryFor = (overlay: Overlay): OverlayMetadataEntry => {
+    const key = getOverlayKey(overlay.source);
+    return (
+      (key ? metadata?.[key] : undefined) ?? {
+        name: overlay.name,
+        description: overlay.description ?? '',
+        source: '',
+        retrieved: '',
+      }
+    );
+  };
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
@@ -162,7 +183,8 @@ export const OverlayMetadataModal: React.FC = () => {
             <Spinner />
           </Flex>
         ) : (
-          <Flex direction="column" gap="3" mt="3">
+          // Header stays put; the boundary list scrolls within a capped height.
+          <Flex direction="column" gap="3" mt="3" style={{maxHeight: '60vh', overflowY: 'auto'}}>
             {error && (
               <Callout.Root color="amber" size="1">
                 <Callout.Icon>
@@ -173,26 +195,24 @@ export const OverlayMetadataModal: React.FC = () => {
                 </Callout.Text>
               </Callout.Root>
             )}
+            {legislativeOverlays.length > 0 && (
+              <>
+                <Text size="2" weight="bold">
+                  Legislative Districts
+                </Text>
+                {legislativeOverlays.map(overlay => (
+                  <OverlaySection key={overlay.overlay_id} entry={entryFor(overlay)} />
+                ))}
+                <Separator size="4" />
+              </>
+            )}
             <OverlaySection entry={COUNTY_ENTRY} />
-            {uniqueOverlays.map(overlay => {
-              const key = getOverlayKey(overlay.source);
-              const entry = key ? metadata?.[key] : undefined;
-              return (
-                <React.Fragment key={overlay.overlay_id}>
-                  <Separator size="4" />
-                  <OverlaySection
-                    entry={
-                      entry ?? {
-                        name: overlay.name,
-                        description: overlay.description ?? '',
-                        source: '',
-                        retrieved: '',
-                      }
-                    }
-                  />
-                </React.Fragment>
-              );
-            })}
+            {otherOverlays.map(overlay => (
+              <React.Fragment key={overlay.overlay_id}>
+                <Separator size="4" />
+                <OverlaySection entry={entryFor(overlay)} />
+              </React.Fragment>
+            ))}
           </Flex>
         )}
       </Dialog.Content>

--- a/app/src/app/components/sidebar/OverlaysPanel.tsx
+++ b/app/src/app/components/sidebar/OverlaysPanel.tsx
@@ -18,18 +18,7 @@ import {useMemo} from 'react';
 import {useMapStore} from '@/app/store/mapStore';
 import {COUNTY_SOURCE_ID} from '@/app/constants/map/layerIds';
 import type {Overlay} from '@/app/utils/api/apiHandlers/types';
-import {OverlayMetadataModal} from './OverlayMetadataModal';
-
-// Enacted-plan datasets (from the source-URL suffix, e.g. `al_cd` -> "cd") are
-// grouped under a "Legislative Districts" heading; everything else follows.
-const LEGISLATIVE_DATASETS = new Set(['cd', 'sldu', 'sldl', 'sld']);
-const datasetKey = (source: string | null) =>
-  source
-    ?.split('/')
-    .pop()
-    ?.replace(/\.geojson$/, '')
-    .split('_')
-    .pop() ?? '';
+import {OverlayMetadataModal, isLegislativeOverlay} from './OverlayMetadataModal';
 
 export const OverlaysPanel = () => {
   const availableOverlays = useMapStore(state => state.mapDocument?.overlays ?? []);
@@ -62,12 +51,8 @@ export const OverlaysPanel = () => {
     return fastUniqBy(sortedOverlays, 'name');
   }, [availableOverlays]);
 
-  const legislativeOverlays = overlaysGroupedByName.filter(o =>
-    LEGISLATIVE_DATASETS.has(datasetKey(o.source))
-  );
-  const otherOverlays = overlaysGroupedByName.filter(
-    o => !LEGISLATIVE_DATASETS.has(datasetKey(o.source))
-  );
+  const legislativeOverlays = overlaysGroupedByName.filter(isLegislativeOverlay);
+  const otherOverlays = overlaysGroupedByName.filter(o => !isLegislativeOverlay(o));
 
   const renderOverlayRow = (overlay: Overlay) => (
     <Flex key={overlay.overlay_id} justify="between" align="center" gap="2">

--- a/app/src/app/components/sidebar/OverlaysPanel.tsx
+++ b/app/src/app/components/sidebar/OverlaysPanel.tsx
@@ -14,6 +14,7 @@ import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
 import {fastUniqBy} from '@/app/utils/arrays';
 import {useMemo} from 'react';
 import {useMapStore} from '@/app/store/mapStore';
+import {COUNTY_SOURCE_ID} from '@/app/constants/map/layerIds';
 
 export const OverlaysPanel = () => {
   const availableOverlays = useMapStore(state => state.mapDocument?.overlays ?? []);
@@ -83,15 +84,43 @@ export const OverlaysPanel = () => {
             Show county boundaries and labels
           </Text>
         </Flex>
-        <Switch
-          checked={mapOptions.showCountyBoundaries ?? false}
-          onCheckedChange={checked =>
-            setMapOptions({
-              showCountyBoundaries: checked,
-              prominentCountyNames: checked,
-            })
-          }
-        />
+        <Flex direction="row" gap="2" align="center" justify="center">
+          <Switch
+            checked={mapOptions.showCountyBoundaries ?? false}
+            onCheckedChange={checked => {
+              setMapOptions({
+                showCountyBoundaries: checked,
+                prominentCountyNames: checked,
+              });
+              // Release the county paint mask when its layer is hidden
+              if (!checked && paintConstraint?.overlayId === COUNTY_SOURCE_ID) {
+                clearPaintConstraint();
+              }
+            }}
+          />
+          {superDraw && (
+            <Tooltip content="Choose an area to paint within.">
+              <IconButton
+                onClick={() => handleLocateClick(COUNTY_SOURCE_ID)}
+                disabled={!mapOptions.showCountyBoundaries}
+                variant="ghost"
+                color="blue"
+                size="1"
+                radius="full"
+                className="cursor-pointer"
+                style={{
+                  opacity: mapOptions.showCountyBoundaries ? 1 : 0.5,
+                }}
+              >
+                {paintConstraint?.overlayId === COUNTY_SOURCE_ID ? (
+                  <MaskOffIcon />
+                ) : (
+                  <MaskOnIcon />
+                )}
+              </IconButton>
+            </Tooltip>
+          )}
+        </Flex>
       </Flex>
       {/* Regular Overlay Layers */}
       {hasOverlays

--- a/app/src/app/components/sidebar/OverlaysPanel.tsx
+++ b/app/src/app/components/sidebar/OverlaysPanel.tsx
@@ -15,6 +15,7 @@ import {fastUniqBy} from '@/app/utils/arrays';
 import {useMemo} from 'react';
 import {useMapStore} from '@/app/store/mapStore';
 import {COUNTY_SOURCE_ID} from '@/app/constants/map/layerIds';
+import {OverlayMetadataModal} from './OverlayMetadataModal';
 
 export const OverlaysPanel = () => {
   const availableOverlays = useMapStore(state => state.mapDocument?.overlays ?? []);
@@ -51,6 +52,9 @@ export const OverlaysPanel = () => {
 
   return (
     <Flex gap="3" direction="column">
+      <Flex justify="end" align="center">
+        <OverlayMetadataModal />
+      </Flex>
       {paintConstraint && (
         <Button variant="outline" color="orange" onClick={clearPaintConstraint}>
           <Flex justify="between" align="center" gap="2">
@@ -78,7 +82,7 @@ export const OverlaysPanel = () => {
       <Flex justify="between" align="center" gap="2">
         <Flex direction="column" gap="1">
           <Text size="2" weight="medium">
-            County Boundaries and Labels
+            Counties
           </Text>
           <Text size="1" color="gray">
             Show county boundaries and labels
@@ -112,11 +116,7 @@ export const OverlaysPanel = () => {
                   opacity: mapOptions.showCountyBoundaries ? 1 : 0.5,
                 }}
               >
-                {paintConstraint?.overlayId === COUNTY_SOURCE_ID ? (
-                  <MaskOffIcon />
-                ) : (
-                  <MaskOnIcon />
-                )}
+                {paintConstraint?.overlayId === COUNTY_SOURCE_ID ? <MaskOffIcon /> : <MaskOnIcon />}
               </IconButton>
             </Tooltip>
           )}

--- a/app/src/app/components/sidebar/OverlaysPanel.tsx
+++ b/app/src/app/components/sidebar/OverlaysPanel.tsx
@@ -1,21 +1,35 @@
 'use client';
-import {Flex, Text, Switch, Spinner, Button, Callout, IconButton, Tooltip} from '@radix-ui/themes';
 import {
-  CrossCircledIcon,
-  InfoCircledIcon,
-  MaskOffIcon,
-  MaskOnIcon,
-  TargetIcon,
-} from '@radix-ui/react-icons';
+  Flex,
+  Text,
+  Switch,
+  Button,
+  Callout,
+  IconButton,
+  Tooltip,
+  Separator,
+} from '@radix-ui/themes';
+import {MaskOffIcon, MaskOnIcon, TargetIcon} from '@radix-ui/react-icons';
 import {useOverlayStore} from '@/app/store/overlayStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {useToolbarStore} from '@/app/store/toolbarStore';
-import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
 import {fastUniqBy} from '@/app/utils/arrays';
 import {useMemo} from 'react';
 import {useMapStore} from '@/app/store/mapStore';
 import {COUNTY_SOURCE_ID} from '@/app/constants/map/layerIds';
+import type {Overlay} from '@/app/utils/api/apiHandlers/types';
 import {OverlayMetadataModal} from './OverlayMetadataModal';
+
+// Enacted-plan datasets (from the source-URL suffix, e.g. `al_cd` -> "cd") are
+// grouped under a "Legislative Districts" heading; everything else follows.
+const LEGISLATIVE_DATASETS = new Set(['cd', 'sldu', 'sldl', 'sld']);
+const datasetKey = (source: string | null) =>
+  source
+    ?.split('/')
+    .pop()
+    ?.replace(/\.geojson$/, '')
+    .split('_')
+    .pop() ?? '';
 
 export const OverlaysPanel = () => {
   const availableOverlays = useMapStore(state => state.mapDocument?.overlays ?? []);
@@ -48,7 +62,51 @@ export const OverlaysPanel = () => {
     return fastUniqBy(sortedOverlays, 'name');
   }, [availableOverlays]);
 
-  const hasOverlays = availableOverlays.length > 0;
+  const legislativeOverlays = overlaysGroupedByName.filter(o =>
+    LEGISLATIVE_DATASETS.has(datasetKey(o.source))
+  );
+  const otherOverlays = overlaysGroupedByName.filter(
+    o => !LEGISLATIVE_DATASETS.has(datasetKey(o.source))
+  );
+
+  const renderOverlayRow = (overlay: Overlay) => (
+    <Flex key={overlay.overlay_id} justify="between" align="center" gap="2">
+      <Flex direction="column" gap="1">
+        <Text size="2" weight="medium">
+          {overlay.name}
+        </Text>
+        {overlay.description && (
+          <Text size="1" color="gray">
+            {overlay.description}
+          </Text>
+        )}
+      </Flex>
+      <Flex direction="row" gap="2" align="center" justify="center">
+        <Switch
+          checked={enabledOverlayIds.has(overlay.name)}
+          onCheckedChange={() => toggleOverlay(overlay.name)}
+        />
+        {superDraw && (
+          <Tooltip content="Choose an area to paint within.">
+            <IconButton
+              onClick={() => handleLocateClick(overlay.overlay_id)}
+              disabled={!enabledOverlayIds.has(overlay.name)}
+              variant="ghost"
+              color="blue"
+              size="1"
+              radius="full"
+              className="cursor-pointer"
+              style={{
+                opacity: enabledOverlayIds.has(overlay.name) ? 1 : 0.5,
+              }}
+            >
+              {paintConstraint?.overlayId === overlay.overlay_id ? <MaskOffIcon /> : <MaskOnIcon />}
+            </IconButton>
+          </Tooltip>
+        )}
+      </Flex>
+    </Flex>
+  );
 
   return (
     <Flex gap="3" direction="column">
@@ -78,6 +136,18 @@ export const OverlaysPanel = () => {
           </Flex>
         </Callout.Root>
       )}
+
+      {/* Congressional + state legislative districts, grouped under a heading */}
+      {legislativeOverlays.length > 0 && (
+        <>
+          <Text size="2" weight="bold">
+            Legislative Districts
+          </Text>
+          {legislativeOverlays.map(renderOverlayRow)}
+          <Separator size="4" />
+        </>
+      )}
+
       {/* County Layer Controls - Always shown as pseudo-overlay */}
       <Flex justify="between" align="center" gap="2">
         <Flex direction="column" gap="1">
@@ -122,51 +192,9 @@ export const OverlaysPanel = () => {
           )}
         </Flex>
       </Flex>
-      {/* Regular Overlay Layers */}
-      {hasOverlays
-        ? overlaysGroupedByName.map(overlay => (
-            <Flex key={overlay.overlay_id} justify="between" align="center" gap="2">
-              <Flex direction="column" gap="1">
-                <Text size="2" weight="medium">
-                  {overlay.name}
-                </Text>
-                {overlay.description && (
-                  <Text size="1" color="gray">
-                    {overlay.description}
-                  </Text>
-                )}
-              </Flex>
-              <Flex direction="row" gap="2" align="center" justify="center">
-                <Switch
-                  checked={enabledOverlayIds.has(overlay.name)}
-                  onCheckedChange={() => toggleOverlay(overlay.name)}
-                />
-                {superDraw && (
-                  <Tooltip content="Choose an area to paint within.">
-                    <IconButton
-                      onClick={() => handleLocateClick(overlay.overlay_id)}
-                      disabled={!enabledOverlayIds.has(overlay.name)}
-                      variant="ghost"
-                      color="blue"
-                      size="1"
-                      radius="full"
-                      className="cursor-pointer"
-                      style={{
-                        opacity: enabledOverlayIds.has(overlay.name) ? 1 : 0.5,
-                      }}
-                    >
-                      {paintConstraint?.overlayId === overlay.overlay_id ? (
-                        <MaskOffIcon />
-                      ) : (
-                        <MaskOnIcon />
-                      )}
-                    </IconButton>
-                  </Tooltip>
-                )}
-              </Flex>
-            </Flex>
-          ))
-        : null}
+
+      {/* Remaining boundaries (metro areas, school districts, tribal areas) */}
+      {otherOverlays.map(renderOverlayRow)}
     </Flex>
   );
 };

--- a/app/src/app/constants/map/layerIds.ts
+++ b/app/src/app/constants/map/layerIds.ts
@@ -31,6 +31,9 @@ export const CANONICAL_LAYER_IDS = {
     BOUNDARY: 'counties_boundary',
     LABELS: 'counties_labels',
     HIGHLIGHT: 'counties_highlight',
+    HOVER_FILL: 'counties_hover_fill',
+    MASK: 'counties_mask',
+    SELECTED: 'counties_selected',
   },
   BLOCK: {
     PARENT: {

--- a/app/src/app/store/overlayStore.ts
+++ b/app/src/app/store/overlayStore.ts
@@ -5,6 +5,9 @@ import {Overlay} from '@utils/api/apiHandlers/types';
 import {useMapStore} from './mapStore';
 import {dissolve} from '@turf/turf';
 import {Feature, MapGeoJSONFeature} from 'maplibre-gl';
+import {COUNTY_SOURCE_ID} from '@constants/map/layerIds';
+
+const COUNTY_SOURCE_LAYER = 'tl_2023_us_county';
 
 export interface OverlayPaintConstraint {
   overlayId: string;
@@ -80,8 +83,15 @@ export const useOverlayStore = create(
         clearPaintConstraint();
         return;
       }
-      // query source layer for feature id
-      const sourceFeatures = mapRef?.querySourceFeatures(`overlay-source-${overlayId}`);
+      // query source layer for feature id; the built-in county layer is a
+      // pseudo-overlay with its own source and source-layer
+      const sourceFeatures =
+        overlayId === COUNTY_SOURCE_ID
+          ? mapRef?.querySourceFeatures(COUNTY_SOURCE_ID, {
+              sourceLayer: COUNTY_SOURCE_LAYER,
+              filter: ['==', ['get', 'GEOID'], featureId],
+            })
+          : mapRef?.querySourceFeatures(`overlay-source-${overlayId}`);
       const matchingFeatures = sourceFeatures?.filter((feature: any) => feature.id === featureId);
       if (matchingFeatures && matchingFeatures.length > 0) {
         set({

--- a/app/src/app/utils/events/mapEvents.ts
+++ b/app/src/app/utils/events/mapEvents.ts
@@ -24,6 +24,8 @@ import {
   BLOCK_POINTS_LAYER_ID_CHILD,
   ZONE_LABEL_LAYER_LIST,
   INTERACTIVE_LAYERS,
+  CANONICAL_LAYER_IDS,
+  COUNTY_SOURCE_ID,
 } from '@constants/map/layerIds';
 import {ACTIVE_TOOLS, type ActiveTool} from '@constants/map/tools';
 import {ResetMapSelectState} from '@utils/events/handlers';
@@ -50,6 +52,16 @@ export const MUTATION_TOOLS: ActiveTool[] = [
 ];
 
 export const EMPTY_FEATURE_ARRAY: MapGeoJSONFeature[] = [];
+
+/**
+ * The clickable layer while selecting a paint-mask area. The built-in county
+ * layer (COUNTY_SOURCE_ID sentinel) uses its always-on invisible fill layer;
+ * overlays use their dedicated click layer.
+ */
+export const getSelectingClickLayer = (selectingLayerId: string) =>
+  selectingLayerId === COUNTY_SOURCE_ID
+    ? CANONICAL_LAYER_IDS.COUNTIES.FILL
+    : `overlay-click-${selectingLayerId}`;
 /*
  MapEvent handling; these functions are called by the event listeners in the MapComponent
  */
@@ -172,7 +184,7 @@ export const handleMapClick = throttle((e: MapLayerMouseEvent | MapLayerTouchEve
 
   if (selectingLayerId) {
     const features = mapRef.queryRenderedFeatures(e.point, {
-      layers: [`overlay-click-${selectingLayerId}`],
+      layers: [getSelectingClickLayer(selectingLayerId)],
     });
     if (features.length > 0) {
       setPaintConstraint(selectingLayerId, features[0].id as string);
@@ -354,7 +366,7 @@ export const handleMapMouseMove = throttle((e: MapLayerMouseEvent | MapLayerTouc
   const isBrushingTool = sourceLayer && ALL_BRUSHING_TOOLS.includes(activeTool);
   if (selectingLayerId) {
     const features = mapRef.queryRenderedFeatures(e.point, {
-      layers: [`overlay-click-${selectingLayerId}`],
+      layers: [getSelectingClickLayer(selectingLayerId)],
     });
     if (features.length > 0) {
       setHoverFeatures([features[0]]);

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1023,8 +1023,8 @@ def sync_overlay_metadata(session: Session, metadata: str, dry_run: bool):
             logger.info(f"No metadata entry for {key}; leaving overlay unchanged")
             continue
 
-        new_name = entry.get("name")
-        new_description = entry.get("description")
+        new_name = entry["name"]
+        new_description = entry["description"]
         if new_name == overlay.name and new_description == overlay.description:
             logger.debug(f"Overlay {key} already up to date")
             continue

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -670,6 +670,131 @@ def add_overlay_to_map(session: Session, districtr_map_slug: str, overlay_id: st
         logger.error(f"Map with slug {districtr_map_slug} not found")
 
 
+@cli.command("link-overlays-to-maps")
+@click.option(
+    "--overlay-name",
+    "-n",
+    "overlay_names",
+    help="Link all overlays with this name (can be specified multiple times)",
+    multiple=True,
+    required=False,
+)
+@click.option(
+    "--overlay-source",
+    "-so",
+    "overlay_sources",
+    help="Link all overlays with this exact source URL or S3 path (can be specified multiple times)",
+    multiple=True,
+    required=False,
+)
+@click.option(
+    "--overlay-id",
+    "-o",
+    "overlay_ids",
+    help="Overlay UUID to link (can be specified multiple times)",
+    multiple=True,
+    required=False,
+)
+@click.option(
+    "--all-overlays",
+    is_flag=True,
+    default=False,
+    help="Link every overlay",
+)
+@click.option(
+    "--statefps",
+    "-s",
+    help="Only link to maps whose statefps overlap these FIPS codes (can be specified multiple times). Omit to link to all maps",
+    multiple=True,
+    required=False,
+)
+@with_session
+def link_overlays_to_maps(
+    session: Session,
+    overlay_names: tuple[str, ...],
+    overlay_sources: tuple[str, ...],
+    overlay_ids: tuple[str, ...],
+    all_overlays: bool,
+    statefps: tuple[str, ...],
+):
+    if (
+        not overlay_names
+        and not overlay_sources
+        and not overlay_ids
+        and not all_overlays
+    ):
+        raise click.UsageError(
+            "Provide at least one of --overlay-name, --overlay-source, --overlay-id, or --all-overlays"
+        )
+
+    resolved_overlay_ids: list[str] = []
+
+    for overlay_name in overlay_names:
+        rows = session.execute(
+            text(
+                "SELECT overlay_id FROM overlay WHERE name = :name ORDER BY created_at"
+            ),
+            {"name": overlay_name},
+        ).all()
+        if not rows:
+            raise click.UsageError(f"No overlays found with name {overlay_name}")
+        resolved_overlay_ids.extend(str(row.overlay_id) for row in rows)
+
+    for overlay_source in overlay_sources:
+        rows = session.execute(
+            text(
+                "SELECT overlay_id FROM overlay WHERE source = :source ORDER BY created_at"
+            ),
+            {"source": overlay_source},
+        ).all()
+        if not rows:
+            raise click.UsageError(f"No overlays found with source {overlay_source}")
+        resolved_overlay_ids.extend(str(row.overlay_id) for row in rows)
+
+    for overlay_id in overlay_ids:
+        # Validate UUID format
+        try:
+            overlay_uuid = uuid.UUID(overlay_id)
+        except ValueError:
+            raise click.UsageError(
+                f"Invalid UUID format: {overlay_id}. Overlay ID must be a valid UUID."
+            )
+
+        overlay_check = session.execute(
+            text("SELECT overlay_id FROM overlay WHERE overlay_id = :overlay_id"),
+            {"overlay_id": str(overlay_uuid)},
+        ).one_or_none()
+        if not overlay_check:
+            raise click.UsageError(f"Overlay with ID {overlay_id} not found")
+        resolved_overlay_ids.append(str(overlay_uuid))
+
+    if all_overlays:
+        rows = session.execute(
+            text("SELECT overlay_id FROM overlay ORDER BY created_at")
+        ).all()
+        resolved_overlay_ids.extend(str(row.overlay_id) for row in rows)
+
+    # Dedupe while preserving order
+    resolved_overlay_ids = list(dict.fromkeys(resolved_overlay_ids))
+
+    statefps_filter = list(statefps) if statefps else None
+
+    stmt = text(
+        """INSERT INTO districtrmap_overlays (districtr_map_id, overlay_id)
+        SELECT uuid, CAST(:overlay_id AS uuid) FROM districtrmap
+        WHERE (CAST(:statefps AS varchar[]) IS NULL OR statefps && CAST(:statefps AS varchar[]))
+        ON CONFLICT (districtr_map_id, overlay_id) DO NOTHING
+        RETURNING districtr_map_id"""
+    )
+    for overlay_id in resolved_overlay_ids:
+        result = session.execute(
+            stmt,
+            {"overlay_id": overlay_id, "statefps": statefps_filter},
+        )
+        linked_map_ids = result.scalars().all()
+        logger.info(f"Linked overlay {overlay_id} to {len(linked_map_ids)} map(s)")
+
+
 @cli.command("remove-overlay-from-map")
 @click.option("--districtr-map-slug", "-d", help="DistrictrMap slug", required=True)
 @click.option("--overlay-id", "-o", help="Overlay ID to remove", required=True)

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -981,6 +981,81 @@ def delete_overlay(session: Session, overlay_id: str):
         logger.error(f"Overlay with ID {overlay_id} not found")
 
 
+@cli.command("sync-overlay-metadata")
+@click.option(
+    "--metadata",
+    "-m",
+    help="Path to the metadata JSON file",
+    required=True,
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Log what would change without writing",
+)
+@with_session
+def sync_overlay_metadata(session: Session, metadata: str, dry_run: bool):
+    """Bulk-update overlay name and description from a published metadata JSON file.
+
+    Overlays are matched to metadata entries by the basename of their source URL:
+    a source ending in `{key}.geojson` matches the metadata entry keyed by `{key}`.
+    """
+    try:
+        with open(metadata) as f:
+            metadata_by_key = json.load(f)
+    except FileNotFoundError:
+        raise click.UsageError(f"Metadata file not found: {metadata}")
+    except json.JSONDecodeError as e:
+        raise click.UsageError(f"Invalid JSON in metadata file {metadata}: {e}")
+
+    overlays = session.execute(
+        text(
+            "SELECT overlay_id, source, name, description FROM overlay WHERE source IS NOT NULL"
+        )
+    ).all()
+
+    updated_count = 0
+    for overlay in overlays:
+        key = overlay.source.rsplit("/", 1)[-1].removesuffix(".geojson")
+        entry = metadata_by_key.get(key)
+        if entry is None:
+            logger.info(f"No metadata entry for {key}; leaving overlay unchanged")
+            continue
+
+        new_name = entry.get("name")
+        new_description = entry.get("description")
+        if new_name == overlay.name and new_description == overlay.description:
+            logger.debug(f"Overlay {key} already up to date")
+            continue
+
+        if dry_run:
+            logger.info(f"Would update {key}: name/description")
+            updated_count += 1
+            continue
+
+        session.execute(
+            text(
+                """UPDATE overlay
+                SET name = :name, description = :description, updated_at = :updated_at
+                WHERE overlay_id = :overlay_id"""
+            ),
+            {
+                "name": new_name,
+                "description": new_description,
+                "updated_at": datetime.now(timezone.utc),
+                "overlay_id": overlay.overlay_id,
+            },
+        )
+        logger.info(f"Updated {key}: name/description")
+        updated_count += 1
+
+    if dry_run:
+        logger.info(f"Dry run: {updated_count} overlay(s) would be updated")
+    else:
+        logger.info(f"Updated {updated_count} overlay(s)")
+
+
 @cli.command("check-missing-graphs")
 @click.option(
     "--skip-alert",

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -497,3 +497,167 @@ def test_link_overlays_to_maps_invalid_selectors(engine, link_test_maps):
 
     no_selector_proc = run_cli("link-overlays-to-maps")
     assert no_selector_proc.returncode != 0, "Missing selectors did not fail"
+
+
+SYNC_TEST_SOURCE = "https://x/overlays/al_cd.geojson"
+SYNC_TEST_STALE_NAME = "Sync Metadata Test Stale Name"
+SYNC_TEST_STALE_DESCRIPTION = "Stale description"
+SYNC_TEST_NEW_NAME = "Congressional Districts"
+SYNC_TEST_NEW_DESCRIPTION = "Used in 2026 elections"
+SYNC_TEST_ABSENT_SOURCE = "https://x/overlays/zz_none.geojson"
+
+
+def purge_sync_test_rows(session: Session):
+    """Delete committed overlays created by the sync-overlay-metadata tests."""
+    session.execute(
+        text("DELETE FROM overlay WHERE source = ANY(:sources)"),
+        {"sources": [SYNC_TEST_SOURCE, SYNC_TEST_ABSENT_SOURCE]},
+    )
+    session.commit()
+
+
+def create_sync_test_overlay(
+    engine,
+    layer_type: str,
+    source: str,
+    name: str = SYNC_TEST_STALE_NAME,
+    description: str = SYNC_TEST_STALE_DESCRIPTION,
+) -> str:
+    """Create a committed overlay row visible to CLI subprocesses."""
+    overlay_id = str(uuid4())
+    with Session(engine) as overlay_session:
+        overlay_session.add(
+            Overlay(
+                overlay_id=overlay_id,
+                name=name,
+                description=description,
+                data_type="geojson",
+                layer_type=layer_type,
+                source=source,
+            )
+        )
+        overlay_session.commit()
+    return overlay_id
+
+
+def get_overlay_name_description(engine, overlay_id: str) -> tuple[str, str]:
+    with Session(engine) as query_session:
+        row = query_session.execute(
+            text(
+                "SELECT name, description FROM overlay WHERE overlay_id = :overlay_id"
+            ),
+            {"overlay_id": overlay_id},
+        ).one()
+    return row.name, row.description
+
+
+@pytest.fixture(name="sync_test_cleanup")
+def sync_test_cleanup_fixture(engine):
+    """Purge sync-overlay-metadata test overlays before and after each test."""
+    with Session(engine) as setup_session:
+        purge_sync_test_rows(setup_session)
+    yield
+    with Session(engine) as teardown_session:
+        purge_sync_test_rows(teardown_session)
+
+
+def test_sync_overlay_metadata_updates_all_matching(
+    engine, tmp_path, sync_test_cleanup
+):
+    """Both overlays sharing a source key get the new name and description"""
+    line_overlay_id = create_sync_test_overlay(engine, "line", SYNC_TEST_SOURCE)
+    text_overlay_id = create_sync_test_overlay(engine, "text", SYNC_TEST_SOURCE)
+
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "al_cd": {
+                    "name": SYNC_TEST_NEW_NAME,
+                    "description": SYNC_TEST_NEW_DESCRIPTION,
+                    "source": "Dave's Redistricting App",
+                    "plan_name": "AL 2026 Congressional",
+                    "year": "2026",
+                }
+            }
+        )
+    )
+
+    result_proc = run_cli("sync-overlay-metadata", "--metadata", str(metadata_path))
+    assert (
+        result_proc.returncode == 0
+    ), f"CLI command failed: {result_proc.stderr or result_proc.stdout}"
+
+    for overlay_id in (line_overlay_id, text_overlay_id):
+        name, description = get_overlay_name_description(engine, overlay_id)
+        assert name == SYNC_TEST_NEW_NAME, "Overlay name not updated"
+        assert (
+            description == SYNC_TEST_NEW_DESCRIPTION
+        ), "Overlay description not updated"
+
+
+def test_sync_overlay_metadata_dry_run_no_changes(engine, tmp_path, sync_test_cleanup):
+    """--dry-run leaves the overlay name and description unchanged"""
+    overlay_id = create_sync_test_overlay(engine, "line", SYNC_TEST_SOURCE)
+
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "al_cd": {
+                    "name": SYNC_TEST_NEW_NAME,
+                    "description": SYNC_TEST_NEW_DESCRIPTION,
+                }
+            }
+        )
+    )
+
+    result_proc = run_cli(
+        "sync-overlay-metadata", "--metadata", str(metadata_path), "--dry-run"
+    )
+    assert (
+        result_proc.returncode == 0
+    ), f"CLI command failed: {result_proc.stderr or result_proc.stdout}"
+
+    name, description = get_overlay_name_description(engine, overlay_id)
+    assert name == SYNC_TEST_STALE_NAME, "Dry run changed overlay name"
+    assert (
+        description == SYNC_TEST_STALE_DESCRIPTION
+    ), "Dry run changed overlay description"
+
+
+def test_sync_overlay_metadata_absent_key_unchanged(
+    engine, tmp_path, sync_test_cleanup
+):
+    """An overlay whose key is absent from the metadata is left unchanged"""
+    overlay_id = create_sync_test_overlay(engine, "line", SYNC_TEST_ABSENT_SOURCE)
+
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "al_cd": {
+                    "name": SYNC_TEST_NEW_NAME,
+                    "description": SYNC_TEST_NEW_DESCRIPTION,
+                }
+            }
+        )
+    )
+
+    result_proc = run_cli("sync-overlay-metadata", "--metadata", str(metadata_path))
+    assert (
+        result_proc.returncode == 0
+    ), f"CLI command failed: {result_proc.stderr or result_proc.stdout}"
+
+    name, description = get_overlay_name_description(engine, overlay_id)
+    assert name == SYNC_TEST_STALE_NAME, "Absent-key overlay name changed"
+    assert (
+        description == SYNC_TEST_STALE_DESCRIPTION
+    ), "Absent-key overlay description changed"
+
+
+def test_sync_overlay_metadata_missing_file_fails(engine, tmp_path):
+    """A nonexistent metadata file exits non-zero"""
+    missing_path = tmp_path / "does_not_exist.json"
+    result_proc = run_cli("sync-overlay-metadata", "--metadata", str(missing_path))
+    assert result_proc.returncode != 0, "Nonexistent metadata file did not fail"

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,4 +1,5 @@
-from app.models import Overlay
+import pytest
+from app.models import DistrictrMap, Overlay
 from sqlmodel import Session
 from tests.constants import (
     POSTGRES_TEST_DB,
@@ -11,7 +12,8 @@ from tests.constants import (
 from pathlib import Path
 import subprocess
 import os
-from sqlalchemy import select
+from sqlalchemy import select, text
+from uuid import uuid4
 import json
 
 test_env = os.environ.copy()
@@ -268,3 +270,230 @@ def test_update_overlay(session: Session):
         f"Updated overlay {original_overlay_id}" in result_output
     ), "Overlay not updated"
     cleanup_overlay(session, "Updated Overlay")
+
+
+LINK_TEST_OVERLAY_NAME = "Link Overlays Test Overlay"
+LINK_TEST_PARENT_LAYER = "link_overlays_test_layer"
+LINK_TEST_MAP_SLUGS = ("link_overlays_test_map_ks", "link_overlays_test_map_mo")
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python", "cli.py", *args],
+        cwd=str(backend_dir),
+        env=test_env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def purge_link_test_rows(session: Session):
+    """Delete committed rows from the link-overlays tests, including leftovers from killed runs."""
+    session.execute(
+        text(
+            """DELETE FROM districtrmap_overlays
+            WHERE overlay_id IN (SELECT overlay_id FROM overlay WHERE name = :name)
+            OR districtr_map_id IN (
+                SELECT uuid FROM districtrmap WHERE districtr_map_slug = ANY(:slugs)
+            )"""
+        ),
+        {"name": LINK_TEST_OVERLAY_NAME, "slugs": list(LINK_TEST_MAP_SLUGS)},
+    )
+    session.execute(
+        text("DELETE FROM overlay WHERE name = :name"),
+        {"name": LINK_TEST_OVERLAY_NAME},
+    )
+    session.execute(
+        text("DELETE FROM districtrmap WHERE districtr_map_slug = ANY(:slugs)"),
+        {"slugs": list(LINK_TEST_MAP_SLUGS)},
+    )
+    session.commit()
+
+
+@pytest.fixture(name="link_test_maps")
+def link_test_maps_fixture(engine):
+    """Two committed districtrmap rows (statefps ['20'] and ['29']).
+
+    The CLI runs as a subprocess with its own database connection, so these
+    rows must be committed with a real Session(engine) — the rollback-session
+    fixture used elsewhere is invisible to subprocesses.
+    """
+    with Session(engine) as setup_session:
+        purge_link_test_rows(setup_session)
+        setup_session.execute(
+            text(
+                """INSERT INTO gerrydbtable (uuid, name, updated_at)
+                VALUES (gen_random_uuid(), :name, now())
+                ON CONFLICT (name)
+                DO UPDATE SET
+                    updated_at = now()"""
+            ),
+            {"name": LINK_TEST_PARENT_LAYER},
+        )
+        map_uuids: dict[str, str] = {}
+        for statefp, districtr_map_slug in zip(("20", "29"), LINK_TEST_MAP_SLUGS):
+            districtr_map = DistrictrMap(
+                uuid=str(uuid4()),
+                name=f"Link overlays test map {statefp}",
+                districtr_map_slug=districtr_map_slug,
+                parent_layer=LINK_TEST_PARENT_LAYER,
+                visible=True,
+                map_type="default",
+                num_districts_modifiable=True,
+                statefps=[statefp],
+            )
+            setup_session.add(districtr_map)
+            map_uuids[statefp] = districtr_map.uuid
+        setup_session.commit()
+
+    yield map_uuids
+
+    with Session(engine) as teardown_session:
+        purge_link_test_rows(teardown_session)
+
+
+def create_link_test_overlay(engine, source: str | None = None) -> str:
+    """Create a committed overlay row visible to CLI subprocesses."""
+    overlay_id = str(uuid4())
+    with Session(engine) as overlay_session:
+        overlay_session.add(
+            Overlay(
+                overlay_id=overlay_id,
+                name=LINK_TEST_OVERLAY_NAME,
+                data_type="geojson",
+                layer_type="fill",
+                source=source,
+            )
+        )
+        overlay_session.commit()
+    return overlay_id
+
+
+def get_linked_map_ids(engine, overlay_id: str) -> set[str]:
+    with Session(engine) as query_session:
+        rows = query_session.execute(
+            text(
+                "SELECT districtr_map_id FROM districtrmap_overlays WHERE overlay_id = :overlay_id"
+            ),
+            {"overlay_id": overlay_id},
+        ).all()
+    return {str(row.districtr_map_id) for row in rows}
+
+
+def test_link_overlays_to_maps_by_name(engine, link_test_maps):
+    """Linking by --overlay-name links the overlay to all maps"""
+    overlay_id = create_link_test_overlay(engine)
+
+    result_proc = run_cli(
+        "link-overlays-to-maps", "--overlay-name", LINK_TEST_OVERLAY_NAME
+    )
+    assert (
+        result_proc.returncode == 0
+    ), f"CLI command failed: {result_proc.stderr or result_proc.stdout}"
+
+    linked_map_ids = get_linked_map_ids(engine, overlay_id)
+    assert link_test_maps["20"] in linked_map_ids, "Overlay not linked to KS map"
+    assert link_test_maps["29"] in linked_map_ids, "Overlay not linked to MO map"
+
+
+def test_link_overlays_to_maps_statefps_filter(engine, link_test_maps):
+    """--statefps only links to maps whose statefps array overlaps the filter"""
+    overlay_id = create_link_test_overlay(engine)
+
+    result_proc = run_cli(
+        "link-overlays-to-maps",
+        "--overlay-name",
+        LINK_TEST_OVERLAY_NAME,
+        "--statefps",
+        "20",
+    )
+    assert (
+        result_proc.returncode == 0
+    ), f"CLI command failed: {result_proc.stderr or result_proc.stdout}"
+
+    linked_map_ids = get_linked_map_ids(engine, overlay_id)
+    assert link_test_maps["20"] in linked_map_ids, "Overlay not linked to KS map"
+    assert (
+        link_test_maps["29"] not in linked_map_ids
+    ), "Overlay linked to MO map despite statefps filter"
+
+
+def test_link_overlays_to_maps_by_source(engine, link_test_maps):
+    """--overlay-source selects only the overlay rows with that exact source"""
+    ks_overlay_id = create_link_test_overlay(
+        engine, source="s3://bucket/link-test-ks.geojson"
+    )
+    mo_overlay_id = create_link_test_overlay(
+        engine, source="s3://bucket/link-test-mo.geojson"
+    )
+
+    result_proc = run_cli(
+        "link-overlays-to-maps",
+        "--overlay-source",
+        "s3://bucket/link-test-ks.geojson",
+        "--statefps",
+        "20",
+    )
+    assert (
+        result_proc.returncode == 0
+    ), f"CLI command failed: {result_proc.stderr or result_proc.stdout}"
+
+    ks_linked_map_ids = get_linked_map_ids(engine, ks_overlay_id)
+    assert (
+        link_test_maps["20"] in ks_linked_map_ids
+    ), "Source-selected overlay not linked to KS map"
+    assert (
+        link_test_maps["29"] not in ks_linked_map_ids
+    ), "Source-selected overlay linked to MO map despite statefps filter"
+    assert (
+        get_linked_map_ids(engine, mo_overlay_id) == set()
+    ), "Overlay with a different source was linked"
+
+
+def test_link_overlays_to_maps_idempotent(engine, link_test_maps):
+    """Running the command twice leaves the junction table unchanged"""
+    overlay_id = create_link_test_overlay(engine)
+
+    first_proc = run_cli(
+        "link-overlays-to-maps", "--overlay-name", LINK_TEST_OVERLAY_NAME
+    )
+    assert (
+        first_proc.returncode == 0
+    ), f"CLI command failed: {first_proc.stderr or first_proc.stdout}"
+    first_linked_map_ids = get_linked_map_ids(engine, overlay_id)
+
+    second_proc = run_cli(
+        "link-overlays-to-maps", "--overlay-name", LINK_TEST_OVERLAY_NAME
+    )
+    assert (
+        second_proc.returncode == 0
+    ), f"CLI command failed: {second_proc.stderr or second_proc.stdout}"
+    second_linked_map_ids = get_linked_map_ids(engine, overlay_id)
+
+    assert (
+        second_linked_map_ids == first_linked_map_ids
+    ), "Second run changed the junction table"
+
+
+def test_link_overlays_to_maps_invalid_selectors(engine, link_test_maps):
+    """Unknown name/source/id, invalid UUID, and missing selectors all fail"""
+    unknown_name_proc = run_cli(
+        "link-overlays-to-maps", "--overlay-name", "No Such Overlay Name"
+    )
+    assert unknown_name_proc.returncode != 0, "Unknown overlay name did not fail"
+
+    unknown_source_proc = run_cli(
+        "link-overlays-to-maps",
+        "--overlay-source",
+        "s3://bucket/no-such-source.geojson",
+    )
+    assert unknown_source_proc.returncode != 0, "Unknown overlay source did not fail"
+
+    invalid_uuid_proc = run_cli("link-overlays-to-maps", "--overlay-id", "not-a-uuid")
+    assert invalid_uuid_proc.returncode != 0, "Invalid UUID format did not fail"
+
+    unknown_uuid_proc = run_cli("link-overlays-to-maps", "--overlay-id", str(uuid4()))
+    assert unknown_uuid_proc.returncode != 0, "Unknown overlay UUID did not fail"
+
+    no_selector_proc = run_cli("link-overlays-to-maps")
+    assert no_selector_proc.returncode != 0, "Missing selectors did not fail"


### PR DESCRIPTION
## Description

Adds a re-runnable CLI command for attaching overlays to maps, and a county paint mask for Super Draw.

**Backend**:
- New `link-overlays-to-maps` CLI command — idempotently links overlays to maps (`INSERT … ON CONFLICT DO NOTHING`), selecting overlays by name, source URL, id,  or `--all-overlays`, and filtering maps by `--statefps` (array-overlap against `districtrmap.statefps`). Selecting by source URL exists because overlay display names repeat across states while source URLs are unique, so per-state scripts can re-link without ids. Safe to re-run any time to pick up newly created maps; maps with NULL `statefps` never match a filter.

**Frontend — county paint mask (Super Draw)**:
- The built-in county boundaries pseudo-overlay now supports the same choose-an-area-to-paint-within mask as real overlays: mask button on the county row (Super Draw only), county branch in `setPaintConstraint` (`querySourceFeatures` on the county source with a `GEOID` filter; `promoteId` added so feature ids resolve), and click/hover routing to the always-on `counties_fill` layer via a shared `getSelectingClickLayer` helper.
- Matching visuals: feature-state hover highlight while selecting, semi-opaque white dim over non-selected counties, and an orange outline on the selected county. Turning the county layer off releases an active county mask.
- Enforcement reuses the existing geometry-based `filterFeatures` path unchanged.

## Reviewers

- Primary: @fangge518 
- Secondary:

## Checklist

- [x] Added/Updated related documentation
      (CLI `--help` text documents all selectors and the statefps filter).
- [x] Added/Updated related unit tests (5 CLI tests for `link-overlays-to-maps`:
      by name, by source, statefps filtering, idempotent re-run, invalid selectors —
      10/10 passing in `backend/tests/test_cli.py`).

## Screenshots (if applicable):

<!-- Suggested: county mask active in Super Draw (dimmed counties + orange
outline on the selected county). -->

## Review required

- **Linker semantics**: `--statefps` uses array overlap (`&&`) against `districtrmap.statefps`, and NULL-statefps maps are deliberately excluded from filtered links — confirm that matches how prod map modules are populated.
- **UI/UX validation**: county mask feel in Super Draw — hover highlight while selecting, dim opacity (0.75), selected outline, and that releasing the mask (button or county-layer toggle) behaves as expected alongside the existing  County Brush.