### PR TITLE
Refresh guide page with new video set and add Map Modes / Super Draw sections

### DIFF
--- a/app/src/app/(static)/about/page.tsx
+++ b/app/src/app/(static)/about/page.tsx
@@ -3,7 +3,7 @@ import {DevTeam} from '@/app/components/Static/Content/DevTeam';
 import {Flex, Heading, Text, Link, Box} from '@radix-ui/themes';
 import {LearnSubNav} from '@/app/components/Static/LearnSubNav';
 
-export default function GuidePage() {
+export default function AboutPage() {
   return (
     <Flex direction="column" gapY="4">
       <LearnSubNav />

--- a/app/src/app/(static)/data/page.tsx
+++ b/app/src/app/(static)/data/page.tsx
@@ -51,9 +51,9 @@ export default function DataPage() {
         3.5 million households across the United States each year, and produces two data products
         from this survey: <b>1-year estimates</b> and <b>5-year estimates</b>. 1-year estimates are
         estimated population statistics published for Census-designated areas with 65,000 people or
-        more, and so are unsuitable for redistricting. The <b>5-year estimates</b> are estimated population
-        statistics, including income and some demographic data, and are published at the block group
-        level regardless of population.
+        more, and so are unsuitable for redistricting. The <b>5-year estimates</b> are estimated
+        population statistics, including income and some demographic data, and are published at the
+        block group level regardless of population.
       </Text>
       <Text size="3">
         To compute the demographic categories like &quot;Black&quot; and &quot;Asian&quot; in

--- a/app/src/app/(static)/data/page.tsx
+++ b/app/src/app/(static)/data/page.tsx
@@ -2,7 +2,7 @@ import {CTA} from '@/app/components/Static/Content/CTA';
 import {Flex, Heading, Text, Link, Box} from '@radix-ui/themes';
 import {LearnSubNav} from '@/app/components/Static/LearnSubNav';
 
-export default function GuidePage() {
+export default function DataPage() {
   return (
     <Flex direction="column" gapY="4">
       <LearnSubNav />
@@ -49,10 +49,9 @@ export default function GuidePage() {
         block level. The <b>American Community Survey (ACS)</b> is another large dataset produced by
         the United States Census Bureau. To collect data, the Census Bureau surveys approximately
         3.5 million households across the United States each year, and produces two data products
-        from households across the United States each year, and produces two data products from this
-        survey: <b>1-year estimates</b> and <b>5-year estimates</b>. 1-year estimates are estimated
-        population statistics published for Census-designated areas with 65,000 people or more, and
-        so is unsuitable for redistricting. The <b>5-year estimates</b> are estimated population
+        from this survey: <b>1-year estimates</b> and <b>5-year estimates</b>. 1-year estimates are
+        estimated population statistics published for Census-designated areas with 65,000 people or
+        more, and so are unsuitable for redistricting. The <b>5-year estimates</b> are estimated population
         statistics, including income and some demographic data, and are published at the block group
         level regardless of population.
       </Text>
@@ -66,8 +65,8 @@ export default function GuidePage() {
         . On the backend, all of our data comes from the{' '}
         <Link href="https://mggg.org/" target="_blank">
           Data and Democracy Lab
-        </Link>{' '}
-        Redistricting Lab&apos;s{' '}
+        </Link>
+        &apos;s{' '}
         <Link href="https://github.com/mggg/gerrydb-client-py" target="_blank">
           gerrydb
         </Link>{' '}

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -116,7 +116,8 @@ export default function GuidePage() {
             Districts
           </Heading>
           <Text size="3">
-            To hide the districts from the map, click the "visual setting" at the top of the side panel and uncheck the "Painted districts" box.
+            To hide the districts from the map, click the “visual setting” at the top of the side
+            panel and uncheck the “Painted districts” box.
           </Text>
           <Text size="3">
             To remove county boundaries overlaid on your map, toggle the “County Boundaries” box.
@@ -140,7 +141,7 @@ export default function GuidePage() {
             corner of the map and then choose the “Highlight unassigned areas” box.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/highlight_unassigned.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/highlight_unassigned.webm`}
           />
 
           <Heading as="h3" size="4">
@@ -148,8 +149,10 @@ export default function GuidePage() {
           </Heading>
           <Text size="3">
             Under this tab, you can study the demographic make up of your districts. You have the
-            option of total population or voting age population. Under the "Map Layer" tab, you can choose to view the demographic
-            data as a choropleth on top of the map by selecting "Overlay" under "Display Modes", or view it as sized circles by selecting "Sized Circles".
+            option of total population or voting age population. Under the “Map Layer” tab, you can
+            choose to view the demographic data as a choropleth on top of the map by selecting
+            “Overlay” under “Display Modes”, or view it as sized circles by selecting “Sized
+            Circles”.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/demographics_panel.webm`}
@@ -161,7 +164,8 @@ export default function GuidePage() {
           <Text size="3">
             In the elections tab you can view how your districts would have behaved under past
             election data. Just like the demographics tab, you can choose to view the election
-            data as a choropleth on top of the map by selecting "Overlay" under "Display Modes", or view it as sized circles by selecting "Sized Circles".
+            data as a choropleth on top of the map by selecting “Overlay” under “Display Modes”, or
+            view it as sized circles by selecting “Sized Circles”.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/election_panel.webm`}
@@ -203,7 +207,9 @@ export default function GuidePage() {
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/view_mode.webm`}
           />
           <Text size="3">
-            <b>Evaluate mode</b> lists commonly used evaluation metrics for your plan. You see see whether your plans is complete, contiguous, population-balance, as well as how compact it districts are and how much it favors a party given past election data.
+            <b>Evaluate mode</b> lists commonly used evaluation metrics for your plan. You can see
+            whether your plan is complete, contiguous, and population-balanced, as well as how
+            compact its districts are and how much it favors a party given past election data.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/evaluation_mode.webm`}
@@ -225,7 +231,9 @@ export default function GuidePage() {
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
           />
           <Text size="3">
-            The "Catalog" from the main page stores all your maps, which allows you to switch between different maps you have seen. You can go there at any time from the navigational menu of the "Districtr" icon.
+            The “Catalog” from the main page stores all your maps, which allows you to switch
+            between different maps you have worked on. You can go there at any time from the
+            navigational menu of the “Districtr” icon.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/map_catalog.webm`}
@@ -261,8 +269,10 @@ export default function GuidePage() {
           <Text size="3">
             Districtr provides the option to export a map in several formats. The most compatible
             format with other platforms is a CSV assignment file which maps Census blocks to
-            districts. Click on the "Map Action" menu in the upper right corner of the map and select “Export
-            assignments”, then “Block assignments”. Alternatively, you can also export your district shapes as a GeoJson or a shape file, or export evaluation metrics as a json file.
+            districts. Click on the “Map Action” menu in the upper right corner of the map and
+            select “Export assignments”, then “Block assignments”. Alternatively, you can also
+            export your district shapes as a GeoJSON or a shapefile, or export evaluation metrics
+            as a JSON file.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/export.webm`}
@@ -293,10 +303,10 @@ export default function GuidePage() {
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/shatter.webm`}
           />
           <Text size="3">
-            Super Draw allows you change whether population statistic is displayed by
-            share or by count, click the gear icon to the right of “Summary Type” and choose
-            “Population by Share” or “Population by Count”. The Super Draw mode also allows you to 
-            switch on a side-by-side demographic and elections choropleth instead of overlay.
+            Super Draw allows you to change whether the population statistic is displayed by share
+            or by count: click the gear icon to the right of “Summary Type” and choose “Population
+            by Share” or “Population by Count”. The Super Draw mode also allows you to switch on a
+            side-by-side demographic and elections choropleth instead of an overlay.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/super_draw_side_by_side.webm`}

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -1,7 +1,7 @@
 import {CTA} from '@/app/components/Static/Content/CTA';
 import {ContentSection} from '@/app/components/Static/ContentSection';
 import {LoopVideoPlayer} from '@/app/components/Static/LoopVideoPlayer';
-import {Box, Flex, Heading, Text} from '@radix-ui/themes';
+import {Flex, Heading, Text} from '@radix-ui/themes';
 import {LearnSubNav} from '@/app/components/Static/LearnSubNav';
 import {GuideToc, type GuideTocEntry} from '@/app/components/Static/GuideToc';
 import {slugify} from '@/app/utils/slugify';
@@ -33,11 +33,6 @@ export default function GuidePage() {
       <GuideToc entries={TOC_ENTRIES} />
       <Flex direction="column" gapY="4" className="min-w-0 flex-1">
         <LearnSubNav />
-        <Box>
-          <Heading size="8" as="h1">
-            Tutorial
-          </Heading>
-        </Box>
         <ContentSection title="Getting Started With Districts">
           <Flex direction="column" gapY="4">
             <Text size="3">

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -170,8 +170,8 @@ export default function GuidePage() {
             Elections
           </Heading>
           <Text size="3">
-            In the elections tab you can view how your districts would have behaved under past
-            election data. Just like the demographics tab, you can choose to view the election data
+            In the elections panel you can view how your districts would have behaved under past
+            election data. Just like the demographics panel, you can choose to view the election data
             as a choropleth on top of the map by selecting “Overlay” under “Display Modes”, or view
             it as sized circles by selecting “Sized Circles”.
           </Text>
@@ -183,7 +183,7 @@ export default function GuidePage() {
             Map Validation
           </Heading>
           <Text size="3">
-            Under the map validation tab, you can check whether your map is missing any geographic
+            Under the map validation panel, you can check whether your map is missing any geographic
             units.
           </Text>
           <LoopVideoPlayer

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -16,253 +16,229 @@ export default function GuidePage() {
       <ContentSection title="Getting Started With Districts">
         <Flex direction="column" gapY="4">
           <Text size="3">
-            On the Districtr homepage, click “Jump to the Map” in the top right corner.
-          </Text>
-          <Text size="3">
-            You will be redirected to an interactive map of the United States. Click the state for
-            which you wish to make a districting plan. All states are available, as well as
-            Washington, D.C. and Puerto Rico.
+            On the Districtr homepage, click “Jump to the Map” in the top right corner. You will
+            be redirected to an interactive map of the United States. Click the state for which
+            you wish to make a districting plan. All states are available, as well as Washington,
+            D.C. and Puerto Rico.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/get_to_map.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/draw_menu.webm`}
           />
           <Text size="3">
             Once you have selected a state, you will be directed to its landing page. The landing
-            page contains all mapping options along with background information.
-          </Text>
-          <Text size="3">
-            Choose a locality (state, region, county, or city) and district type by clicking on a
-            card. The available localities and districts vary by state. (Additional localities can
-            be added upon request.)
+            page contains all mapping options along with background information. Choose a
+            locality (state, region, county, or city) and district type by clicking on a card.
+            The available localities and districts vary by state. (Additional localities can be
+            added upon request.)
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/get_to_locality_module.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/select_module.webm`}
           />
-          <Text size="3">You will now be redirected to your selected districting page.</Text>
+          <Text size="3">
+            You will now be redirected to your selected districting page. Select the hand icon on
+            the toolbar at the bottom of the map, then click and drag to pan across the map. To
+            zoom in and out, use the plus and minus buttons in the bottom right corner of the map,
+            or use a mouse scroll wheel or trackpad.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/moving_in_map.webm`}
+          />
         </Flex>
       </ContentSection>
-      <ContentSection title="Main Tools">
+      <ContentSection title="Drawing Districts">
         <Flex direction="column" gapY="4">
-          <Heading as="h3" size="4">
-            Moving across the map
-          </Heading>
-
           <Text size="3">
-            Select the hand icon on the toolbar at the bottom of the map. Then click and drag to pan
-            across the map.
-          </Text>
-          <Text size="3">
-            To zoom in and out, use the plus and minus buttons in the bottom right corner of the
-            map. You can also use a mouse scroll wheel or trackpad.
+            To draw your first district, select the paintbrush icon on the toolbar at the bottom
+            of the map. Click and drag on the map to add units to your district.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/move_zoom.webm`}
-          />
-
-          <Heading as="h3" size="4">
-            Drawing the districts
-          </Heading>
-
-          <Text size="3">
-            To draw your first district, select the paintbrush icon on the toolbar at the bottom of
-            the map. Click and drag on the map to add units to your district.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/paint_1.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_on_map.webm`}
           />
           <Text size="3">
             To draw another district, select a new color from the color bar that appears when you
             click the paint icon. Each color corresponds to a different district. For pages with
-            large numbers of districts, only one color will show when you start. For these, use the
-            dropdown menu to select a different color.
+            large numbers of districts, only one color will show when you start. For these, use
+            the dropdown menu to select a different color.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/paint_2.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_another_district.webm`}
           />
           <Text size="3">
             To change the size of the brush, drag the brush size slider directly above the color
             bar.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/brush_size.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/brush_size.webm`}
           />
           <Text size="3">
-            To paint whole counties, toggle the “County Brush” box next to the slider.
+            To paint whole counties at once, toggle the “County Brush” box next to the slider.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/paint_by_county.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/county_brush.webm`}
+          />
+          <Text size="3">
+            To correct the boundaries of your districts, click the erase icon on the toolbar at
+            the bottom of the map. Click and drag to remove units from that district. The size of
+            the eraser can be adjusted by dragging the slider.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/eraser.webm`}
+          />
+          <Text size="3">
+            Click the “undo/redo” buttons to revert the boundaries of your district plan to a
+            previous version.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/undo_redo.webm`}
           />
           <Text size="3">
             To inspect districts without altering them, or to avoid painting over already-drawn
-            areas, toggle the lock icon next to the district number in the list of districts in the
-            “Population” tab.
+            areas, toggle the lock icon next to the district number in the list of districts in
+            the “Population” tab.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/lock_districts.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
           />
           <Text size="3">
-            To correct the boundaries of your districts, click the erase icon on the toolbar at the
-            bottom of the map. Click and drag to remove units from that district. The size of the
-            eraser can be adjusted by dragging the slider.
+            To see which units you still need to color, click the gear icon in the upper right
+            corner of the map and choose the “Highlight unassigned areas” box.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/erase.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/highlight_unassigned.webm`}
           />
-          <Text size="3">
-            Alternately, click the “undo/redo” buttons to revert the boundaries of your district
-            plan to a previous version.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/undo_redo.webm`}
-          />
-          <Text size="3">
-            If you need to use smaller units of geography to balance the population of your
-            districts, click the break icon on the toolbar at the bottom of the map. Then click on a
-            unit you want to “shatter”, allowing you to paint subsets of the original unit. You can
-            see the population number of each broken piece by clicking the gear icon in the upper
-            right corner of the map and selecting “Show total population labels on blocks”.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/shatter.webm`}
-          />
-          <Text size="3">
-            If you need to move the toolbar, you can do so by clicking the gear icon in the upper
-            right corner of the map and selecting “Enable draggable toolbar”. Beneath that option,
-            you can also choose to resize the toolbar. Once enabled, you can drag the toolbar around
-            the map or snap it to the right hand panel.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/draggable_toolbar.webm`}
-          />
-          <Heading as="h3" size="4">
-            Districts
-          </Heading>
-          <Text size="3">
-            To hide the districts from the map, click the gear icon in the upper right corner of the
-            map and toggle the “Show painted districts” box.
-          </Text>
-          <Text size="3">
-            To see county boundaries overlaid on your map, toggle the “Show County Boundaries” box.
-          </Text>
         </Flex>
       </ContentSection>
 
-      <ContentSection title="Tabs">
+      <ContentSection title="Data Panels">
         <Flex direction="column" gapY="4">
-          <Heading as="h3" size="4">
-            Population
-          </Heading>
-
-          <Text size="3">
-            The population tab allows you to view the population of each drawn district. To balance
-            your population evenly between districts, make reference to the ideal population count
-            and vertical bar provided in this tab.
-          </Text>
-          <Text size="3">
-            To see which units you still need to color, click the gear icon in the upper right
-            corner of the map and then choose the “Highlight unassigned areas” box.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/highlight_unassigned.webm`}
-          />
-
           <Heading as="h3" size="4">
             Demographics
           </Heading>
           <Text size="3">
             Under this tab, you can study the demographic make up of your districts. You have the
-            option of total population or voting age population. To change whether this is by share
-            or by count, click the gear icon to the right of “Evaluation” and choose “Population by
-            Share” or “Population by Count”.
-          </Text>
-          <Text size="3">
-            You can also view the demographic data as a choropleth on the map itself. Choose
-            “Comparison” at the bottom of the demographics tab to put the choropleth side by side
-            with the map, or “Overlay” to put it on top of the map. Choose a map variable to
-            display.
+            option of total population or voting age population. To change whether this is by
+            share or by count, click the gear icon to the right of “Evaluation” and choose
+            “Population by Share” or “Population by Count”. You can also view the demographic
+            data as a choropleth on the map itself. Choose “Comparison” at the bottom of the
+            demographics tab to put the choropleth side by side with the map, or “Overlay” to put
+            it on top of the map. Choose a map variable to display.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/demographic.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/demographics_panel.webm`}
           />
 
           <Heading as="h3" size="4">
             Elections
           </Heading>
-
           <Text size="3">
             In the elections tab you can view how your districts would have behaved under past
             election data. You can also view the election data as a choropleth on the map itself.
-            Choose “Comparison” at the bottom of the demographics tab to put the choropleth side by
+            Choose “Comparison” at the bottom of the elections tab to put the choropleth side by
             side with the map, or “Overlay” to put it on top of the map. Choose a map variable to
             display.
           </Text>
-
-          <Text size="3">
-            You can also view the election data as a choropleth on the map itself. Choose
-            “Comparison” at the bottom of the demographics tab to put the choropleth side by side
-            with the map, or “Overlay” to put it on top of the map. Choose a map variable to
-            display.
-          </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/election.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/election_panel.webm`}
           />
 
           <Heading as="h3" size="4">
             Map Validation
           </Heading>
-
           <Text size="3">
-            Under the map validation tab, you can check that your map is missing any geographic
-            units, and check if the districts are contiguous.
+            Under the map validation tab, you can check whether your map is missing any
+            geographic units.
           </Text>
-
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/zoom_unassigned.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/completeness_check.webm`}
           />
+          <Text size="3">You can also check whether your districts are contiguous.</Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/contiguity.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/contiguity_check.webm`}
           />
         </Flex>
       </ContentSection>
-      <ContentSection title="Saving and Sharing">
+
+      <ContentSection title="Map Modes">
+        <Flex direction="column" gapY="4">
+          <Text size="3">
+            The “Mode” switcher in the top bar lets you move between different ways of working
+            with your map: <b>Draw</b> for building your plan, <b>View</b> for a clean read-only
+            display of it, and <b>Evaluate</b> for a dashboard of statistics about it. (There’s
+            also a <b>Super Draw</b> mode with extra drawing tools for more advanced users — more
+            on that at the end of this guide.) Switching to View or Evaluate works from a
+            shareable link to your map; if you haven’t shared your map yet, Districtr
+            automatically creates that shareable version for you the first time you switch, so you
+            never have to leave the editor to set it up.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/switch_mode.webm`}
+          />
+          <Text size="3">
+            <b>View mode</b> shows your map without any of the editing tools, so you can look at
+            or present your plan without the risk of accidentally changing it.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/view_mode.webm`}
+          />
+          <Text size="3">
+            <b>Evaluate mode</b> opens a dashboard summarizing your plan: population balance,
+            demographics, and election results by district, all in one place, so you can review
+            how your districts stack up without switching between sidebar tabs.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/evaluation_mode.webm`}
+          />
+        </Flex>
+      </ContentSection>
+
+      <ContentSection title="Saving, Sharing, Importing & Exporting">
         <Flex direction="column" gapY="4">
           <Heading as="h3" size="4">
             Saving your Map
           </Heading>
-          <Text size="3">Your map automatically saves as you work.</Text>
           <Text size="3">
-            Clicking the “Save/Status” button in the upper right hand corner of the map allows you
-            to save your current map with a map name and any comments about the map. Optionally, you
-            can toggle your map from a draft to “Ready to Share” if you are fully finished.
+            Your map automatically saves as you work. Clicking the “Save/Status” button in the
+            upper right hand corner of the map allows you to save your current map with a map name
+            and any comments about the map. Optionally, you can toggle your map from a draft to
+            “Ready to Share” if you are fully finished.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/save_map.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
           />
           <Text size="3">
             This allows you to return to your map from the “Manage local maps” page in the upper
             left menu.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/recent_maps.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/map_catalog.webm`}
           />
+
           <Heading as="h3" size="4">
             Sharing your Map
           </Heading>
-
           <Text size="3">
-            Clicking the “Share” button saves the map you created and allows you to share a link to
-            the map. You can either share a frozen link, which does not allow editing of the
+            Clicking the “Share” button saves the map you created and allows you to share a link
+            to the map. You can either share a frozen link, which does not allow editing of the
             original map, or an editable link, which only allows people with a password to edit.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/share_map.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/share_map.webm`}
           />
-        </Flex>
-      </ContentSection>
-      <ContentSection title="Saving and Sharing">
-        <Flex direction="column" gapY="4">
+
           <Heading as="h3" size="4">
-            Exporting/Importing Maps
+            Importing Maps
+          </Heading>
+          <Text size="3">
+            Districtr allows users to import maps from CSV block assignment files. Click on the
+            Districtr menu in the upper left corner and select “Create new map” and then “Upload
+            block assignments”. From here, upload your assignment file.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/import.webm`}
+          />
+
+          <Heading as="h3" size="4">
+            Exporting Maps
           </Heading>
           <Text size="3">
             Districtr provides the option to export a map in several formats. The most compatible
@@ -272,15 +248,34 @@ export default function GuidePage() {
             out of VTDs, this will create a block assignment file.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/block_export.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/export.webm`}
           />
+        </Flex>
+      </ContentSection>
+
+      <ContentSection title="Super Draw">
+        <Flex direction="column" gapY="4">
           <Text size="3">
-            Districtr allows users to import maps from CSV block assignment files. Click on the
-            Districtr menu in the upper left corner and select “Create new map” and then “Upload
-            block assignments”. From here, upload your assignment file.
+            You now know everything you need to draw and share a plan — but if you want to go
+            further, <b>Super Draw</b> mode unlocks additional tools for fine-tuning your
+            districts. Switch into it from the same “Mode” menu described above.
+          </Text>
+          <Text size="3">
+            If you need to use smaller units of geography to balance the population of your
+            districts, click the break icon on the toolbar at the bottom of the map. Then click on
+            a unit you want to “shatter”, allowing you to paint subsets of the original unit. You
+            can see the population number of each broken piece by clicking the gear icon in the
+            upper right corner of the map and selecting “Show total population labels on blocks”.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/block_import.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/shatter.webm`}
+          />
+          <Text size="3">
+            Super Draw also gives you a side-by-side demographic overlay, so you can see how your
+            districts are changing in real time as you paint, without leaving the drawing tools.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/super_draw_side_by_side.webm`}
           />
         </Flex>
       </ContentSection>

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -16,9 +16,9 @@ export default function GuidePage() {
       <ContentSection title="Getting Started With Districts">
         <Flex direction="column" gapY="4">
           <Text size="3">
-            On the Districtr homepage, click “Jump to the Map” in the top right corner. You will
+            On the Districtr homepage, click “Draw” in the top right corner. You will
             be redirected to an interactive map of the United States. Click the state for which
-            you wish to make a districting plan. All states are available, as well as Washington,
+            you wish to redistrict. All states are available, as well as Washington,
             D.C. and Puerto Rico.
           </Text>
           <LoopVideoPlayer
@@ -34,19 +34,31 @@ export default function GuidePage() {
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/select_module.webm`}
           />
+          <Text size="3">You will now be redirected to your selected districting page.</Text>
+        </Flex>
+      </ContentSection>
+      <ContentSection title="Main Tools">
+        <Flex direction="column" gapY="4">
+          <Heading as="h3" size="4">
+            Moving across the map
+          </Heading>
+
           <Text size="3">
-            You will now be redirected to your selected districting page. Select the hand icon on
-            the toolbar at the bottom of the map, then click and drag to pan across the map. To
-            zoom in and out, use the plus and minus buttons in the bottom right corner of the map,
-            or use a mouse scroll wheel or trackpad.
+            Select the hand icon on the toolbar at the bottom of the map. Then click and drag to pan
+            across the map.
+          </Text>
+          <Text size="3">
+            To zoom in and out, use the plus and minus buttons in the bottom right corner of the
+            map. You can also use a mouse scroll wheel or trackpad.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/moving_in_map.webm`}
           />
-        </Flex>
-      </ContentSection>
-      <ContentSection title="Drawing Districts">
-        <Flex direction="column" gapY="4">
+
+          <Heading as="h3" size="4">
+            Drawing the districts
+          </Heading>
+
           <Text size="3">
             To draw your first district, select the paintbrush icon on the toolbar at the bottom
             of the map. Click and drag on the map to add units to your district.

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -3,326 +3,357 @@ import {ContentSection} from '@/app/components/Static/ContentSection';
 import {LoopVideoPlayer} from '@/app/components/Static/LoopVideoPlayer';
 import {Box, Flex, Heading, Text} from '@radix-ui/themes';
 import {LearnSubNav} from '@/app/components/Static/LearnSubNav';
+import {GuideToc, type GuideTocEntry} from '@/app/components/Static/GuideToc';
+import {slugify} from '@/app/utils/slugify';
+
+const TOC_ENTRIES: GuideTocEntry[] = [
+  {title: 'Getting Started With Districts'},
+  {
+    title: 'Main Tools',
+    subsections: ['Moving across the map', 'Drawing the districts', 'Visual settings'],
+  },
+  {
+    title: 'Data Panels',
+    subsections: ['District overview', 'Demographics', 'Elections', 'Map Validation'],
+  },
+  {title: 'Map Modes'},
+  {
+    title: 'Saving, Sharing, Importing & Exporting',
+    subsections: ['Saving your Map', 'Sharing your Map', 'Importing Maps', 'Exporting Maps'],
+  },
+  {title: 'Super Draw'},
+];
+
+/** Anchor id + scroll-offset props for a subheading, so it lines up with its GuideToc link. */
+const subheadingAnchor = (title: string) => ({id: slugify(title), className: 'scroll-mt-28'});
 
 export default function GuidePage() {
   return (
-    <Flex direction="column" gapY="4">
-      <LearnSubNav />
-      <Box>
-        <Heading size="8" as="h1">
-          Tutorial
-        </Heading>
-      </Box>
-      <ContentSection title="Getting Started With Districts">
-        <Flex direction="column" gapY="4">
-          <Text size="3">
-            On the Districtr homepage, click “Draw” in the top right corner. You will be redirected
-            to an interactive map of the United States. Click the state for which you wish to
-            redistrict. All states are available, as well as Washington, D.C. and Puerto Rico.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/draw_menu.webm`}
-          />
-          <Text size="3">
-            Once you have selected a state, you will be directed to its landing page. The landing
-            page contains all mapping options along with background information. Choose a locality
-            (state, region, county, or city) and district type by clicking on a card. The available
-            localities and districts vary by state. (Additional localities can be added upon
-            request.)
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/select_module.webm`}
-          />
-          <Text size="3">You will now be redirected to your selected districting page.</Text>
-        </Flex>
-      </ContentSection>
-      <ContentSection title="Main Tools">
-        <Flex direction="column" gapY="4">
-          <Heading as="h3" size="4">
-            Moving across the map
+    <Flex direction="row" gapX="6" align="start">
+      <GuideToc entries={TOC_ENTRIES} />
+      <Flex direction="column" gapY="4" className="min-w-0 flex-1">
+        <LearnSubNav />
+        <Box>
+          <Heading size="8" as="h1">
+            Tutorial
           </Heading>
+        </Box>
+        <ContentSection title="Getting Started With Districts">
+          <Flex direction="column" gapY="4">
+            <Text size="3">
+              On the Districtr homepage, click “Draw” in the top right corner. You will be
+              redirected to an interactive map of the United States. Click the state for which you
+              wish to redistrict. All states are available, as well as Washington, D.C. and Puerto
+              Rico.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/draw_menu.webm`}
+            />
+            <Text size="3">
+              Once you have selected a state, you will be directed to its landing page. The landing
+              page contains all mapping options along with background information. Choose a locality
+              (state, region, county, or city) and district type by clicking on a card. The
+              available localities and districts vary by state. (Additional localities can be added
+              upon request.)
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/select_module.webm`}
+            />
+            <Text size="3">You will now be redirected to your selected districting page.</Text>
+          </Flex>
+        </ContentSection>
+        <ContentSection title="Main Tools">
+          <Flex direction="column" gapY="4">
+            <Heading as="h3" size="4" {...subheadingAnchor('Moving across the map')}>
+              Moving across the map
+            </Heading>
 
-          <Text size="3">
-            Select the hand icon on the toolbar at the top of the side panel, on the right of the
-            map. Then click and drag to pan across the map.
-          </Text>
-          <Text size="3">
-            To zoom in and out, use the plus and minus buttons in the bottom right corner of the
-            map. You can also use a mouse scroll wheel or trackpad.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/moving_in_map.webm`}
-          />
+            <Text size="3">
+              Select the hand icon on the toolbar at the top of the side panel, on the right of the
+              map. Then click and drag to pan across the map.
+            </Text>
+            <Text size="3">
+              To zoom in and out, use the plus and minus buttons in the bottom right corner of the
+              map. You can also use a mouse scroll wheel or trackpad.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/moving_in_map.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Drawing the districts
-          </Heading>
+            <Heading as="h3" size="4" {...subheadingAnchor('Drawing the districts')}>
+              Drawing the districts
+            </Heading>
 
-          <Text size="3">
-            To draw your first district, select the paintbrush icon on the toolbar at the top of the
-            side panel. Click and drag on the map to add units to your district.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_on_map.webm`}
-          />
-          <Text size="3">
-            To draw another district, select a new color from the color bar that appears when you
-            click the paint icon. Each color corresponds to a different district. For pages with
-            large numbers of districts, only one color will show when you start. For these, use the
-            dropdown menu to select a different color.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_another_district.webm`}
-          />
-          <Text size="3">
-            To change the size of the brush, drag the brush size slider directly above the color
-            bar.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/brush_size.webm`}
-          />
-          <Text size="3">
-            To paint whole counties at once, toggle the “County Brush” box next to the slider.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/county_brush.webm`}
-          />
-          <Text size="3">
-            To inspect districts without altering them, or to avoid painting over already-drawn
-            areas, toggle the lock icon next to the district number in the “District overview”
-            panel.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
-          />
-          <Text size="3">
-            To correct the boundaries of your districts, click the erase icon on the toolbar at the
-            top of the side panel. Click and drag to remove units from that district. The size of
-            the eraser can be adjusted by dragging the slider.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/eraser.webm`}
-          />
-          <Text size="3">
-            Click the “undo/redo” buttons to revert the boundaries of your district plan to a
-            previous version.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/undo_redo.webm`}
-          />
+            <Text size="3">
+              To draw your first district, select the paintbrush icon on the toolbar at the top of
+              the side panel. Click and drag on the map to add units to your district.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_on_map.webm`}
+            />
+            <Text size="3">
+              To draw another district, select a new color from the color bar that appears when you
+              click the paint icon. Each color corresponds to a different district. For pages with
+              large numbers of districts, only one color will show when you start. For these, use
+              the dropdown menu to select a different color.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_another_district.webm`}
+            />
+            <Text size="3">
+              To change the size of the brush, drag the brush size slider directly above the color
+              bar.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/brush_size.webm`}
+            />
+            <Text size="3">
+              To paint whole counties at once, toggle the “County Brush” box next to the slider.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/county_brush.webm`}
+            />
+            <Text size="3">
+              To inspect districts without altering them, or to avoid painting over already-drawn
+              areas, toggle the lock icon next to the district number in the “District overview”
+              panel.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
+            />
+            <Text size="3">
+              To correct the boundaries of your districts, click the erase icon on the toolbar at
+              the top of the side panel. Click and drag to remove units from that district. The size
+              of the eraser can be adjusted by dragging the slider.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/eraser.webm`}
+            />
+            <Text size="3">
+              Click the “undo/redo” buttons to revert the boundaries of your district plan to a
+              previous version.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/undo_redo.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Visual settings
-          </Heading>
-          <Text size="3">
-            Click the gear icon (“Visual settings”) at the top of the side panel to control what the
-            map shows. From here, you can uncheck “Painted districts” to hide the districts from the
-            map, toggle “County Boundaries” to show or remove county boundaries, and check
-            “Highlight unassigned areas” to see which units you still need to color.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/visual_settings.webm`}
-          />
-        </Flex>
-      </ContentSection>
+            <Heading as="h3" size="4" {...subheadingAnchor('Visual settings')}>
+              Visual settings
+            </Heading>
+            <Text size="3">
+              Click the gear icon (“Visual settings”) at the top of the side panel to control what
+              the map shows. From here, you can uncheck “Painted districts” to hide the districts
+              from the map, toggle “County Boundaries” to show or remove county boundaries, and
+              check “Highlight unassigned areas” to see which units you still need to color.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/visual_settings.webm`}
+            />
+          </Flex>
+        </ContentSection>
 
-      <ContentSection title="Data Panels">
-        <Flex direction="column" gapY="4">
-          <Heading as="h3" size="4">
-            District overview
-          </Heading>
+        <ContentSection title="Data Panels">
+          <Flex direction="column" gapY="4">
+            <Heading as="h3" size="4" {...subheadingAnchor('District overview')}>
+              District overview
+            </Heading>
 
-          <Text size="3">
-            The “District overview” panel lists each drawn district — click a district number to
-            select it and switch the brush to that district's color. It also shows the population of
-            each district; to balance your population evenly between districts, make reference to
-            the ideal population count and vertical bar provided in this panel. You may also add comments to each district by clicking the comment icon next to the district number.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_overview.webm`}
-          />
+            <Text size="3">
+              The “District overview” panel lists each drawn district — click a district number to
+              select it and switch the brush to that district's color. It also shows the population
+              of each district; to balance your population evenly between districts, make reference
+              to the ideal population count and vertical bar provided in this panel. You may also
+              add comments to each district by clicking the comment icon next to the district
+              number.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_overview.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Demographics
-          </Heading>
-          <Text size="3">
-            Under this panel, you can study the demographic make up of your districts:
-          </Text>
-          <ul className="list-disc pl-6">
-            <li>
-              <Text size="3">
-                Choose total population or voting age population as the statistic.
-              </Text>
-            </li>
-            <li>
-              <Text size="3">
-                Under the “Map Layer” tab, view the demographic data as a choropleth on top of the
-                map by selecting “Overlay” under “Display Modes”, or as sized circles by selecting
-                “Sized Circles”.
-              </Text>
-            </li>
-          </ul>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/demographics_panel.webm`}
-          />
+            <Heading as="h3" size="4" {...subheadingAnchor('Demographics')}>
+              Demographics
+            </Heading>
+            <Text size="3">
+              Under this panel, you can study the demographic make up of your districts:
+            </Text>
+            <ul className="list-disc pl-6">
+              <li>
+                <Text size="3">
+                  Choose total population or voting age population as the statistic.
+                </Text>
+              </li>
+              <li>
+                <Text size="3">
+                  Under the “Map Layer” tab, view the demographic data as a choropleth on top of the
+                  map by selecting “Overlay” under “Display Modes”, or as sized circles by selecting
+                  “Sized Circles”.
+                </Text>
+              </li>
+            </ul>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/demographics_panel.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Elections
-          </Heading>
-          <Text size="3">
-            In the elections panel you can view how your districts would have behaved under past
-            election data. Just like the demographics panel, you can choose to view the election data
-            as a choropleth on top of the map by selecting “Overlay” under “Display Modes”, or view
-            it as sized circles by selecting “Sized Circles”.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/election_panel.webm`}
-          />
+            <Heading as="h3" size="4" {...subheadingAnchor('Elections')}>
+              Elections
+            </Heading>
+            <Text size="3">
+              In the elections panel you can view how your districts would have behaved under past
+              election data. Just like the demographics panel, you can choose to view the election
+              data as a choropleth on top of the map by selecting “Overlay” under “Display Modes”,
+              or view it as sized circles by selecting “Sized Circles”.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/election_panel.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Map Validation
-          </Heading>
-          <Text size="3">
-            Under the map validation panel, you can check whether your map is missing any geographic
-            units.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/completeness_check.webm`}
-          />
-          <Text size="3">You can also check whether your districts are contiguous.</Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/contiguity_check.webm`}
-          />
-        </Flex>
-      </ContentSection>
+            <Heading as="h3" size="4" {...subheadingAnchor('Map Validation')}>
+              Map Validation
+            </Heading>
+            <Text size="3">
+              Under the map validation panel, you can check whether your map is missing any
+              geographic units.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/completeness_check.webm`}
+            />
+            <Text size="3">You can also check whether your districts are contiguous.</Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/contiguity_check.webm`}
+            />
+          </Flex>
+        </ContentSection>
 
-      <ContentSection title="Map Modes">
-        <Flex direction="column" gapY="4">
-          <Text size="3">
-            The “Mode” switcher in the top bar lets you move between different ways of working with
-            your map: <b>Draw</b> for building your plan, <b>View</b> for a clean read-only display
-            of it, and <b>Evaluate</b> for a dashboard of statistics about it. (There’s also a{' '}
-            <b>Super Draw</b> mode with extra drawing tools for more advanced users — more on that
-            at the end of this guide.) Switching to View or Evaluate works from a shareable link to
-            your map; if you haven’t shared your map yet, Districtr automatically creates that
-            shareable version for you the first time you switch, so you never have to leave the
-            editor to set it up.
-          </Text>
-          <Text size="3">
-            <b>View mode</b> shows your map without any of the editing tools. This is the view
-            others see when you share a public link to your map.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/view_mode.webm`}
-          />
-          <Text size="3">
-            <b>Evaluate mode</b> lists commonly used evaluation metrics for your plan. You can see
-            whether your plan is complete, contiguous, and population-balanced, as well as how
-            compact its districts are and how much it favors a party given past election data.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/evaluation_mode.webm`}
-          />
-        </Flex>
-      </ContentSection>
+        <ContentSection title="Map Modes">
+          <Flex direction="column" gapY="4">
+            <Text size="3">
+              The “Mode” switcher in the top bar lets you move between different ways of working
+              with your map: <b>Draw</b> for building your plan, <b>View</b> for a clean read-only
+              display of it, and <b>Evaluate</b> for a dashboard of statistics about it. (There’s
+              also a <b>Super Draw</b> mode with extra drawing tools for more advanced users — more
+              on that at the end of this guide.) Switching to View or Evaluate works from a
+              shareable link to your map; if you haven’t shared your map yet, Districtr
+              automatically creates that shareable version for you the first time you switch, so you
+              never have to leave the editor to set it up.
+            </Text>
+            <Text size="3">
+              <b>View mode</b> shows your map without any of the editing tools. This is the view
+              others see when you share a public link to your map.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/view_mode.webm`}
+            />
+            <Text size="3">
+              <b>Evaluate mode</b> lists commonly used evaluation metrics for your plan. You can see
+              whether your plan is complete, contiguous, and population-balanced, as well as how
+              compact its districts are and how much it favors a party given past election data.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/evaluation_mode.webm`}
+            />
+          </Flex>
+        </ContentSection>
 
-      <ContentSection title="Saving, Sharing, Importing & Exporting">
-        <Flex direction="column" gapY="4">
-          <Heading as="h3" size="4">
-            Saving your Map
-          </Heading>
-          <Text size="3">
-            Your map automatically saves as you work, right in your browser's local storage — no
-            account or login needed. Clicking the map title at the middle of the top bar allows you
-            to edit the map name and any comments about the map. Optionally, you can toggle your map
-            from a draft to “Ready to Share” if you are fully finished.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
-          />
-          <Text size="3">
-            The “Catalog” from the main page stores all your maps, which allows you to switch
-            between different maps you have worked on. These maps are stored in your browser's local
-            storage — no account or login needed. They will be removed when you clear your browser
-            data. You can go there at any time from the navigational menu of the “Districtr” icon.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/map_catalog.webm`}
-          />
+        <ContentSection title="Saving, Sharing, Importing & Exporting">
+          <Flex direction="column" gapY="4">
+            <Heading as="h3" size="4" {...subheadingAnchor('Saving your Map')}>
+              Saving your Map
+            </Heading>
+            <Text size="3">
+              Your map automatically saves as you work, right in your browser's local storage — no
+              account or login needed. Clicking the map title at the middle of the top bar allows
+              you to edit the map name and any comments about the map. Optionally, you can toggle
+              your map from a draft to “Ready to Share” if you are fully finished.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
+            />
+            <Text size="3">
+              The “Catalog” from the main page stores all your maps, which allows you to switch
+              between different maps you have worked on. These maps are stored in your browser's
+              local storage — no account or login needed. They will be removed when you clear your
+              browser data. You can go there at any time from the navigational menu of the
+              “Districtr” icon.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/map_catalog.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Sharing your Map
-          </Heading>
-          <Text size="3">
-            Clicking the “Share” button saves the map you created and allows you to share a link to
-            the map. You can either share a frozen link, which does not allow editing of the
-            original map, or an editable link, which only allows people with a password to edit.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/share_map.webm`}
-          />
+            <Heading as="h3" size="4" {...subheadingAnchor('Sharing your Map')}>
+              Sharing your Map
+            </Heading>
+            <Text size="3">
+              Clicking the “Share” button saves the map you created and allows you to share a link
+              to the map. You can either share a frozen link, which does not allow editing of the
+              original map, or an editable link, which only allows people with a password to edit.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/share_map.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Importing Maps
-          </Heading>
-          <Text size="3">
-            Districtr allows users to import maps from CSV block assignment files. Click on the
-            Districtr menu in the upper left corner and select “Create new map” and then “Upload
-            block assignments”. From here, upload your assignment file.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/import.webm`}
-          />
+            <Heading as="h3" size="4" {...subheadingAnchor('Importing Maps')}>
+              Importing Maps
+            </Heading>
+            <Text size="3">
+              Districtr allows users to import maps from CSV block assignment files. Click on the
+              Districtr menu in the upper left corner and select “Create new map” and then “Upload
+              block assignments”. From here, upload your assignment file.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/import.webm`}
+            />
 
-          <Heading as="h3" size="4">
-            Exporting Maps
-          </Heading>
-          <Text size="3">
-            Districtr provides the option to export a map in several formats. The most compatible
-            format with other platforms is a CSV assignment file which maps Census blocks to
-            districts. Click on the “Map Action” menu in the upper right corner of the map and
-            select “Export assignments”, then “Block assignments”. Alternatively, you can also
-            export your district shapes as a GeoJSON or a shapefile, or export evaluation metrics as
-            a JSON file.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/export.webm`}
-          />
-        </Flex>
-      </ContentSection>
+            <Heading as="h3" size="4" {...subheadingAnchor('Exporting Maps')}>
+              Exporting Maps
+            </Heading>
+            <Text size="3">
+              Districtr provides the option to export a map in several formats. The most compatible
+              format with other platforms is a CSV assignment file which maps Census blocks to
+              districts. Click on the “Map Action” menu in the upper right corner of the map and
+              select “Export assignments”, then “Block assignments”. Alternatively, you can also
+              export your district shapes as a GeoJSON or a shapefile, or export evaluation metrics
+              as a JSON file.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/export.webm`}
+            />
+          </Flex>
+        </ContentSection>
 
-      <CTA />
-      <ContentSection title="Super Draw">
-        <Flex direction="column" gapY="4">
-          <Text size="3">
-            You now know everything you need to draw and share a plan — but if you want to go
-            further, <b>Super Draw</b> mode unlocks additional tools for fine-tuning your districts.
-            Switch into it from the same “Mode” menu described above.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/switch_mode.webm`}
-          />
-          <Text size="3">
-            If you need to use smaller units of geography to balance the population of your
-            districts, click the break icon on the toolbar at the top of the side panel. Then click
-            on a unit you want to “break”, allowing you to paint subsets of the original unit. You
-            can see the population number of each broken piece by clicking the gear icon in the
-            upper right corner of the map and selecting “Show total population labels on blocks”.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/shatter.webm`}
-          />
-          <Text size="3">
-            Super Draw allows you to change whether the population statistic is displayed by share
-            or by count: click the gear icon to the right of “Summary Type” and choose “Population
-            by Share” or “Population by Count”. The Super Draw mode also allows you to switch on a
-            side-by-side demographic and elections choropleth instead of an overlay.
-          </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/super_draw_side_by_side.webm`}
-          />
-        </Flex>
-      </ContentSection>
+        <CTA />
+        <ContentSection title="Super Draw">
+          <Flex direction="column" gapY="4">
+            <Text size="3">
+              You now know everything you need to draw and share a plan — but if you want to go
+              further, <b>Super Draw</b> mode unlocks additional tools for fine-tuning your
+              districts. Switch into it from the same “Mode” menu described above.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/switch_mode.webm`}
+            />
+            <Text size="3">
+              If you need to use smaller units of geography to balance the population of your
+              districts, click the break icon on the toolbar at the top of the side panel. Then
+              click on a unit you want to “break”, allowing you to paint subsets of the original
+              unit. You can see the population number of each broken piece by clicking the gear icon
+              in the upper right corner of the map and selecting “Show total population labels on
+              blocks”.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/shatter.webm`}
+            />
+            <Text size="3">
+              Super Draw allows you to change whether the population statistic is displayed by share
+              or by count: click the gear icon to the right of “Summary Type” and choose “Population
+              by Share” or “Population by Count”. The Super Draw mode also allows you to switch on a
+              side-by-side demographic and elections choropleth instead of an overlay.
+            </Text>
+            <LoopVideoPlayer
+              videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/super_draw_side_by_side.webm`}
+            />
+          </Flex>
+        </ContentSection>
+      </Flex>
     </Flex>
   );
 }

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -89,6 +89,14 @@ export default function GuidePage() {
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/county_brush.webm`}
           />
           <Text size="3">
+            To inspect districts without altering them, or to avoid painting over already-drawn
+            areas, toggle the lock icon next to the district number in the list of districts in
+            the “Population” tab.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
+          />
+          <Text size="3">
             To correct the boundaries of your districts, click the erase icon on the toolbar at
             the top of the side panel. Click and drag to remove units from that district. The size
             of the eraser can be adjusted by dragging the slider.
@@ -103,37 +111,45 @@ export default function GuidePage() {
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/undo_redo.webm`}
           />
+    
+          <Heading as="h3" size="4">
+            Districts
+          </Heading>
           <Text size="3">
-            To inspect districts without altering them, or to avoid painting over already-drawn
-            areas, toggle the lock icon next to the district number in the list of districts in
-            the “Population” tab.
+            To hide the districts from the map, click the "visual setting" at the top of the side panel and uncheck the "Painted districts" box.
           </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
-          />
           <Text size="3">
-            To see which units you still need to color, click the gear icon in the upper right
-            corner of the map and choose the “Highlight unassigned areas” box.
+            To remove county boundaries overlaid on your map, toggle the “County Boundaries” box.
           </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/highlight_unassigned.webm`}
-          />
         </Flex>
       </ContentSection>
 
       <ContentSection title="Data Panels">
         <Flex direction="column" gapY="4">
           <Heading as="h3" size="4">
+            Population
+          </Heading>
+
+          <Text size="3">
+            The population tab allows you to view the population of each drawn district. To balance
+            your population evenly between districts, make reference to the ideal population count
+            and vertical bar provided in this tab.
+          </Text>
+          <Text size="3">
+            To see which units you still need to color, click the gear icon in the upper right
+            corner of the map and then choose the “Highlight unassigned areas” box.
+          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/highlight_unassigned.webm`}
+          />
+
+          <Heading as="h3" size="4">
             Demographics
           </Heading>
           <Text size="3">
             Under this tab, you can study the demographic make up of your districts. You have the
-            option of total population or voting age population. To change whether this is by
-            share or by count, click the gear icon to the right of “Evaluation” and choose
-            “Population by Share” or “Population by Count”. You can also view the demographic
-            data as a choropleth on the map itself. Choose “Comparison” at the bottom of the
-            demographics tab to put the choropleth side by side with the map, or “Overlay” to put
-            it on top of the map. Choose a map variable to display.
+            option of total population or voting age population. Under the "Map Layer" tab, you can choose to view the demographic
+            data as a choropleth on top of the map by selecting "Overlay" under "Display Modes", or view it as sized circles by selecting "Sized Circles".
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/demographics_panel.webm`}
@@ -144,10 +160,8 @@ export default function GuidePage() {
           </Heading>
           <Text size="3">
             In the elections tab you can view how your districts would have behaved under past
-            election data. You can also view the election data as a choropleth on the map itself.
-            Choose “Comparison” at the bottom of the elections tab to put the choropleth side by
-            side with the map, or “Overlay” to put it on top of the map. Choose a map variable to
-            display.
+            election data. Just like the demographics tab, you can choose to view the election
+            data as a choropleth on top of the map by selecting "Overlay" under "Display Modes", or view it as sized circles by selecting "Sized Circles".
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/election_panel.webm`}
@@ -182,20 +196,14 @@ export default function GuidePage() {
             automatically creates that shareable version for you the first time you switch, so you
             never have to leave the editor to set it up.
           </Text>
-          <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/switch_mode.webm`}
-          />
           <Text size="3">
-            <b>View mode</b> shows your map without any of the editing tools, so you can look at
-            or present your plan without the risk of accidentally changing it.
+            <b>View mode</b> shows your map without any of the editing tools. This is the view others see when you share a public link to your map. 
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/view_mode.webm`}
           />
           <Text size="3">
-            <b>Evaluate mode</b> opens a dashboard summarizing your plan: population balance,
-            demographics, and election results by district, all in one place, so you can review
-            how your districts stack up without switching between sidebar tabs.
+            <b>Evaluate mode</b> lists commonly used evaluation metrics for your plan. You see see whether your plans is complete, contiguous, population-balance, as well as how compact it districts are and how much it favors a party given past election data.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/evaluation_mode.webm`}
@@ -209,8 +217,7 @@ export default function GuidePage() {
             Saving your Map
           </Heading>
           <Text size="3">
-            Your map automatically saves as you work. Clicking the “Save/Status” button in the
-            upper right hand corner of the map allows you to save your current map with a map name
+            Your map automatically saves as you work. Clicking the map title at the middle of the top bar allows you to edit the map name
             and any comments about the map. Optionally, you can toggle your map from a draft to
             “Ready to Share” if you are fully finished.
           </Text>
@@ -218,8 +225,7 @@ export default function GuidePage() {
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
           />
           <Text size="3">
-            This allows you to return to your map from the “Manage local maps” page in the upper
-            left menu.
+            The "Catalog" from the main page stores all your maps, which allows you to switch between different maps you have seen. You can go there at any time from the navigational menu of the "Districtr" icon.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/map_catalog.webm`}
@@ -255,9 +261,8 @@ export default function GuidePage() {
           <Text size="3">
             Districtr provides the option to export a map in several formats. The most compatible
             format with other platforms is a CSV assignment file which maps Census blocks to
-            districts. Click on the Districtr menu in the upper left corner and select “Export
-            assignments”, then “Block assignments”. Note that even if you built your map entirely
-            out of VTDs, this will create a block assignment file.
+            districts. Click on the "Map Action" menu in the upper right corner of the map and select “Export
+            assignments”, then “Block assignments”. Alternatively, you can also export your district shapes as a GeoJson or a shape file, or export evaluation metrics as a json file.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/export.webm`}
@@ -272,6 +277,9 @@ export default function GuidePage() {
             further, <b>Super Draw</b> mode unlocks additional tools for fine-tuning your
             districts. Switch into it from the same “Mode” menu described above.
           </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/switch_mode.webm`}
+          />
           <Text size="3">
             If you need to use smaller units of geography to balance the population of your
             districts, click the break icon on the toolbar at the top of the side panel. Then click
@@ -284,8 +292,10 @@ export default function GuidePage() {
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/shatter.webm`}
           />
           <Text size="3">
-            Super Draw also gives you a side-by-side demographic overlay, so you can see how your
-            districts are changing in real time as you paint, without leaving the drawing tools.
+            Super Draw allows you change whether population statistic is displayed by
+            share or by count, click the gear icon to the right of “Summary Type” and choose
+            “Population by Share” or “Population by Count”. The Super Draw mode also allows you to 
+            switch on a side-by-side demographic and elections choropleth instead of overlay.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/super_draw_side_by_side.webm`}

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -89,8 +89,8 @@ export default function GuidePage() {
           />
           <Text size="3">
             To inspect districts without altering them, or to avoid painting over already-drawn
-            areas, toggle the lock icon next to the district number in the list of districts in the
-            “Population” tab.
+            areas, toggle the lock icon next to the district number in the “District overview”
+            panel.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
@@ -112,47 +112,56 @@ export default function GuidePage() {
           />
 
           <Heading as="h3" size="4">
-            Districts
+            Visual settings
           </Heading>
           <Text size="3">
-            To hide the districts from the map, click the “visual setting” at the top of the side
-            panel and uncheck the “Painted districts” box.
+            Click the gear icon (“Visual settings”) at the top of the side panel to control what the
+            map shows. From here, you can uncheck “Painted districts” to hide the districts from the
+            map, toggle “County Boundaries” to show or remove county boundaries, and check
+            “Highlight unassigned areas” to see which units you still need to color.
           </Text>
-          <Text size="3">
-            To remove county boundaries overlaid on your map, toggle the “County Boundaries” box.
-          </Text>
+          <LoopVideoPlayer
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/visual_settings.webm`}
+          />
         </Flex>
       </ContentSection>
 
       <ContentSection title="Data Panels">
         <Flex direction="column" gapY="4">
           <Heading as="h3" size="4">
-            Population
+            District overview
           </Heading>
 
           <Text size="3">
-            The population tab allows you to view the population of each drawn district. To balance
-            your population evenly between districts, make reference to the ideal population count
-            and vertical bar provided in this tab.
-          </Text>
-          <Text size="3">
-            To see which units you still need to color, click the gear icon in the upper right
-            corner of the map and then choose the “Highlight unassigned areas” box.
+            The “District overview” panel lists each drawn district — click a district number to
+            select it and switch the brush to that district's color. It also shows the population of
+            each district; to balance your population evenly between districts, make reference to
+            the ideal population count and vertical bar provided in this panel.
           </Text>
           <LoopVideoPlayer
-            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/highlight_unassigned.webm`}
+            videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_overview.webm`}
           />
 
           <Heading as="h3" size="4">
             Demographics
           </Heading>
           <Text size="3">
-            Under this tab, you can study the demographic make up of your districts. You have the
-            option of total population or voting age population. Under the “Map Layer” tab, you can
-            choose to view the demographic data as a choropleth on top of the map by selecting
-            “Overlay” under “Display Modes”, or view it as sized circles by selecting “Sized
-            Circles”.
+            Under this panel, you can study the demographic make up of your districts:
           </Text>
+          <ul className="list-disc pl-6">
+            <li>
+              <Text size="3">
+                Choose total population or voting age population as the statistic.
+              </Text>
+            </li>
+            <li>
+              <Text size="3">
+                Under the “Map Layer” tab, view the demographic data as a choropleth on top of the
+                map by selecting “Overlay” under “Display Modes”, or as sized circles by selecting
+                “Sized Circles”.
+              </Text>
+            </li>
+          </ul>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/demographics_panel.webm`}
           />
@@ -223,9 +232,10 @@ export default function GuidePage() {
             Saving your Map
           </Heading>
           <Text size="3">
-            Your map automatically saves as you work. Clicking the map title at the middle of the
-            top bar allows you to edit the map name and any comments about the map. Optionally, you
-            can toggle your map from a draft to “Ready to Share” if you are fully finished.
+            Your map automatically saves as you work, right in your browser's local storage — no
+            account or login needed. Clicking the map title at the middle of the top bar allows you
+            to edit the map name and any comments about the map. Optionally, you can toggle your map
+            from a draft to “Ready to Share” if you are fully finished.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
@@ -294,7 +304,7 @@ export default function GuidePage() {
           <Text size="3">
             If you need to use smaller units of geography to balance the population of your
             districts, click the break icon on the toolbar at the top of the side panel. Then click
-            on a unit you want to “shatter”, allowing you to paint subsets of the original unit. You
+            on a unit you want to “break”, allowing you to paint subsets of the original unit. You
             can see the population number of each broken piece by clicking the gear icon in the
             upper right corner of the map and selecting “Show total population labels on blocks”.
           </Text>

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -16,20 +16,19 @@ export default function GuidePage() {
       <ContentSection title="Getting Started With Districts">
         <Flex direction="column" gapY="4">
           <Text size="3">
-            On the Districtr homepage, click “Draw” in the top right corner. You will
-            be redirected to an interactive map of the United States. Click the state for which
-            you wish to redistrict. All states are available, as well as Washington,
-            D.C. and Puerto Rico.
+            On the Districtr homepage, click “Draw” in the top right corner. You will be redirected
+            to an interactive map of the United States. Click the state for which you wish to
+            redistrict. All states are available, as well as Washington, D.C. and Puerto Rico.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/draw_menu.webm`}
           />
           <Text size="3">
             Once you have selected a state, you will be directed to its landing page. The landing
-            page contains all mapping options along with background information. Choose a
-            locality (state, region, county, or city) and district type by clicking on a card.
-            The available localities and districts vary by state. (Additional localities can be
-            added upon request.)
+            page contains all mapping options along with background information. Choose a locality
+            (state, region, county, or city) and district type by clicking on a card. The available
+            localities and districts vary by state. (Additional localities can be added upon
+            request.)
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/select_module.webm`}
@@ -60,8 +59,8 @@ export default function GuidePage() {
           </Heading>
 
           <Text size="3">
-            To draw your first district, select the paintbrush icon on the toolbar at the top of
-            the side panel. Click and drag on the map to add units to your district.
+            To draw your first district, select the paintbrush icon on the toolbar at the top of the
+            side panel. Click and drag on the map to add units to your district.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_on_map.webm`}
@@ -69,8 +68,8 @@ export default function GuidePage() {
           <Text size="3">
             To draw another district, select a new color from the color bar that appears when you
             click the paint icon. Each color corresponds to a different district. For pages with
-            large numbers of districts, only one color will show when you start. For these, use
-            the dropdown menu to select a different color.
+            large numbers of districts, only one color will show when you start. For these, use the
+            dropdown menu to select a different color.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_another_district.webm`}
@@ -90,16 +89,16 @@ export default function GuidePage() {
           />
           <Text size="3">
             To inspect districts without altering them, or to avoid painting over already-drawn
-            areas, toggle the lock icon next to the district number in the list of districts in
-            the “Population” tab.
+            areas, toggle the lock icon next to the district number in the list of districts in the
+            “Population” tab.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_lock.webm`}
           />
           <Text size="3">
-            To correct the boundaries of your districts, click the erase icon on the toolbar at
-            the top of the side panel. Click and drag to remove units from that district. The size
-            of the eraser can be adjusted by dragging the slider.
+            To correct the boundaries of your districts, click the erase icon on the toolbar at the
+            top of the side panel. Click and drag to remove units from that district. The size of
+            the eraser can be adjusted by dragging the slider.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/eraser.webm`}
@@ -111,7 +110,7 @@ export default function GuidePage() {
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/undo_redo.webm`}
           />
-    
+
           <Heading as="h3" size="4">
             Districts
           </Heading>
@@ -163,9 +162,9 @@ export default function GuidePage() {
           </Heading>
           <Text size="3">
             In the elections tab you can view how your districts would have behaved under past
-            election data. Just like the demographics tab, you can choose to view the election
-            data as a choropleth on top of the map by selecting “Overlay” under “Display Modes”, or
-            view it as sized circles by selecting “Sized Circles”.
+            election data. Just like the demographics tab, you can choose to view the election data
+            as a choropleth on top of the map by selecting “Overlay” under “Display Modes”, or view
+            it as sized circles by selecting “Sized Circles”.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/election_panel.webm`}
@@ -175,8 +174,8 @@ export default function GuidePage() {
             Map Validation
           </Heading>
           <Text size="3">
-            Under the map validation tab, you can check whether your map is missing any
-            geographic units.
+            Under the map validation tab, you can check whether your map is missing any geographic
+            units.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/completeness_check.webm`}
@@ -191,17 +190,18 @@ export default function GuidePage() {
       <ContentSection title="Map Modes">
         <Flex direction="column" gapY="4">
           <Text size="3">
-            The “Mode” switcher in the top bar lets you move between different ways of working
-            with your map: <b>Draw</b> for building your plan, <b>View</b> for a clean read-only
-            display of it, and <b>Evaluate</b> for a dashboard of statistics about it. (There’s
-            also a <b>Super Draw</b> mode with extra drawing tools for more advanced users — more
-            on that at the end of this guide.) Switching to View or Evaluate works from a
-            shareable link to your map; if you haven’t shared your map yet, Districtr
-            automatically creates that shareable version for you the first time you switch, so you
-            never have to leave the editor to set it up.
+            The “Mode” switcher in the top bar lets you move between different ways of working with
+            your map: <b>Draw</b> for building your plan, <b>View</b> for a clean read-only display
+            of it, and <b>Evaluate</b> for a dashboard of statistics about it. (There’s also a{' '}
+            <b>Super Draw</b> mode with extra drawing tools for more advanced users — more on that
+            at the end of this guide.) Switching to View or Evaluate works from a shareable link to
+            your map; if you haven’t shared your map yet, Districtr automatically creates that
+            shareable version for you the first time you switch, so you never have to leave the
+            editor to set it up.
           </Text>
           <Text size="3">
-            <b>View mode</b> shows your map without any of the editing tools. This is the view others see when you share a public link to your map. 
+            <b>View mode</b> shows your map without any of the editing tools. This is the view
+            others see when you share a public link to your map.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/view_mode.webm`}
@@ -223,9 +223,9 @@ export default function GuidePage() {
             Saving your Map
           </Heading>
           <Text size="3">
-            Your map automatically saves as you work. Clicking the map title at the middle of the top bar allows you to edit the map name
-            and any comments about the map. Optionally, you can toggle your map from a draft to
-            “Ready to Share” if you are fully finished.
+            Your map automatically saves as you work. Clicking the map title at the middle of the
+            top bar allows you to edit the map name and any comments about the map. Optionally, you
+            can toggle your map from a draft to “Ready to Share” if you are fully finished.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/edit_metadata.webm`}
@@ -243,8 +243,8 @@ export default function GuidePage() {
             Sharing your Map
           </Heading>
           <Text size="3">
-            Clicking the “Share” button saves the map you created and allows you to share a link
-            to the map. You can either share a frozen link, which does not allow editing of the
+            Clicking the “Share” button saves the map you created and allows you to share a link to
+            the map. You can either share a frozen link, which does not allow editing of the
             original map, or an editable link, which only allows people with a password to edit.
           </Text>
           <LoopVideoPlayer
@@ -271,8 +271,8 @@ export default function GuidePage() {
             format with other platforms is a CSV assignment file which maps Census blocks to
             districts. Click on the “Map Action” menu in the upper right corner of the map and
             select “Export assignments”, then “Block assignments”. Alternatively, you can also
-            export your district shapes as a GeoJSON or a shapefile, or export evaluation metrics
-            as a JSON file.
+            export your district shapes as a GeoJSON or a shapefile, or export evaluation metrics as
+            a JSON file.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/export.webm`}
@@ -285,8 +285,8 @@ export default function GuidePage() {
         <Flex direction="column" gapY="4">
           <Text size="3">
             You now know everything you need to draw and share a plan — but if you want to go
-            further, <b>Super Draw</b> mode unlocks additional tools for fine-tuning your
-            districts. Switch into it from the same “Mode” menu described above.
+            further, <b>Super Draw</b> mode unlocks additional tools for fine-tuning your districts.
+            Switch into it from the same “Mode” menu described above.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/switch_mode.webm`}
@@ -294,8 +294,7 @@ export default function GuidePage() {
           <Text size="3">
             If you need to use smaller units of geography to balance the population of your
             districts, click the break icon on the toolbar at the top of the side panel. Then click
-            on
-            a unit you want to “shatter”, allowing you to paint subsets of the original unit. You
+            on a unit you want to “shatter”, allowing you to paint subsets of the original unit. You
             can see the population number of each broken piece by clicking the gear icon in the
             upper right corner of the map and selecting “Show total population labels on blocks”.
           </Text>

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -136,7 +136,7 @@ export default function GuidePage() {
             The “District overview” panel lists each drawn district — click a district number to
             select it and switch the brush to that district's color. It also shows the population of
             each district; to balance your population evenly between districts, make reference to
-            the ideal population count and vertical bar provided in this panel.
+            the ideal population count and vertical bar provided in this panel. You may also add comments to each district by clicking the comment icon next to the district number.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/district_overview.webm`}
@@ -242,8 +242,9 @@ export default function GuidePage() {
           />
           <Text size="3">
             The “Catalog” from the main page stores all your maps, which allows you to switch
-            between different maps you have worked on. You can go there at any time from the
-            navigational menu of the “Districtr” icon.
+            between different maps you have worked on. These maps are stored in your browser's local
+            storage — no account or login needed. They will be removed when you clear your browser
+            data. You can go there at any time from the navigational menu of the “Districtr” icon.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/map_catalog.webm`}

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -44,8 +44,8 @@ export default function GuidePage() {
           </Heading>
 
           <Text size="3">
-            Select the hand icon on the toolbar at the bottom of the map. Then click and drag to pan
-            across the map.
+            Select the hand icon on the toolbar at the top of the side panel, on the right of the
+            map. Then click and drag to pan across the map.
           </Text>
           <Text size="3">
             To zoom in and out, use the plus and minus buttons in the bottom right corner of the
@@ -60,8 +60,8 @@ export default function GuidePage() {
           </Heading>
 
           <Text size="3">
-            To draw your first district, select the paintbrush icon on the toolbar at the bottom
-            of the map. Click and drag on the map to add units to your district.
+            To draw your first district, select the paintbrush icon on the toolbar at the top of
+            the side panel. Click and drag on the map to add units to your district.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/drawing_on_map.webm`}
@@ -90,8 +90,8 @@ export default function GuidePage() {
           />
           <Text size="3">
             To correct the boundaries of your districts, click the erase icon on the toolbar at
-            the bottom of the map. Click and drag to remove units from that district. The size of
-            the eraser can be adjusted by dragging the slider.
+            the top of the side panel. Click and drag to remove units from that district. The size
+            of the eraser can be adjusted by dragging the slider.
           </Text>
           <LoopVideoPlayer
             videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/eraser.webm`}
@@ -274,7 +274,8 @@ export default function GuidePage() {
           </Text>
           <Text size="3">
             If you need to use smaller units of geography to balance the population of your
-            districts, click the break icon on the toolbar at the bottom of the map. Then click on
+            districts, click the break icon on the toolbar at the top of the side panel. Then click
+            on
             a unit you want to “shatter”, allowing you to paint subsets of the original unit. You
             can see the population number of each broken piece by clicking the gear icon in the
             upper right corner of the map and selecting “Show total population labels on blocks”.

--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -270,6 +270,7 @@ export default function GuidePage() {
         </Flex>
       </ContentSection>
 
+      <CTA />
       <ContentSection title="Super Draw">
         <Flex direction="column" gapY="4">
           <Text size="3">
@@ -302,7 +303,6 @@ export default function GuidePage() {
           />
         </Flex>
       </ContentSection>
-      <CTA />
     </Flex>
   );
 }

--- a/app/src/app/(static)/page.tsx
+++ b/app/src/app/(static)/page.tsx
@@ -18,11 +18,6 @@ const Main: React.FC = () => {
         <Text size="4">
           Districtr is a free browser-based tool for drawing districts and mapping your community.
         </Text>
-        <Text size="4" className="py-4 text-center">
-          This is a beta release of Districtr 2.0. We have a limited selection of states available
-          for mapping, and are accepting user feedback via the green &quot;Feedback&quot; button in
-          the bottom right corner.
-        </Text>
       </Flex>
       <ContentSection
         title="Help shape our democracy!"
@@ -98,7 +93,7 @@ const Main: React.FC = () => {
           >
             <Flex direction={'column'} gapY="4">
               <Heading size="6" as="h3" className="text-orange-700 mb-4">
-                You can draw your community (coming soon)
+                You can draw your community
               </Heading>
               <Text size="5">
                 Communities of Interest (known as “COIs”) are groups or neighborhoods with

--- a/app/src/app/(static)/rules/page.tsx
+++ b/app/src/app/(static)/rules/page.tsx
@@ -20,7 +20,7 @@ const RuleSection: React.FC<{
   );
 };
 
-export default function GuidePage() {
+export default function RulesPage() {
   return (
     <Flex direction="column" gapY="4">
       <LearnSubNav />
@@ -43,7 +43,7 @@ export default function GuidePage() {
         >
           <RuleSection
             title="Population balance"
-            description="Districts should have very close to the same Population"
+            description="Districts should have very close to the same population"
             image="/equalpop.png"
             imageAlt="Equal Population"
           />
@@ -94,7 +94,7 @@ export default function GuidePage() {
         <Link href="https://districtr.org/assets/the-rules-for-districtr.pdf" target="_blank">
           handout
         </Link>
-        . friend of the Lab Doug Spencer maintains a guide to state-by-state rules at{' '}
+        . Friend of the Lab Doug Spencer maintains a guide to state-by-state rules at{' '}
         <Link href="https://redistricting.lls.edu/" target="_blank">
           All About Redistricting
         </Link>

--- a/app/src/app/components/Static/Content/CTA.tsx
+++ b/app/src/app/components/Static/Content/CTA.tsx
@@ -1,7 +1,6 @@
 'use client';
 import React from 'react';
-import Image from 'next/image';
-import {Box, Flex, Text} from '@radix-ui/themes';
+import {Box, Flex} from '@radix-ui/themes';
 import {PlaceMapModal} from '../PlaceMap/PlaceMapModal';
 
 export const CTA: React.FC = () => {
@@ -12,15 +11,6 @@ export const CTA: React.FC = () => {
       justify="center"
       className="relative w-full py-16 overflow-hidden bg-districtrLightBlue rounded-xl my-4"
     >
-      <Box className="absolute inset-0 z-0 opacity-100 transform rotate-25 m-[-10%]">
-        <Image
-          src="/home-megaphone.png"
-          alt="Megaphone background"
-          fill
-          style={{objectFit: 'contain'}}
-        />
-      </Box>
-
       <Box className="relative z-10 text-center max-w-2xl mx-auto px-4">
         <PlaceMapModal>
           <Box className="bg-districtrBlue text-white text-xl px-8 py-3 rounded-md font-bold hover:bg-blue-700 transition-colors cursor-pointer">

--- a/app/src/app/components/Static/Content/DevTeam.tsx
+++ b/app/src/app/components/Static/Content/DevTeam.tsx
@@ -5,14 +5,13 @@ export const DevTeam: React.FC = () => (
     <Heading className="text-districtrIndigo pt-6">Development Team</Heading>
 
     <Text size="3">
-      <b>Software Devs:</b> Anna Bailliekova, Nick Doiron, Mario Giampieri, Dylan Halpern, Raphael
-      Laude
+      <b>Software Devs:</b> Dylan Halpern, Peter Rock, Ge Fang
     </Text>
     <Text size="3">
       <b>Project Team:</b> Peter Rock, Moon Duchin
     </Text>
     <Text size="3">
-      <b>Past Contributors:</b> Max Hully, Ruth Buck (originating team); Liz Kopecky (past project
+      <b>Past Contributors:</b> Anna Bailliekova, Nick Doiron, Mario Giampieri, Raphael Laude, Max Hully, Ruth Buck (originating team); Liz Kopecky (past project
       manager); Chris Donnay (past project manager); Jamie Atlas, Eion Blanchard, Jack Deschler,
       Chris Gernon, Peter Horvath, Muniba Khan, Zhenghong Lieu, JN Matthews, Anthony Pizzimenti,
       Heather Rosenfeld, Anna Schall, and many more

--- a/app/src/app/components/Static/Content/DevTeam.tsx
+++ b/app/src/app/components/Static/Content/DevTeam.tsx
@@ -9,13 +9,13 @@ export const DevTeam: React.FC = () => (
       Laude
     </Text>
     <Text size="3">
-      <b>Project Team:</b> Chris Donnay (project manager), Moon Duchin
+      <b>Project Team:</b> Peter Rock, Moon Duchin
     </Text>
     <Text size="3">
       <b>Past Contributors:</b> Max Hully, Ruth Buck (originating team); Liz Kopecky (past project
-      manager); Jamie Atlas, Eion Blanchard, Jack Deschler, Chris Gernon, Peter Horvath, Muniba
-      Khan, Zhenghong Lieu, JN Matthews, Anthony Pizzimenti, Heather Rosenfeld, Anna Schall, and
-      many more
+      manager); Chris Donnay (past project manager); Jamie Atlas, Eion Blanchard, Jack Deschler,
+      Chris Gernon, Peter Horvath, Muniba Khan, Zhenghong Lieu, JN Matthews, Anthony Pizzimenti,
+      Heather Rosenfeld, Anna Schall, and many more
     </Text>
   </>
 );

--- a/app/src/app/components/Static/Content/DevTeam.tsx
+++ b/app/src/app/components/Static/Content/DevTeam.tsx
@@ -11,10 +11,11 @@ export const DevTeam: React.FC = () => (
       <b>Project Team:</b> Peter Rock, Moon Duchin
     </Text>
     <Text size="3">
-      <b>Past Contributors:</b> Chris Donnay (past project manager), Anna Bailliekova, Nick Doiron, Mario Giampieri, Raphael Laude, Max Hully, Ruth Buck (originating team), Liz Kopecky (past project
-      manager), Jamie Atlas, Eion Blanchard, Jack Deschler,
-      Chris Gernon, Peter Horvath, Muniba Khan, Zhenghong Lieu, JN Matthews, Anthony Pizzimenti,
-      Heather Rosenfeld, Anna Schall, and many more
+      <b>Past Contributors:</b> Chris Donnay (past project manager), Anna Bailliekova, Nick Doiron,
+      Mario Giampieri, Raphael Laude, Max Hully, Ruth Buck (originating team), Liz Kopecky (past
+      project manager), Jamie Atlas, Eion Blanchard, Jack Deschler, Chris Gernon, Peter Horvath,
+      Muniba Khan, Zhenghong Lieu, JN Matthews, Anthony Pizzimenti, Heather Rosenfeld, Anna Schall,
+      and many more
     </Text>
   </>
 );

--- a/app/src/app/components/Static/Content/DevTeam.tsx
+++ b/app/src/app/components/Static/Content/DevTeam.tsx
@@ -11,8 +11,8 @@ export const DevTeam: React.FC = () => (
       <b>Project Team:</b> Peter Rock, Moon Duchin
     </Text>
     <Text size="3">
-      <b>Past Contributors:</b> Anna Bailliekova, Nick Doiron, Mario Giampieri, Raphael Laude, Max Hully, Ruth Buck (originating team); Liz Kopecky (past project
-      manager); Chris Donnay (past project manager); Jamie Atlas, Eion Blanchard, Jack Deschler,
+      <b>Past Contributors:</b> Chris Donnay (past project manager), Anna Bailliekova, Nick Doiron, Mario Giampieri, Raphael Laude, Max Hully, Ruth Buck (originating team), Liz Kopecky (past project
+      manager), Jamie Atlas, Eion Blanchard, Jack Deschler,
       Chris Gernon, Peter Horvath, Muniba Khan, Zhenghong Lieu, JN Matthews, Anthony Pizzimenti,
       Heather Rosenfeld, Anna Schall, and many more
     </Text>

--- a/app/src/app/components/Static/ContentSection.tsx
+++ b/app/src/app/components/Static/ContentSection.tsx
@@ -1,6 +1,7 @@
 import {Box, Flex} from '@radix-ui/themes';
 import React from 'react';
 import {ContentHeader} from './ContentHeader';
+import {slugify} from '@/app/utils/slugify';
 
 export const ContentSection: React.FC<{
   title: string;
@@ -8,7 +9,7 @@ export const ContentSection: React.FC<{
   flavorImage?: React.ReactNode;
 }> = ({title, flavorImage, children}) => {
   return (
-    <Box>
+    <Box id={slugify(title)} className="scroll-mt-28">
       <Flex direction="row" align="center" justify="start" my="2">
         <ContentHeader title={title} />
         {!!flavorImage && flavorImage}

--- a/app/src/app/components/Static/GuideToc.tsx
+++ b/app/src/app/components/Static/GuideToc.tsx
@@ -1,0 +1,54 @@
+import {Box, Flex, Link, Text} from '@radix-ui/themes';
+import React from 'react';
+import {slugify} from '@/app/utils/slugify';
+
+export interface GuideTocEntry {
+  title: string;
+  subsections?: string[];
+}
+
+/** Sticky in-page anchor nav for the guide's sections and subheadings. Ids are
+ * derived from the same titles passed to `ContentSection` and each subheading,
+ * via the shared `slugify`, so the links can't drift out of sync with the page. */
+export const GuideToc: React.FC<{entries: GuideTocEntry[]}> = ({entries}) => {
+  return (
+    <Box asChild className="hidden lg:block w-48 shrink-0">
+      <nav aria-label="Guide sections">
+        <Box className="sticky top-28">
+          <Flex direction="column" gapY="2">
+            {entries.map(({title, subsections}) => (
+              <Box key={title}>
+                <Link
+                  href={`#${slugify(title)}`}
+                  size="2"
+                  weight="bold"
+                  color="gray"
+                  className="!cursor-pointer hover:!text-districtrBlue"
+                >
+                  {title}
+                </Link>
+                {!!subsections?.length && (
+                  <Flex direction="column" gapY="1" className="pl-3 mt-1">
+                    {subsections.map(sub => (
+                      <Link
+                        key={sub}
+                        href={`#${slugify(sub)}`}
+                        size="1"
+                        color="gray"
+                        className="!cursor-pointer hover:!text-districtrBlue"
+                      >
+                        <Text as="p" className="truncate">
+                          {sub}
+                        </Text>
+                      </Link>
+                    ))}
+                  </Flex>
+                )}
+              </Box>
+            ))}
+          </Flex>
+        </Box>
+      </nav>
+    </Box>
+  );
+};

--- a/app/src/app/components/Static/GuideToc.tsx
+++ b/app/src/app/components/Static/GuideToc.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, Link, Text} from '@radix-ui/themes';
+import {Flex, Link, Text} from '@radix-ui/themes';
 import React from 'react';
 import {slugify} from '@/app/utils/slugify';
 
@@ -12,43 +12,39 @@ export interface GuideTocEntry {
  * via the shared `slugify`, so the links can't drift out of sync with the page. */
 export const GuideToc: React.FC<{entries: GuideTocEntry[]}> = ({entries}) => {
   return (
-    <Box asChild className="hidden lg:block w-48 shrink-0">
-      <nav aria-label="Guide sections">
-        <Box className="sticky top-28">
-          <Flex direction="column" gapY="2">
-            {entries.map(({title, subsections}) => (
-              <Box key={title}>
-                <Link
-                  href={`#${slugify(title)}`}
-                  size="2"
-                  weight="bold"
-                  color="gray"
-                  className="!cursor-pointer hover:!text-districtrBlue"
-                >
-                  {title}
-                </Link>
-                {!!subsections?.length && (
-                  <Flex direction="column" gapY="1" className="pl-3 mt-1">
-                    {subsections.map(sub => (
-                      <Link
-                        key={sub}
-                        href={`#${slugify(sub)}`}
-                        size="1"
-                        color="gray"
-                        className="!cursor-pointer hover:!text-districtrBlue"
-                      >
-                        <Text as="p" className="truncate">
-                          {sub}
-                        </Text>
-                      </Link>
-                    ))}
-                  </Flex>
-                )}
-              </Box>
-            ))}
+    <nav aria-label="Guide sections" className="hidden lg:block w-56 shrink-0 sticky top-28 h-fit">
+      <Flex direction="column" gapY="3">
+        {entries.map(({title, subsections}) => (
+          <Flex direction="column" gapY="1" key={title}>
+            <Link
+              href={`#${slugify(title)}`}
+              size="3"
+              weight="bold"
+              color="gray"
+              className="!cursor-pointer hover:!text-districtrBlue"
+            >
+              {title}
+            </Link>
+            {!!subsections?.length && (
+              <Flex direction="column" gapY="1" className="pl-3">
+                {subsections.map(sub => (
+                  <Link
+                    href={`#${slugify(sub)}`}
+                    size="2"
+                    color="gray"
+                    className="!cursor-pointer hover:!text-districtrBlue"
+                    key={sub}
+                  >
+                    <Text as="p" className="truncate">
+                      {sub}
+                    </Text>
+                  </Link>
+                ))}
+              </Flex>
+            )}
           </Flex>
-        </Box>
-      </nav>
-    </Box>
+        ))}
+      </Flex>
+    </nav>
   );
 };

--- a/app/src/app/components/Static/LoopVideoPlayer.tsx
+++ b/app/src/app/components/Static/LoopVideoPlayer.tsx
@@ -3,11 +3,28 @@ import {Box} from '@radix-ui/themes';
 import {useEffect, useRef} from 'react';
 import {useInView} from 'react-intersection-observer';
 
+/** Pause on the final frame for this long before restarting the loop. */
+const LOOP_HOLD_MS = 300;
+
 export const LoopVideoPlayer: React.FC<{videoUrl: string}> = ({videoUrl}) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const {ref, inView} = useInView({
     threshold: 0.2,
   });
+  const inViewRef = useRef(inView);
+  inViewRef.current = inView;
+
+  // Looping is manual (no `loop` attribute) so the last frame can hold briefly
+  // before the video restarts.
+  const handleEnded = () => {
+    window.setTimeout(() => {
+      const video = videoRef.current;
+      if (video && inViewRef.current) {
+        video.currentTime = 0;
+        video.play().catch(() => {});
+      }
+    }, LOOP_HOLD_MS);
+  };
 
   useEffect(() => {
     if (!videoRef.current) return;
@@ -48,7 +65,7 @@ export const LoopVideoPlayer: React.FC<{videoUrl: string}> = ({videoUrl}) => {
       ref={ref}
       className="w-full h-auto max-w-[800px] mx-auto shadow-xl m-4 border-districtrIndigo border-2 rounded-lg overflow-hidden"
     >
-      <video ref={videoRef} src={videoUrl} loop muted playsInline preload="true" />
+      <video ref={videoRef} src={videoUrl} onEnded={handleEnded} muted playsInline preload="true" />
     </Box>
   );
 };

--- a/app/src/app/components/Static/LoopVideoPlayer.tsx
+++ b/app/src/app/components/Static/LoopVideoPlayer.tsx
@@ -4,7 +4,7 @@ import {useEffect, useRef} from 'react';
 import {useInView} from 'react-intersection-observer';
 
 /** Pause on the final frame for this long before restarting the loop. */
-const LOOP_HOLD_MS = 300;
+const LOOP_HOLD_MS = 500;
 
 export const LoopVideoPlayer: React.FC<{videoUrl: string}> = ({videoUrl}) => {
   const videoRef = useRef<HTMLVideoElement>(null);

--- a/app/src/app/utils/slugify.ts
+++ b/app/src/app/utils/slugify.ts
@@ -1,0 +1,7 @@
+/** Turns heading text into a URL-safe anchor id, e.g. for in-page table-of-contents links. */
+export const slugify = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');


### PR DESCRIPTION


The tutorial video clips embedded in `/guide` were recorded in May 2025 and no longer match the UI — most notably the topbar Mode switcher (Draw/Super Draw/View/Evaluate) didn't exist yet. This replaces all 20 old clips with 25 new ones at a new S3 prefix (`videos/guide-2026/`, old `videos/` untouched), and restructures the page around them:

- **Getting Started**, **Drawing Districts**, **Data Panels**, and **Saving, Sharing, Importing & Exporting** carry forward the old content with updated clips and light prose edits.
- **Map Modes** and **Super Draw** are new sections covering the topbar mode switcher and the Super Draw–gated tools (shatter, side-by-side overlay), which had no guide coverage before.
- Dropped the draggable-toolbar step (that feature was removed) and fixed three pre-existing text bugs: a duplicated "Saving and Sharing" section title, a duplicated choropleth paragraph under Elections, and awkward wording under Map Validation.

Also updates the About page dev roster: Project Team is now Peter Rock, Moon Duchin; the Software Devs and Past Contributors lists are refreshed.

Beyond the guide itself:

- The prose got a close editing pass against the current UI (the toolbar now lives at the top of the side panel, not the bottom of the map; menus and panel names updated to match the app).
- Shared components: the CTA banner drops its rotated megaphone background for a solid light-blue fill (affects every page that uses it), and on the guide it moves above the Super Draw section — the natural stopping point for everyday users. The looping video player now holds the final frame for half a second before restarting, so each clip's end state registers.
- Proofreading fixes on the Data, Rules, and About pages: a duplicated ACS sentence and a doubled lab name on Data, casing fixes on Rules, and page components renamed after their pages.

Files: `app/src/app/(static)/{guide,data,rules,about}/page.tsx`, `app/src/app/components/Static/Content/{DevTeam,CTA}.tsx`, `app/src/app/components/Static/LoopVideoPlayer.tsx`.

## Review required

The content and prose guide is expected to get a close review. 

