### PR TITLE
Reduce autosave notification noise

### DIFF
--- a/app/src/app/components/Map/CoiMapContainer.tsx
+++ b/app/src/app/components/Map/CoiMapContainer.tsx
@@ -63,6 +63,9 @@ export const CoiMapContainer: React.FC<{
           <GeocodeSearchBar mapRef={mapRef} mapBounds={mapBounds} />
         </div>
       )}
+      {/* pointer-events-none on the container kills hover, so the not-allowed
+          cursor while locked needs this event-catching overlay. */}
+      {mapLock && <div className="absolute inset-0 z-20 pointer-events-auto cursor-not-allowed" />}
       <GlMap
         ref={mapRef}
         mapStyle={mapStyle}

--- a/app/src/app/components/Map/MapContainer.tsx
+++ b/app/src/app/components/Map/MapContainer.tsx
@@ -80,6 +80,9 @@ export const MapContainer: React.FC<{
           <GeocodeSearchBar mapRef={mapRef} mapBounds={mapBounds} />
         </div>
       )}
+      {/* pointer-events-none on the container kills hover, so the not-allowed
+          cursor while locked needs this event-catching overlay. */}
+      {mapLock && <div className="absolute inset-0 z-20 pointer-events-auto cursor-not-allowed" />}
       <GlMap
         ref={mapRef}
         mapStyle={mapStyle}

--- a/app/src/app/components/Topbar/LoadingOverlay.tsx
+++ b/app/src/app/components/Topbar/LoadingOverlay.tsx
@@ -81,6 +81,14 @@ export const LoadingOverlay: React.FC = () => {
   if (viewTransition === 'display') {
     return <OverlayCard icon={EyeOpenIcon} message="Loading view mode" />;
   }
+  // Silent locks (background autosave) keep the page-wide interaction guard the
+  // visible card used to provide — otherwise topbar/sidebar edits landing while
+  // the save PUT is in flight get clobbered by its completion handlers — just
+  // without rendering anything. Shown immediately: it's invisible, so the
+  // anti-flash delay below doesn't apply.
+  if (mapLock?.isLocked && mapLock.silent) {
+    return <div className="fixed inset-0 z-[100000] cursor-not-allowed" aria-hidden />;
+  }
   if (showBusy) {
     return <OverlayCard message={mapLock?.reason || 'Loading map…'} />;
   }

--- a/app/src/app/components/Topbar/LoadingOverlay.tsx
+++ b/app/src/app/components/Topbar/LoadingOverlay.tsx
@@ -66,12 +66,13 @@ export const LoadingOverlay: React.FC = () => {
   const mapLock = useMapStore(state => state.mapLock);
   const documentLoading = useMapStore(state => state.loadingStates.documentLoading);
 
-  const busy = Boolean(mapLock?.isLocked) || documentLoading;
+  // Silent locks (background autosave) block edits but never show the overlay.
+  const busy = Boolean(mapLock?.isLocked && !mapLock.silent) || documentLoading;
   const showBusy = useDelayed(busy, BUSY_SHOW_DELAY_MS);
 
   // Auto-save kicked off by a mode switch: the transition is already active, so surface
   // the save explicitly and immediately (skipping the busy delay below).
-  if (viewTransition && mapLock?.isLocked) {
+  if (viewTransition && mapLock?.isLocked && !mapLock.silent) {
     return <OverlayCard message="Saving changes…" />;
   }
   if (viewTransition === 'evaluate') {

--- a/app/src/app/hooks/useAutoSave.ts
+++ b/app/src/app/hooks/useAutoSave.ts
@@ -39,7 +39,9 @@ export function useAutoSave() {
       if (!ref.current.enabled || saving) return;
       saving = true;
       try {
-        await ref.current.save();
+        // Silent: autosave shouldn't toast "Map saved" or flash the lock overlay
+        // — the topbar cloud icon and "Auto-saving…" popup are enough.
+        await ref.current.save(false, {silent: true});
       } finally {
         saving = false;
       }

--- a/app/src/app/store/assignmentsStore.ts
+++ b/app/src/app/store/assignmentsStore.ts
@@ -94,7 +94,7 @@ export interface AssignmentsStore {
 
   /** Clears all shatter state */
   resetShatterState: () => void;
-  handlePutAssignments: (overwrite?: boolean) => Promise<void>;
+  handlePutAssignments: (overwrite?: boolean, opts?: {silent?: boolean}) => Promise<void>;
   handleRevert: (mapDocument: DocumentObject) => Promise<void>;
   handlePutAssignmentsConflict: (
     resolution: SyncConflictResolution,
@@ -786,7 +786,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
     });
   },
 
-  handlePutAssignments: async (overwrite = false) => {
+  handlePutAssignments: async (overwrite = false, {silent = false} = {}) => {
     // Flush any pending IDB updates before explicit save
     await idb.flushPendingUpdate();
 
@@ -801,7 +801,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
     const hasPendingChanges =
       Object.values(updated).some(Boolean) ||
       (get().clientLastUpdated !== '' && get().clientLastUpdated !== mapDocument.updated_at);
-    setMapLock({isLocked: true, reason: 'Saving plan'});
+    setMapLock({isLocked: true, reason: 'Saving plan', silent});
 
     try {
       // Use mapStore.mapDocument (has latest comments from in-memory edits) merged with
@@ -837,7 +837,7 @@ export const useAssignmentsStore = createWithFullMiddlewares<AssignmentsStore>(
         });
       } else if (assignmentsPostResponse.ok) {
         setShowSaveConflictModal(false);
-        if (hasPendingChanges) {
+        if (hasPendingChanges && !silent) {
           setNotification({message: 'Map saved', importance: 2, type: 'success'});
         }
       }

--- a/app/src/app/store/coiAssignmentsStore.ts
+++ b/app/src/app/store/coiAssignmentsStore.ts
@@ -151,7 +151,7 @@ export interface CoiAssignmentsStore {
   removeCommunitiesAbove: (maxCommunity: number) => void;
   removeCommunity: (removedCommunity: Zone) => void;
 
-  handlePutAssignments: (overwrite?: boolean) => Promise<void>;
+  handlePutAssignments: (overwrite?: boolean, opts?: {silent?: boolean}) => Promise<void>;
   handleRevert: (mapDocument: DocumentObject) => Promise<void>;
   resolveConflict: (
     resolution: SyncConflictResolution,
@@ -1444,7 +1444,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
     temporalManager.purgeZone(MAP_MODES.COI, removedCommunity);
   },
 
-  handlePutAssignments: async (overwrite = false) => {
+  handlePutAssignments: async (overwrite = false, {silent = false} = {}) => {
     // console.log('[COI save] handlePutAssignments called, overwrite:', overwrite);
     await idb.flushPendingUpdate();
 
@@ -1471,7 +1471,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
     const hasPendingChanges =
       Object.values(updated).some(Boolean) ||
       (get().clientLastUpdated !== '' && get().clientLastUpdated !== mapDocument.updated_at);
-    setMapLock({isLocked: true, reason: 'Saving Coi assignment plan'});
+    setMapLock({isLocked: true, reason: 'Saving Coi assignment plan', silent});
     try {
       const documentForSave: DocumentObject = {
         ...idbDocument.document_metadata,
@@ -1511,7 +1511,7 @@ export const useCoiAssignmentsStore = createWithFullMiddlewares<CoiAssignmentsSt
       } else if (assignmntsPostResponse.ok) {
         // console.log('[COI save] Save succeeded:', assignmntsPostResponse.response);
         setShowSaveConflictModal(false);
-        if (hasPendingChanges) {
+        if (hasPendingChanges && !silent) {
           setNotification({message: 'Map saved', importance: 2, type: 'success'});
         }
       }

--- a/app/src/app/store/mapStore.ts
+++ b/app/src/app/store/mapStore.ts
@@ -194,6 +194,8 @@ export interface MapStore {
   mapLock: {
     isLocked: boolean;
     reason: string;
+    // Silent locks (background autosave) still block edits but skip the overlay.
+    silent?: boolean;
   } | null;
   setMapLock: (lock: MapStore['mapLock']) => void;
   notification: {


### PR DESCRIPTION
Reduces autosave notifications

Simplifies visual indicator with simple not allowed cursor when map is locked

No behavior changes in map locking while saving