### PR TITLE
Fix Alaska map bbox and prevent recurrence on reload

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -481,6 +481,36 @@ def add_extent_to_districtrmap(
                 rec.parent_layer
             ) INTO layer_extent;
 
+            -- A >180-degree-wide bbox is impossible for a legitimate single-state
+            -- layer. It means the geometry straddles the antimeridian (e.g.
+            -- Alaska's Aleutian islands, recorded with longitudes on both the
+            -- -179.x and +179.x side), and the naive ST_XMin/ST_XMax above
+            -- produced a near-global span instead of the true, much narrower,
+            -- extent. Recompute using ST_ShiftLongitude, which maps negative
+            -- longitudes into the 0..360 range so the data becomes contiguous;
+            -- the resulting bbox may have coordinates outside +/-180, which
+            -- MapLibre's fitBounds handles correctly for antimeridian-crossing
+            -- regions.
+            IF (ST_XMax(layer_extent) - ST_XMin(layer_extent)) > 180 THEN
+                EXECUTE format('
+                    SELECT ST_Extent(
+                        ST_ShiftLongitude(
+                            ST_Transform(
+                                ST_SetSRID(
+                                    geometry,
+                                    (SELECT ST_SRID(geometry) FROM gerrydb.%I WHERE geometry IS NOT NULL LIMIT 1)
+                                ),
+                                4326
+                            )
+                        )
+                    )
+                    FROM gerrydb.%I
+                    WHERE geometry IS NOT NULL',
+                    rec.parent_layer,
+                    rec.parent_layer
+                ) INTO layer_extent;
+            END IF;
+
             UPDATE districtrmap
             SET extent = ARRAY[
                 ST_XMin(layer_extent),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -406,6 +406,49 @@ def simple_child_geos_gerrydb_fixture(session: Session, simple_child_geos):
     session.close()
 
 
+@pytest.fixture(name="antimeridian_geos")
+def antimeridian_geos_fixture(session: Session):
+    """Two small polygons straddling the antimeridian, mirroring Alaska's Aleutian
+    islands, so extent computation can be tested for that failure mode."""
+    layer = "antimeridian_geos"
+    result = subprocess.run(
+        args=[
+            "ogr2ogr",
+            "-f",
+            "PostgreSQL",
+            OGR2OGR_PG_CONNECTION_STRING,
+            FIXTURES_PATH / "gerrydb" / f"{layer}.geojson",
+            "-lco",
+            "OVERWRITE=yes",
+            "-nln",
+            f"{GERRY_DB_SCHEMA}.{layer}",
+            "-nlt",
+            "MULTIPOLYGON",
+            "-lco",
+            "GEOMETRY_NAME=geometry",
+        ],
+    )
+
+    if result.returncode != 0:
+        print(f"ogr2ogr failed. Got {result}")
+        raise ValueError(f"ogr2ogr failed with return code {result.returncode}")
+
+
+@pytest.fixture(name="antimeridian_geos_gerrydb")
+def antimeridian_geos_gerrydb_fixture(session: Session, antimeridian_geos):
+    upsert_query = text("""
+        INSERT INTO gerrydbtable (uuid, name, updated_at)
+        VALUES (gen_random_uuid(), :name, now())
+        ON CONFLICT (name)
+        DO UPDATE SET
+            updated_at = now()
+    """)
+    session.begin()
+    session.execute(upsert_query, {"name": "antimeridian_geos"})
+    session.commit()
+    session.close()
+
+
 @pytest.fixture(name="gerrydb_simple_geos_view")
 def gerrydb_simple_geos_view_fixture(
     session: Session, simple_parent_geos_gerrydb, simple_child_geos_gerrydb

--- a/backend/tests/fixtures/gerrydb/antimeridian_geos.geojson
+++ b/backend/tests/fixtures/gerrydb/antimeridian_geos.geojson
@@ -1,0 +1,58 @@
+{
+  "type": "FeatureCollection",
+  "name": "antimeridian_geos",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "path": "vtd:000020000001",
+        "total_pop_20": 100,
+        "white_pop_20": 90,
+        "black_pop_20": 5
+      },
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [
+            [
+              [179.5, 51.0],
+              [179.9, 51.0],
+              [179.9, 51.5],
+              [179.5, 51.5],
+              [179.5, 51.0]
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "path": "vtd:000020000002",
+        "total_pop_20": 100,
+        "white_pop_20": 90,
+        "black_pop_20": 5
+      },
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [
+            [
+              [-179.9, 51.0],
+              [-179.5, 51.0],
+              [-179.5, 51.5],
+              [-179.9, 51.5],
+              [-179.9, 51.0]
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -245,6 +245,30 @@ def test_add_districtr_map_already_in_group_to_group(
     assert result == 2
 
 
+def test_add_extent_to_districtrmap_antimeridian(
+    session: Session, antimeridian_geos_gerrydb
+):
+    """Regression test for the Alaska bbox bug: geometry straddling the antimeridian
+    (vertices on both the -179.x and +179.x side) must not produce a bogus
+    ~360-degree-wide extent -- the true angular width here is ~1 degree."""
+    inserted_districtr_map = create_districtr_map(
+        session,
+        name="Antimeridian layer",
+        districtr_map_slug="antimeridian_geos_test",
+        gerrydb_table_name="antimeridian_geos",
+        parent_layer="antimeridian_geos",
+    )
+    add_extent_to_districtrmap(
+        session=session, districtr_map_uuid=inserted_districtr_map
+    )
+    extent = session.execute(
+        text("SELECT extent FROM districtrmap WHERE uuid = :uuid"),
+        {"uuid": inserted_districtr_map},
+    ).scalar_one()
+    x_min, y_min, x_max, y_max = extent
+    assert x_max - x_min < 10, f"Expected a narrow bbox, got extent={extent}"
+
+
 def test_add_extent_to_districtrmap_manual_bounds(
     session: Session, simple_parent_geos_gerrydb
 ):


### PR DESCRIPTION
Alaska maps were opening zoomed all the way out to the whole world instead of framing Alaska. `DistrictrMap.extent` (the bbox fed straight into MapLibre's `fitBounds`) was `[-179.23, 51.18, 179.86, 71.44]` — a ~359°-wide box.

Root cause: `add_extent_to_districtrmap` (`backend/app/utils.py`) computes the bbox as a naive `ST_XMin`/`ST_XMax` over `ST_Extent(geometry)`. That's fine for any ordinary state, but Alaska's Aleutian islands have vertices on both sides of the antimeridian (mainland ~-179° to -130°, westernmost islands ~+172° to +180°) — min/max across mixed signs produces a near-global span instead of the true ~50° one. This function reruns on every map (re)creation, so the bug would resurface the next time Alaska's map data gets reloaded.

Already hand-fixed the 6 affected rows on dev and prod (`districtrmap.extent` set to a standard non-wrapping Alaska bbox). This PR is the code fix so it doesn't come back.

**Fix:** when the naive extent comes out wider than 180° (impossible for any single non-antimeridian-crossing state), recompute with `ST_ShiftLongitude`, which maps negative longitudes into the 0–360° range so the data becomes contiguous. The resulting bbox can have coordinates outside ±180°, which MapLibre's `fitBounds` renders correctly for antimeridian-crossing regions.

Added a regression fixture (`antimeridian_geos.geojson`, two small polygons straddling 180°) and a test asserting the computed bbox stays narrow instead of ballooning to ~360°.
