### PR TITLE
Fix slight color mismatch between VTDs and broken blocks

### DIFF
--- a/app/src/app/components/Map/PolygonLayers/GeometryBackgroundLayer.tsx
+++ b/app/src/app/components/Map/PolygonLayers/GeometryBackgroundLayer.tsx
@@ -15,20 +15,25 @@ export const GeometryBackgroundLayer: React.FC<{
   visibleMembershipKeys?: string[];
 }> = ({id, sourceLayerId, filter, beforeId, style, visibleMembershipKeys}) => {
   const backgroundOpacity = style?.backgroundOpacity ?? 0.2;
-  const hideWhenAssignedExpression = (visibleMembershipKeys?.length
-    ? [
-        'any',
-        ...visibleMembershipKeys.map(membershipKey => [
+  // Hide broken parents too, so their gray background doesn't tint the child
+  // blocks rendered on top of them.
+  const hideWhenAssignedExpression = [
+    'any',
+    ['boolean', ['feature-state', 'broken'], false],
+    ...(visibleMembershipKeys?.length
+      ? visibleMembershipKeys.map(membershipKey => [
           'boolean',
           ['feature-state', membershipKey],
           false,
+        ])
+      : [
+          [
+            '!=',
+            ['coalesce', ['feature-state', 'zone'], SENTINEL_EMPTY_VALUE],
+            SENTINEL_EMPTY_VALUE,
+          ],
         ]),
-      ]
-    : [
-        '!=',
-        ['coalesce', ['feature-state', 'zone'], SENTINEL_EMPTY_VALUE],
-        SENTINEL_EMPTY_VALUE,
-      ]) as unknown as ExpressionSpecification;
+  ] as unknown as ExpressionSpecification;
 
   const layerProps: LayerProps = {
     id,

--- a/app/src/app/constants/map/layerRenderConfig.ts
+++ b/app/src/app/constants/map/layerRenderConfig.ts
@@ -23,7 +23,9 @@ export const MAP_LAYER_ANCHOR_ORDER = [
   MAP_LAYER_ANCHOR_IDS.counties,
 ] as const;
 
+// Same value for both so unassigned broken blocks match unassigned parents;
+// the broken parent's own background is hidden underneath (GeometryBackgroundLayer).
 export const UNASSIGNED_BACKGROUND_OPACITY = {
   parent: 0.18,
-  child: 0.22,
+  child: 0.18,
 } as const;


### PR DESCRIPTION
Broken parents keep rendering their gray unassigned background (zone is null once shattered), which tinted the child blocks painted on top of them. Hide the background for broken features, and unify the child unassigned opacity with the parent's so unassigned areas match too.