### PR TITLE
Fix coalition builder breaking the population chart in view mode

### DIFF
--- a/app/src/app/components/Map/GeoSources/PublicSource.tsx
+++ b/app/src/app/components/Map/GeoSources/PublicSource.tsx
@@ -80,10 +80,17 @@ export const PublicSource: React.FC<{children: React.ReactNode}> = ({children}) 
       setStateFp(publicDistrictsQuery.data.statefp);
     }
 
-    // Feed demographic data into demographyService for sidebar stats
-    const {columns, demographicData, assignments} = publicDistrictsQuery.data;
+    // Feed demographic data into demographyService for sidebar stats. The backend
+    // already aggregates demography per district (document.district_unions), so
+    // this goes through the assignments-free public path — see demographyService.ts.
+    const {columns, demographicData} = publicDistrictsQuery.data;
     const hash = `anonymous|${mapDocument?.public_id}`;
-    demographyService.update(Array.from(columns), demographicData, hash, [], assignments);
+    demographyService.updatePublicDemography(
+      Array.from(columns),
+      demographicData,
+      hash,
+      useDemographyStore.getState().coalitionGroups
+    );
     setDemographyHash(hash);
 
     // Set available column sets so sidebar knows which columns are available

--- a/app/src/app/utils/api/apiHandlers/getPublicDistricts.ts
+++ b/app/src/app/utils/api/apiHandlers/getPublicDistricts.ts
@@ -36,7 +36,6 @@ export const getPublicDistricts = async (mapDocument?: DocumentObject | null) =>
     path: [],
     sourceLayer: [],
   };
-  const assignments: Map<string, NullableZone> = new Map();
   let statefp = '';
   response.response.forEach((row: PublicDistrictData) => {
     const demographicDataRow =
@@ -76,14 +75,12 @@ export const getPublicDistricts = async (mapDocument?: DocumentObject | null) =>
       if (!(typedColumn in demographicData)) demographicData[typedColumn] = [];
       demographicData[typedColumn]!.push(numericValue);
     });
-    assignments.set(path, row.zone);
   });
 
   return {
     geojsonFeatures,
     columns,
     demographicData,
-    assignments,
     statefp,
   };
 };

--- a/app/src/app/utils/demography/demographyService.ts
+++ b/app/src/app/utils/demography/demographyService.ts
@@ -128,6 +128,15 @@ class DemographyService {
   zoneTable?: ColumnTable;
 
   /**
+   * True once `updatePublicDemography()` (public/read-only views) has loaded data.
+   * `this.table` is then already one row per zone — see document.district_unions —
+   * so population calculation must skip the block/zone join and assignment stores
+   * entirely, which are never populated in view mode. Reset by `update()` (edit/COI
+   * path) and `clear()` so edit and view sessions can't leak state into each other.
+   */
+  private isPublicSource: boolean = false;
+
+  /**
    * The summary of populations.
    */
   populations: SummaryTable = [];
@@ -180,17 +189,37 @@ class DemographyService {
     columns: AllTabularColumns[number][],
     data: ColumnarTableData,
     hash: string,
-    coalitionGroups: CoalitionGroupKey[] = [],
-    _zoneAssignments?: ZoneAssignmentsMap
+    coalitionGroups: CoalitionGroupKey[] = []
   ): void {
     if (hash === this.hash) return;
+    this.isPublicSource = false;
     this.availableColumns = columns;
     this.table = table(data).derive(getColumnDerives(columns)).dedupe('path');
-    const populationAssignments = _zoneAssignments ?? getActivePopulationAssignments();
     const popsOk = this.updatePopulations({
-      zoneAssignments: populationAssignments,
+      zoneAssignments: getActivePopulationAssignments(),
       coalitionGroups,
     });
+    if (!popsOk) return;
+    this.updateSummaryStats();
+    this.hash = hash;
+  }
+
+  /**
+   * View-mode counterpart to `update()`: loads demography that the backend has
+   * already aggregated per district (document.district_unions), so there is no
+   * assignments concept to thread through — see calculatePopulationsFromZoneTable.
+   */
+  updatePublicDemography(
+    columns: AllTabularColumns[number][],
+    data: ColumnarTableData,
+    hash: string,
+    coalitionGroups: CoalitionGroupKey[] = []
+  ): void {
+    if (hash === this.hash) return;
+    this.isPublicSource = true;
+    this.availableColumns = columns;
+    this.table = table(data).derive(getColumnDerives(columns)).dedupe('path');
+    const popsOk = this.updatePopulations({coalitionGroups});
     if (!popsOk) return;
     this.updateSummaryStats();
     this.hash = hash;
@@ -242,6 +271,7 @@ class DemographyService {
     this.overlayTable = undefined;
     this.overlayHash = '';
     this.zoneTable = undefined;
+    this.isPublicSource = false;
     this.populations = [];
     this.summaryStats = {};
     this.universeTotals = null;
@@ -343,15 +373,9 @@ class DemographyService {
     zoneAssignments?: PopulationAssignments,
     coalitionGroups: CoalitionGroupKey[] = []
   ): {ok: true; table: SummaryTable} | {ok: false} {
-    const mapState = useMapStore.getState();
-    const mapMode = useMapControlsStore.getState().mapMode;
-    const zoneIds =
-      mapMode === MAP_MODES.COI
-        ? sortCommunitiesByRenderOrder(mapState.communities).map(community => community.id)
-        : Array.from(
-            {length: mapState.mapDocument?.num_districts ?? FALLBACK_NUM_DISTRICTS},
-            (_, i) => i + 1
-          );
+    if (this.isPublicSource) {
+      return this.calculatePopulationsFromZoneTable(coalitionGroups);
+    }
     this.updateZoneTable(zoneAssignments ?? getActivePopulationAssignments());
 
     if (!this.table || !this.zoneTable) {
@@ -372,7 +396,6 @@ class DemographyService {
       };
     }
     const columns = this.table.columnNames();
-    // if any tot
     const populationsTable = joinedTable
       .groupby('zone')
       .rollup(getRollups(columns, 'sum'))
@@ -382,10 +405,66 @@ class DemographyService {
       .rollup(getRollups(columns, 'max'))
       .objects()[0] as MaxValues;
 
+    return this.finalizePopulations(
+      populationsTable.objects() as SummaryTable,
+      maxRollups,
+      coalitionGroups
+    );
+  }
+
+  /**
+   * View-mode counterpart to the block-join path above. `this.table` is already
+   * one row per zone (the backend pre-aggregates demography per district — see
+   * document.district_unions), so population calculation is just deriving `zone`
+   * from `path` and percent columns; no assignments/join concept applies.
+   */
+  private calculatePopulationsFromZoneTable(
+    coalitionGroups: CoalitionGroupKey[]
+  ): {ok: true; table: SummaryTable} | {ok: false} {
+    if (!this.table) {
+      return {ok: false};
+    }
+    const columns = this.table.columnNames();
+    const populationsTable = this.table
+      .derive({
+        zone: escape((row: TableRow) => (row.path === '__unassigned__' ? null : +row.path)),
+      })
+      .derive(getPctDerives(columns));
+
+    const maxRollups = populationsTable
+      .rollup(getRollups(columns, 'max'))
+      .objects()[0] as MaxValues;
+
+    return this.finalizePopulations(
+      populationsTable.objects() as SummaryTable,
+      maxRollups,
+      coalitionGroups
+    );
+  }
+
+  /**
+   * Shared tail of both population-calculation paths: fills in zero rows for
+   * unpainted/unassigned zones, applies coalition columns, sorts, and updates
+   * zoneStats/summaryStats derived from the final per-zone table.
+   */
+  private finalizePopulations(
+    zonePopulationsTable: SummaryTable,
+    maxRollups: MaxValues | undefined,
+    coalitionGroups: CoalitionGroupKey[]
+  ): {ok: true; table: SummaryTable} {
+    const mapState = useMapStore.getState();
+    const mapMode = useMapControlsStore.getState().mapMode;
+    const zoneIds =
+      mapMode === MAP_MODES.COI
+        ? sortCommunitiesByRenderOrder(mapState.communities).map(community => community.id)
+        : Array.from(
+            {length: mapState.mapDocument?.num_districts ?? FALLBACK_NUM_DISTRICTS},
+            (_, i) => i + 1
+          );
+
     if (maxRollups) {
       this.zoneStats.maxValues = maxRollups as MaxValues & Record<string, number>;
     }
-    const zonePopulationsTable = populationsTable.objects() as SummaryTable;
     const populatedZoneIds = new Set(
       zonePopulationsTable
         .map(row => row.zone)


### PR DESCRIPTION
In view mode (a public/read-only plan view), toggling any demographic coalition checkbox made the population chart go blank; unchecking it didn't restore the original numbers either. Draw/edit mode was unaffected.

View mode fed demography through the same block-level assignment/join pipeline edit mode uses, via a fabricated identity-assignment map built in `PublicSource.tsx`. Every later population recompute triggered by the coalition builder (a checkbox toggle) called `updatePopulations()` with no `zoneAssignments` arg, which fell back to the live assignment stores — empty in view mode, since view mode never populates them for performance. The join against an empty zone table zeroed out every district's population, and `PopulationChart` skips rendering any bar with `total_pop_20 <= 0`.

**Fix:** the backend already returns fully-aggregated per-district demography (`document.district_unions` sums every numeric gerrydb column per zone, including race/ethnicity columns). Give view mode its own population-assembly path in `DemographyService` that uses that data directly — no block/zone join, no assignments concept, no live-store dependency — so a coalition toggle in view mode is a pure recompute over already-fetched data.

## Tested

- [x] `bun run ts` and `bun run build` clean.
- [x] Local seed data, public view `/map/311` (CA custom districts, 72k+ real assignments): population chart renders on load, coalition checkbox toggle updates bars/numbers per-district, unchecking restores totals.
- [x] Draw mode: coalition toggle still updates the population chart correctly (its code path, `calculatePopulations`'s non-public branch, is unchanged by this diff — not independently re-run).
