### PR TITLE
Drop outdated frontpage caveat about limited-state availability

### DIFF
--- a/app/src/app/(static)/page.tsx
+++ b/app/src/app/(static)/page.tsx
@@ -57,7 +57,7 @@ const Main: React.FC = () => {
           >
             <Flex direction={'column'}>
               <Heading size="6" as="h3" className="text-purple-700 mb-4">
-                You can draw districts (in limited states)
+                You can draw districts
               </Heading>
               <Text size="5">
                 In the U.S., there&apos;s a big redistricting cycle every 10 years after new Census


### PR DESCRIPTION
## Summary
- Remove "(in limited states)" from the frontpage heading "You can draw districts" — all modules are populated now, so the caveat no longer applies.

## Test plan
- [x] Visual: verified the string change in [app/src/app/(static)/page.tsx](app/src/app/(static)/page.tsx)