### PR TITLE
Add a Total column to the demography table; fix nested scrollbar and dark-cell text contrast

### DIFF
--- a/app/src/app/components/EvalPanel/PartisanSection.tsx
+++ b/app/src/app/components/EvalPanel/PartisanSection.tsx
@@ -8,6 +8,7 @@ import {formatElectionKey} from '@/app/utils/elections';
 import {formatNumber} from '@/app/utils/numbers';
 import {NUMBER_FORMATS} from '@/app/constants/demography/format';
 import {PovSwitcher, type Pov} from '@components/Shared/PovSwitcher';
+import {getReadableTextColor} from '@/app/utils/colors';
 
 interface PartisanSectionProps {
   evaluation: DocumentEvaluation;
@@ -43,6 +44,14 @@ const scaledBg = (value: number | undefined, cutoff: number) => {
   if (value > 0) return demBg(alpha);
   if (value < 0) return repBg(alpha);
   return undefined;
+};
+
+// Mirrors scaledBg's alpha calculation so cells near MAX_ALPHA (dark) get
+// readable white text instead of the default dark text.
+const scaledTextColor = (value: number | undefined, cutoff: number) => {
+  if (value == null) return undefined;
+  const alpha = Math.min(Math.abs(value) / cutoff, 1.0) * MAX_ALPHA;
+  return getReadableTextColor(value > 0 ? DEM : REP, alpha);
 };
 
 function dispLabel(disp: number, numDistricts: number): string {
@@ -242,6 +251,7 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                             justify="center"
                             style={{
                               backgroundColor: scaledBg(rawDisp ?? undefined, METRIC_CUTOFF.disp),
+                              color: scaledTextColor(rawDisp ?? undefined, METRIC_CUTOFF.disp),
                             }}
                           >
                             <Text size="2">
@@ -326,6 +336,10 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                               evaluation.disproportionality?.[key],
                               METRIC_CUTOFF.disp
                             ),
+                            color: scaledTextColor(
+                              evaluation.disproportionality?.[key],
+                              METRIC_CUTOFF.disp
+                            ),
                           }}
                         >
                           <Text size="2">
@@ -339,6 +353,10 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                           justify="center"
                           style={{
                             backgroundColor: scaledBg(
+                              evaluation.efficiency_gap?.[key],
+                              METRIC_CUTOFF.efficiency_gap
+                            ),
+                            color: scaledTextColor(
                               evaluation.efficiency_gap?.[key],
                               METRIC_CUTOFF.efficiency_gap
                             ),
@@ -358,6 +376,10 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                               evaluation.mean_median?.[key],
                               METRIC_CUTOFF.mean_median
                             ),
+                            color: scaledTextColor(
+                              evaluation.mean_median?.[key],
+                              METRIC_CUTOFF.mean_median
+                            ),
                           }}
                         >
                           <Text size="2">
@@ -374,6 +396,10 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                               evaluation.partisan_bias?.[key],
                               METRIC_CUTOFF.partisan_bias
                             ),
+                            color: scaledTextColor(
+                              evaluation.partisan_bias?.[key],
+                              METRIC_CUTOFF.partisan_bias
+                            ),
                           }}
                         >
                           <Text size="2">
@@ -387,6 +413,7 @@ export const PartisanSection: React.FC<PartisanSectionProps> = ({evaluation}) =>
                           justify="center"
                           style={{
                             backgroundColor: scaledBg(evaluation.eguia?.[key], METRIC_CUTOFF.eguia),
+                            color: scaledTextColor(evaluation.eguia?.[key], METRIC_CUTOFF.eguia),
                           }}
                         >
                           <Text size="2">

--- a/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
+++ b/app/src/app/components/Map/Tooltip/InspectorTooltip.tsx
@@ -4,7 +4,7 @@ import {formatNumber} from '@utils/numbers';
 import {useTooltipStore} from '@store/tooltipStore';
 import {demographyService} from '@/app/utils/demography/demographyService';
 import {useEffect, useMemo, useState} from 'react';
-import {CONFIG_BY_COLUMN_SET} from '@store/demography/evaluationConfig';
+import {CONFIG_BY_COLUMN_SET} from '@store/demography/demographyTableConfig';
 import {PARTISAN_SCALE} from '@store/demography/constants';
 import {previousHoverFeatures as hoverFeatures} from '@/app/utils/map/hoverFeatures';
 import {SUMMARY_TYPES, TOTAL_COLUMN} from '@constants/demography/summary';

--- a/app/src/app/components/Toolbar/ToolControls/InspectorControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/InspectorControls.tsx
@@ -1,5 +1,5 @@
 import {useTooltipStore} from '@store/tooltipStore';
-import {CONFIG_BY_COLUMN_SET} from '@store/demography/evaluationConfig';
+import {CONFIG_BY_COLUMN_SET} from '@store/demography/demographyTableConfig';
 import {demographyService} from '@/app/utils/demography/demographyService';
 import {useEffect} from 'react';
 import {Flex, Heading, Button} from '@radix-ui/themes';

--- a/app/src/app/components/sidebar/ConditionalScrollArea.tsx
+++ b/app/src/app/components/sidebar/ConditionalScrollArea.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import {ScrollArea} from '@radix-ui/themes';
 
-// Radix's overlay scrollbar (see the `type="always"` note below) reserves no
-// gutter of its own — it renders on top of the viewport's right edge. This
-// padding gives it a dead zone to sit in instead of overlapping the
-// rightmost column's data, and doubles as breathing room between this inner
-// scrollbar and the sidebar's own outer scrollbar (DataCards/Sidebar), which
-// otherwise sit close enough together that grabbing the outer one means
-// first scrolling the inner list all the way to its end.
-const SCROLLBAR_GUTTER = '1rem';
+// Radix's overlay scrollbar (see the `type="always"` note below) renders as a
+// sibling of the scrollable viewport, at the ScrollArea's own box edge — not
+// as part of the scrolled content. Two separate reservations are needed:
+//   1. Padding *inside* the viewport's content, so the scrollbar (which still
+//      sits at the ScrollArea's right edge) doesn't overlap the rightmost
+//      column's data.
+//   2. Shrinking the ScrollArea's own box width, so that edge — and the
+//      scrollbar rendered on it — sits inboard of the sidebar's own outer
+//      scrollbar (DataCards/Sidebar), leaving a real gap between the two
+//      scrollbar tracks. Padding inside the content (1) has no effect on this
+//      — it doesn't move the ScrollArea box itself.
+const DATA_GUTTER = '0.75rem';
+const OUTER_SCROLLBAR_GAP = '0.75rem';
 
 export const ConditionalScrollArea: React.FC<{
   children: React.ReactNode;
@@ -24,9 +29,9 @@ export const ConditionalScrollArea: React.FC<{
         type="always"
         size="2"
         className="flex-grow-1"
-        style={{maxHeight}}
+        style={{maxHeight, width: `calc(100% - ${OUTER_SCROLLBAR_GAP})`}}
       >
-        <div style={{paddingRight: SCROLLBAR_GUTTER, boxSizing: 'border-box', width: '100%'}}>
+        <div style={{paddingRight: DATA_GUTTER, boxSizing: 'border-box', width: '100%'}}>
           {children}
         </div>
       </ScrollArea>

--- a/app/src/app/components/sidebar/ConditionalScrollArea.tsx
+++ b/app/src/app/components/sidebar/ConditionalScrollArea.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import {ScrollArea} from '@radix-ui/themes';
 
+// Radix's overlay scrollbar (see the `type="always"` note below) reserves no
+// gutter of its own — it renders on top of the viewport's right edge. This
+// padding gives it a dead zone to sit in instead of overlapping the
+// rightmost column's data, and doubles as breathing room between this inner
+// scrollbar and the sidebar's own outer scrollbar (DataCards/Sidebar), which
+// otherwise sit close enough together that grabbing the outer one means
+// first scrolling the inner list all the way to its end.
+const SCROLLBAR_GUTTER = '1rem';
+
 export const ConditionalScrollArea: React.FC<{
   children: React.ReactNode;
   shouldUseScrollableRows: boolean;
@@ -17,7 +26,9 @@ export const ConditionalScrollArea: React.FC<{
         className="flex-grow-1"
         style={{maxHeight}}
       >
-        {children}
+        <div style={{paddingRight: SCROLLBAR_GUTTER, boxSizing: 'border-box', width: '100%'}}>
+          {children}
+        </div>
       </ScrollArea>
     );
   }

--- a/app/src/app/components/sidebar/DemographyTable/DemographyTable.tsx
+++ b/app/src/app/components/sidebar/DemographyTable/DemographyTable.tsx
@@ -526,7 +526,12 @@ const DemographyTableCell: React.FC<DemographyTableCellProps> = ({
         color: textColor,
       }}
     >
-      {numericValue === undefined
+      {/* An empty/unpainted district has no data for the Total column's underlying
+          zone, which arrives as a real 0 (needed elsewhere for chart scaling and
+          min/max stats) rather than undefined — display it the same as "no data"
+          (`--`) so it doesn't read as a legitimate zero, and so TOTPOP and VAP
+          render consistently for the same empty district. */}
+      {numericValue === undefined || (isTotalColumn && numericValue === 0)
         ? '--'
         : formatNumber(numericValue, isTotalColumn ? NUMBER_FORMATS.STRING : numberFormat)}
     </Table.Cell>

--- a/app/src/app/components/sidebar/DemographyTable/DemographyTable.tsx
+++ b/app/src/app/components/sidebar/DemographyTable/DemographyTable.tsx
@@ -23,7 +23,7 @@ import {
   modeButtonConfig,
   numberFormats,
   summaryStatLabels,
-} from '@/app/store/demography/evaluationConfig';
+} from '@/app/store/demography/demographyTableConfig';
 import {GearIcon, InfoCircledIcon} from '@radix-ui/react-icons';
 import {useColorScheme} from '@/app/hooks/useColorScheme';
 import {demographyService} from '@/app/utils/demography/demographyService';
@@ -42,20 +42,26 @@ import {
   isCoalitionUniverse,
   TOTAL_COLUMN,
 } from '@constants/demography/summary';
-import {type NumberFormat} from '@constants/demography/format';
-import {EVAL_MODES, type EvalMode} from '@constants/demography/evalMode';
+import {NUMBER_FORMATS, type NumberFormat} from '@constants/demography/format';
+import {
+  TABLE_DISPLAY_MODES,
+  type TableDisplayMode,
+} from '@constants/demography/demographyTableMode';
 import {MAP_MODES} from '@constants/map/mode';
 import {PovSwitcher, type Pov} from '@components/Shared/PovSwitcher';
 import {ConditionalScrollArea} from '../ConditionalScrollArea';
+import {getReadableTextColor} from '@/app/utils/colors';
 
 type ColumnConfig = {
   label: string;
   column: string;
   sourceCol?: string;
   tooltip?: string;
+  /** Denominator column: always a raw count, never shaded, never a share of itself. */
+  isTotal?: boolean;
 };
 
-type EvaluationProps = {
+type DemographyTableProps = {
   summaryType: SummaryType;
   setSummaryType: (summaryType: SummaryType) => void;
   displayedColumnSets?: Array<SummaryType>;
@@ -65,18 +71,18 @@ type EvaluationProps = {
   universeTotals?: SummaryRecord | null;
 };
 
-type EvaluationDataRow = SummaryRecord | Record<string, string | number | boolean>;
+type DemographyTableDataRow = SummaryRecord | Record<string, string | number | boolean>;
 
-type EvaluationTableHeaderProps = {
+type DemographyTableHeaderProps = {
   columnConfigs: ColumnConfig[];
   zoneHeader?: string;
 };
 
-type EvaluationTableBodyProps = {
-  rows: EvaluationDataRow[];
+type DemographyTableBodyProps = {
+  rows: DemographyTableDataRow[];
   colorScheme: string[];
   columnConfigs: ColumnConfig[];
-  evalMode: EvalMode;
+  evalMode: TableDisplayMode;
   colorBg: boolean;
   summaryType: SummaryType;
   numberFormat: NumberFormat;
@@ -87,12 +93,12 @@ type EvaluationTableBodyProps = {
   pov: Pov;
 };
 
-type EvaluationTableRowProps = Omit<EvaluationTableBodyProps, 'rows'> & {
-  row: EvaluationDataRow;
+type DemographyTableRowProps = Omit<DemographyTableBodyProps, 'rows'> & {
+  row: DemographyTableDataRow;
 };
 
-type EvaluationTableCellProps = Omit<
-  EvaluationTableRowProps,
+type DemographyTableCellProps = Omit<
+  DemographyTableRowProps,
   'columnConfigs' | 'colorScheme' | 'mapMode' | 'communities' | 'getZoneColor'
 > & {
   columnConfig: ColumnConfig;
@@ -135,7 +141,7 @@ function buildUniverseRow({
   return row;
 }
 
-const Evaluation: React.FC<EvaluationProps> = ({
+const DemographyTable: React.FC<DemographyTableProps> = ({
   summaryType,
   setSummaryType,
   displayedColumnSets,
@@ -144,7 +150,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
   singleZone,
   universeTotals,
 }) => {
-  const [evalMode, setEvalMode] = useState<EvalMode>(EVAL_MODES.SHARE);
+  const [evalMode, setEvalMode] = useState<TableDisplayMode>(TABLE_DISPLAY_MODES.SHARE);
   const [colorBg, setColorBg] = useState<boolean>(true);
   const [showUnassigned, setShowUnassigned] = useState<boolean>(true);
   const [pov, setPov] = useState<Pov>('dem');
@@ -217,7 +223,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
         })
       : undefined;
 
-  const baseRows: EvaluationDataRow[] = (() => {
+  const baseRows: DemographyTableDataRow[] = (() => {
     if (singleZone != null) {
       const filtered = zoneData.filter(r => r.zone === singleZone);
       return [...filtered, ...(universeRow ? [universeRow] : [])];
@@ -282,7 +288,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
                   <SegmentedControl.Root
                     size="1"
                     value={evalMode}
-                    onValueChange={v => setEvalMode(v as EvalMode)}
+                    onValueChange={v => setEvalMode(v as TableDisplayMode)}
                   >
                     {modeButtonConfig.map((mode, i) => (
                       <SegmentedControl.Item key={i} value={mode.value}>
@@ -324,11 +330,11 @@ const Evaluation: React.FC<EvaluationProps> = ({
       <ConditionalScrollArea shouldUseScrollableRows={rows.length > 10} maxHeight="60vh">
         <Box overflowX="auto" className="text-sm">
           <Table.Root className="min-w-full border-collapse">
-            <EvaluationTableHeader
+            <DemographyTableHeader
               columnConfigs={effectiveColumnConfigs}
               zoneHeader={mapMode === MAP_MODES.COI ? 'Community' : 'District'}
             />
-            <EvaluationTableBody
+            <DemographyTableBody
               rows={rows}
               colorScheme={colorScheme}
               columnConfigs={effectiveColumnConfigs}
@@ -348,7 +354,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
     </Box>
   );
 };
-const EvaluationTableHeader: React.FC<EvaluationTableHeaderProps> = ({
+const DemographyTableHeader: React.FC<DemographyTableHeaderProps> = ({
   columnConfigs,
   zoneHeader = 'District',
 }) => {
@@ -381,11 +387,11 @@ const EvaluationTableHeader: React.FC<EvaluationTableHeaderProps> = ({
   );
 };
 
-const EvaluationTableBody: React.FC<EvaluationTableBodyProps> = ({rows, ...props}) => {
+const DemographyTableBody: React.FC<DemographyTableBodyProps> = ({rows, ...props}) => {
   return (
     <Table.Body>
       {rows.map(row => (
-        <EvaluationTableRow
+        <DemographyTableRow
           // Stable per-row key so React reconciles correctly when the rows
           // array is re-ordered (e.g., universe/unassigned swap). Array-index
           // keys would otherwise force re-mounts / miss updates. Unassigned
@@ -405,7 +411,7 @@ const EvaluationTableBody: React.FC<EvaluationTableBodyProps> = ({rows, ...props
   );
 };
 
-const EvaluationTableRow: React.FC<EvaluationTableRowProps> = ({
+const DemographyTableRow: React.FC<DemographyTableRowProps> = ({
   row,
   colorScheme,
   columnConfigs,
@@ -448,7 +454,7 @@ const EvaluationTableRow: React.FC<EvaluationTableRowProps> = ({
       </Table.Cell>
       {!!columnConfigs &&
         columnConfigs.map(columnConfig => (
-          <EvaluationTableCell
+          <DemographyTableCell
             key={columnConfig.column}
             row={row}
             evalMode={evalMode}
@@ -466,7 +472,7 @@ const EvaluationTableRow: React.FC<EvaluationTableRowProps> = ({
   );
 };
 
-const EvaluationTableCell: React.FC<EvaluationTableCellProps> = ({
+const DemographyTableCell: React.FC<DemographyTableCellProps> = ({
   row,
   evalMode,
   columnConfig,
@@ -478,28 +484,36 @@ const EvaluationTableCell: React.FC<EvaluationTableCellProps> = ({
   maxValues,
   pov,
 }) => {
-  const column = evalMode === EVAL_MODES.COUNT ? columnConfig.column : `${columnConfig.column}_pct`;
+  const isTotalColumn = Boolean(columnConfig.isTotal);
+  const column = isTotalColumn
+    ? columnConfig.column
+    : evalMode === TABLE_DISPLAY_MODES.COUNT
+      ? columnConfig.column
+      : `${columnConfig.column}_pct`;
   const value = (row as Record<string, number | undefined>)[column];
   const numericValue = typeof value === 'number' && Number.isFinite(value) ? value : undefined;
   let colorValue: number | undefined;
-  if (numericValue !== undefined) {
+  if (numericValue !== undefined && !isTotalColumn) {
     colorValue =
-      evalMode === EVAL_MODES.COUNT && maxValues[column] !== 0
+      evalMode === TABLE_DISPLAY_MODES.COUNT && maxValues[column] !== 0
         ? numericValue / maxValues[column]
         : numericValue;
   }
   const hasValidColorValue =
     colorValue !== undefined && typeof colorValue === 'number' && Number.isFinite(colorValue);
   let backgroundColor: string | undefined;
-  if (!hasValidColorValue || isUniverse) {
+  let textColor: string | undefined;
+  if (!hasValidColorValue || isUniverse || isTotalColumn) {
   } else if (colorBg && summaryType === SUMMARY_TYPES.VOTERHISTORY) {
     // Diverging red <- white -> blue keyed to the two-party dem share, matching
     // the choropleth map; identical coloring in either POV.
-    backgroundColor = PARTISAN_SCALE(pov === 'dem' ? numericValue! : 1 - numericValue!);
+    const partisanValue = pov === 'dem' ? numericValue! : 1 - numericValue!;
+    backgroundColor = PARTISAN_SCALE(partisanValue);
+    textColor = getReadableTextColor(backgroundColor, 1);
   } else if (colorBg && !isUnassigned) {
-    backgroundColor = interpolateGreys(colorValue as number)
-      .replace('rgb', 'rgba')
-      .replace(')', ',0.5)');
+    const greyColor = interpolateGreys(colorValue as number);
+    backgroundColor = greyColor.replace('rgb', 'rgba').replace(')', ',0.5)');
+    textColor = getReadableTextColor(greyColor, 0.5);
   } else {
     backgroundColor = 'initial';
   }
@@ -509,10 +523,13 @@ const EvaluationTableCell: React.FC<EvaluationTableCellProps> = ({
       className={`py-1 px-2 align-middle text-right ${isUniverse ? 'font-semibold' : ''}`}
       style={{
         backgroundColor,
+        color: textColor,
       }}
     >
-      {numericValue === undefined ? '--' : formatNumber(numericValue, numberFormat)}
+      {numericValue === undefined
+        ? '--'
+        : formatNumber(numericValue, isTotalColumn ? NUMBER_FORMATS.STRING : numberFormat)}
     </Table.Cell>
   );
 };
-export default Evaluation;
+export default DemographyTable;

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -105,11 +105,18 @@ export default function SidebarComponent() {
         <ToolbarInSidebar />
         <CoiCommunityViewer />
         <MapContextComment />
+        {/* Negative right margin bleeds this ScrollArea's box (and the Radix
+            scrollbar rendered at its edge) out past the sidebar's own `p-3`
+            padding, out to the sidebar's true right edge — flush against the
+            browser window, the easiest target to grab (no need to aim short
+            of the edge). Matching padding-right inside keeps DataCards'
+            visual inset the same as before; only the scrollbar moved. */}
         <StyledScrollArea
           className="size-full overflow-y-auto flex-grow-1 max-w-full"
           scrollbars="vertical"
+          style={{marginRight: '-0.75rem'}}
         >
-          <Flex direction="column" gap="3" className="w-full">
+          <Flex direction="column" gap="3" className="w-full" style={{paddingRight: '0.75rem'}}>
             <Box
               display={{
                 initial: 'none',

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -32,7 +32,7 @@ export default function SidebarComponent() {
   return (
     <div
       className="
-      p-3
+      pt-3 pb-3 pl-3
       z-10 flex-none
       border-t lg:border-t-0
       lg:h-screen
@@ -102,19 +102,24 @@ export default function SidebarComponent() {
         </Draggable>
       </div>
       <Flex direction="column" gap="3" className="size-full">
-        <ToolbarInSidebar />
-        <CoiCommunityViewer />
-        <MapContextComment />
-        {/* Negative right margin bleeds this ScrollArea's box (and the Radix
-            scrollbar rendered at its edge) out past the sidebar's own `p-3`
-            padding, out to the sidebar's true right edge — flush against the
-            browser window, the easiest target to grab (no need to aim short
-            of the edge). Matching padding-right inside keeps DataCards'
+        <div className="flex flex-col gap-3 pr-3">
+          <ToolbarInSidebar />
+          <CoiCommunityViewer />
+          <MapContextComment />
+        </div>
+        {/* The sidebar's outer padding (above) deliberately excludes the right
+            side, so this ScrollArea's own box — and the Radix scrollbar
+            rendered at its edge, a sibling of the scrolled content, not a
+            descendant — extends all the way to the sidebar's true right edge:
+            flush against the browser window, the easiest possible target to
+            grab. `--scrollarea-scrollbar-vertical-margin-right` is zeroed too
+            so Radix's own built-in scrollbar margin doesn't reintroduce a
+            gap. The inner padding-right on DataCards' wrapper below keeps its
             visual inset the same as before; only the scrollbar moved. */}
         <StyledScrollArea
           className="size-full overflow-y-auto flex-grow-1 max-w-full"
           scrollbars="vertical"
-          style={{marginRight: '-0.75rem'}}
+          style={{'--scrollarea-scrollbar-vertical-margin-right': '0px'} as React.CSSProperties}
         >
           <Flex direction="column" gap="3" className="w-full" style={{paddingRight: '0.75rem'}}>
             <Box

--- a/app/src/app/components/sidebar/SummaryPanel.tsx
+++ b/app/src/app/components/sidebar/SummaryPanel.tsx
@@ -1,5 +1,5 @@
 import {Blockquote, Button, Flex, Heading, Select, Text} from '@radix-ui/themes';
-import Evaluation from './Evaluation/Evaluation';
+import DemographyTable from './DemographyTable/DemographyTable';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
 import {useEffect, useState} from 'react';
 import {MapPanel} from './MapPanel';
@@ -90,6 +90,7 @@ export const SummaryPanel: React.FC<SummaryPanelProps> = ({
     column: string;
     sourceCol?: string;
     tooltip?: string;
+    isTotal?: boolean;
   }> = (() => {
     if (!summaryType || !baseColumnConfig) return [];
     if (summaryType !== SUMMARY_TYPES.TOTPOP && summaryType !== SUMMARY_TYPES.VAP)
@@ -185,7 +186,7 @@ export const SummaryPanel: React.FC<SummaryPanelProps> = ({
             </Flex>
           )}
           {sectionOpen('evaluation') && (
-            <Evaluation
+            <DemographyTable
               summaryType={summaryType}
               setSummaryType={setSummaryType}
               columnConfigs={columnConfigs}

--- a/app/src/app/constants/demography/demographyTableMode.ts
+++ b/app/src/app/constants/demography/demographyTableMode.ts
@@ -1,0 +1,7 @@
+export const TABLE_DISPLAY_MODES = {
+  SHARE: 'share',
+  COUNT: 'count',
+  TOTPOP: 'totpop',
+} as const;
+
+export type TableDisplayMode = (typeof TABLE_DISPLAY_MODES)[keyof typeof TABLE_DISPLAY_MODES];

--- a/app/src/app/constants/demography/demographyTableMode.ts
+++ b/app/src/app/constants/demography/demographyTableMode.ts
@@ -1,7 +1,6 @@
 export const TABLE_DISPLAY_MODES = {
   SHARE: 'share',
   COUNT: 'count',
-  TOTPOP: 'totpop',
 } as const;
 
 export type TableDisplayMode = (typeof TABLE_DISPLAY_MODES)[keyof typeof TABLE_DISPLAY_MODES];

--- a/app/src/app/constants/demography/evalMode.ts
+++ b/app/src/app/constants/demography/evalMode.ts
@@ -1,7 +1,0 @@
-export const EVAL_MODES = {
-  SHARE: 'share',
-  COUNT: 'count',
-  TOTPOP: 'totpop',
-} as const;
-
-export type EvalMode = (typeof EVAL_MODES)[keyof typeof EVAL_MODES];

--- a/app/src/app/store/demography/demographyTableConfig.ts
+++ b/app/src/app/store/demography/demographyTableConfig.ts
@@ -1,11 +1,19 @@
-import {EvalColumnConfiguration, SummaryStatConfig} from '@/app/utils/api/summaryStats';
+import {DemographyTableColumnConfiguration, SummaryStatConfig} from '@/app/utils/api/summaryStats';
 import {SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
 import {NUMBER_FORMATS, type NumberFormat} from '@constants/demography/format';
-import {EVAL_MODES, type EvalMode} from '@constants/demography/evalMode';
+import {
+  TABLE_DISPLAY_MODES,
+  type TableDisplayMode,
+} from '@constants/demography/demographyTableMode';
 
-export const TOTPOPColumnConfig: EvalColumnConfiguration<
+export const TOTPOPColumnConfig: DemographyTableColumnConfiguration<
   SummaryStatConfig[typeof SUMMARY_TYPES.TOTPOP]
 > = [
+  {
+    label: 'Total',
+    column: 'total_pop_20',
+    isTotal: true,
+  },
   {
     label: 'Black',
     column: 'bpop_20',
@@ -32,18 +40,20 @@ export const TOTPOPColumnConfig: EvalColumnConfiguration<
   },
 ];
 
-export const VAPColumnConfig: EvalColumnConfiguration<SummaryStatConfig[typeof SUMMARY_TYPES.VAP]> =
-  [
-    {column: 'bvap_20', label: 'Black'},
-    {column: 'hvap_20', label: 'Hispanic'},
-    {column: 'amin_vap_20', label: 'AMIN'},
-    {column: 'asian_nhpi_vap_20', label: 'Asian'},
-    {column: 'white_vap_20', label: 'White'},
-    {column: 'other_vap_20', label: 'Other'},
-  ];
+export const VAPColumnConfig: DemographyTableColumnConfiguration<
+  SummaryStatConfig[typeof SUMMARY_TYPES.VAP]
+> = [
+  {label: 'Total', column: 'total_vap_20', isTotal: true},
+  {column: 'bvap_20', label: 'Black'},
+  {column: 'hvap_20', label: 'Hispanic'},
+  {column: 'amin_vap_20', label: 'AMIN'},
+  {column: 'asian_nhpi_vap_20', label: 'Asian'},
+  {column: 'white_vap_20', label: 'White'},
+  {column: 'other_vap_20', label: 'Other'},
+];
 // Columns are the Democratic candidate's votes; the table derives the raw
 // two-party share (X_dem_pct) and swaps to X_rep for the Republican POV.
-export const VoterColumnConfig: EvalColumnConfiguration<
+export const VoterColumnConfig: DemographyTableColumnConfiguration<
   SummaryStatConfig[typeof SUMMARY_TYPES.VOTERHISTORY]
 > = [
   {column: 'sen_22_dem', label: '2022 Sen'},
@@ -59,7 +69,7 @@ export const VoterColumnConfig: EvalColumnConfiguration<
 
 export const CONFIG_BY_COLUMN_SET: Record<
   SummaryType,
-  EvalColumnConfiguration<SummaryStatConfig[SummaryType]>
+  DemographyTableColumnConfiguration<SummaryStatConfig[SummaryType]>
 > = {
   TOTPOP: TOTPOPColumnConfig,
   VAP: VAPColumnConfig,
@@ -67,48 +77,48 @@ export const CONFIG_BY_COLUMN_SET: Record<
 };
 
 export const evalColumnConfigs: Partial<
-  Record<SummaryType, EvalColumnConfiguration<SummaryStatConfig[SummaryType]>>
+  Record<SummaryType, DemographyTableColumnConfiguration<SummaryStatConfig[SummaryType]>>
 > = {
   TOTPOP: TOTPOPColumnConfig,
   VAP: VAPColumnConfig,
   VOTERHISTORY: VoterColumnConfig,
 };
 
-export const modeButtonConfig: Array<{label: string; value: EvalMode}> = [
+export const modeButtonConfig: Array<{label: string; value: TableDisplayMode}> = [
   {
     label: 'Population by Share',
-    value: EVAL_MODES.SHARE,
+    value: TABLE_DISPLAY_MODES.SHARE,
   },
   {
     label: 'Population by Count',
-    value: EVAL_MODES.COUNT,
+    value: TABLE_DISPLAY_MODES.COUNT,
   },
 ];
 
-export const numberFormats: Record<EvalMode, NumberFormat> = {
-  [EVAL_MODES.SHARE]: NUMBER_FORMATS.PERCENT,
-  [EVAL_MODES.COUNT]: NUMBER_FORMATS.STRING,
-  [EVAL_MODES.TOTPOP]: NUMBER_FORMATS.PERCENT,
+export const numberFormats: Record<TableDisplayMode, NumberFormat> = {
+  [TABLE_DISPLAY_MODES.SHARE]: NUMBER_FORMATS.PERCENT,
+  [TABLE_DISPLAY_MODES.COUNT]: NUMBER_FORMATS.STRING,
+  [TABLE_DISPLAY_MODES.TOTPOP]: NUMBER_FORMATS.PERCENT,
 };
 
 export const summaryStatLabels: Array<{
   value: SummaryType;
   label: string;
-  supportedModes: EvalMode[];
+  supportedModes: TableDisplayMode[];
 }> = [
   {
     value: SUMMARY_TYPES.TOTPOP,
     label: 'Total population',
-    supportedModes: [EVAL_MODES.SHARE, EVAL_MODES.COUNT],
+    supportedModes: [TABLE_DISPLAY_MODES.SHARE, TABLE_DISPLAY_MODES.COUNT],
   },
   {
     value: SUMMARY_TYPES.VAP,
     label: 'Voting age population',
-    supportedModes: [EVAL_MODES.SHARE, EVAL_MODES.COUNT],
+    supportedModes: [TABLE_DISPLAY_MODES.SHARE, TABLE_DISPLAY_MODES.COUNT],
   },
   {
     value: SUMMARY_TYPES.VOTERHISTORY,
     label: 'Voter history',
-    supportedModes: [EVAL_MODES.SHARE],
+    supportedModes: [TABLE_DISPLAY_MODES.SHARE],
   },
 ];

--- a/app/src/app/store/demography/demographyTableConfig.ts
+++ b/app/src/app/store/demography/demographyTableConfig.ts
@@ -10,11 +10,6 @@ export const TOTPOPColumnConfig: DemographyTableColumnConfiguration<
   SummaryStatConfig[typeof SUMMARY_TYPES.TOTPOP]
 > = [
   {
-    label: 'Total',
-    column: 'total_pop_20',
-    isTotal: true,
-  },
-  {
     label: 'Black',
     column: 'bpop_20',
   },
@@ -38,18 +33,23 @@ export const TOTPOPColumnConfig: DemographyTableColumnConfiguration<
     label: 'Other',
     column: 'other_pop_20',
   },
+  {
+    label: 'Total',
+    column: 'total_pop_20',
+    isTotal: true,
+  },
 ];
 
 export const VAPColumnConfig: DemographyTableColumnConfiguration<
   SummaryStatConfig[typeof SUMMARY_TYPES.VAP]
 > = [
-  {label: 'Total', column: 'total_vap_20', isTotal: true},
   {column: 'bvap_20', label: 'Black'},
   {column: 'hvap_20', label: 'Hispanic'},
   {column: 'amin_vap_20', label: 'AMIN'},
   {column: 'asian_nhpi_vap_20', label: 'Asian'},
   {column: 'white_vap_20', label: 'White'},
   {column: 'other_vap_20', label: 'Other'},
+  {label: 'Total', column: 'total_vap_20', isTotal: true},
 ];
 // Columns are the Democratic candidate's votes; the table derives the raw
 // two-party share (X_dem_pct) and swaps to X_rep for the Republican POV.
@@ -98,7 +98,6 @@ export const modeButtonConfig: Array<{label: string; value: TableDisplayMode}> =
 export const numberFormats: Record<TableDisplayMode, NumberFormat> = {
   [TABLE_DISPLAY_MODES.SHARE]: NUMBER_FORMATS.PERCENT,
   [TABLE_DISPLAY_MODES.COUNT]: NUMBER_FORMATS.STRING,
-  [TABLE_DISPLAY_MODES.TOTPOP]: NUMBER_FORMATS.PERCENT,
 };
 
 export const summaryStatLabels: Array<{

--- a/app/src/app/store/demography/types.ts
+++ b/app/src/app/store/demography/types.ts
@@ -1,4 +1,4 @@
-import {AllEvaluationConfigs, AllMapConfigs} from '@/app/utils/api/summaryStats';
+import {AllDemographyTableConfigs, AllMapConfigs} from '@/app/utils/api/summaryStats';
 import {type ScaleLinear, type ScaleSequential, type ScaleThreshold} from 'd3-scale';
 import {type MapStore} from '../mapStore';
 import {type CoalitionGroupKey, DemographyVariable} from '@constants/demography/coalition';
@@ -55,7 +55,7 @@ export interface DemographyStore {
   setCoalitionGroups: (groups: CoalitionGroupKey[]) => Promise<void>;
   resetCoalition: () => void;
   availableColumnSets: {
-    evaluation: Record<string, AllEvaluationConfigs>;
+    evaluation: Record<string, AllDemographyTableConfigs>;
     map: Record<string, AllMapConfigs>;
   };
   setAvailableColumnSets: (columnSets: Partial<DemographyStore['availableColumnSets']>) => void;

--- a/app/src/app/utils/api/summaryStats.ts
+++ b/app/src/app/utils/api/summaryStats.ts
@@ -12,10 +12,13 @@ export interface ColumnSet {
   sumColumn?: string;
 }
 
-export type EvalColumnConfiguration<T extends ColumnSet> = Array<{
+export type DemographyTableColumnConfiguration<T extends ColumnSet> = Array<{
   label: string;
   column: T['columns'][number];
   sourceCol?: T['columns'][number];
+  /** Denominator column (e.g. total_pop_20/total_vap_20): always rendered as a raw
+   *  count, never a share of itself, and never color-shaded. */
+  isTotal?: boolean;
 }>;
 
 export type MapColumnConfiguration<T extends ColumnSet> = Array<{
@@ -141,7 +144,9 @@ export const possibleDerivedColumns = Object.values(derivedColumnsConfig).flat()
 // DERIVED TYPES
 export type SummaryStatConfig = typeof summaryStatsConfig;
 export type AllTabularColumns = SummaryStatConfig[SummaryType]['columns'];
-export type AllEvaluationConfigs = EvalColumnConfiguration<SummaryStatConfig[SummaryType]>;
+export type AllDemographyTableConfigs = DemographyTableColumnConfiguration<
+  SummaryStatConfig[SummaryType]
+>;
 export type AllMapConfigs = MapColumnConfiguration<SummaryStatConfig[SummaryType]>;
 export type DemographyRow = {
   [key in AllTabularColumns[number]]: number;

--- a/app/src/app/utils/colors.ts
+++ b/app/src/app/utils/colors.ts
@@ -1,4 +1,42 @@
 import {colorScheme as DefaultColorScheme} from '@/app/constants/colors';
+
+/**
+ * Picks readable text color for a given background: 'white' if the background
+ * (blended toward white by 1 - alpha, since alpha'd cells sit on a white/
+ * near-white page background) is dark enough that default dark text would be
+ * hard to read, otherwise undefined (inherit the default dark text).
+ *
+ * `color` is the un-alpha'd base color (hex or `rgb(...)`) and `alpha` is
+ * supplied separately, rather than one pre-composed CSS string, so callers
+ * using CSS color-mix()/similar (not machine-parseable the way rgb()/hex are)
+ * can still pass their known base color + alpha directly.
+ */
+export function getReadableTextColor(color: string, alpha: number = 1): 'white' | undefined {
+  const rgb = parseColorToRgb(color);
+  if (!rgb) return undefined;
+  const [r, g, b] = rgb;
+  const blend = (channel: number) => channel * alpha + 255 * (1 - alpha);
+  const luminance = (0.299 * blend(r) + 0.587 * blend(g) + 0.114 * blend(b)) / 255;
+  return luminance < 0.55 ? 'white' : undefined;
+}
+
+function parseColorToRgb(color: string): [number, number, number] | null {
+  const rgbMatch = color.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i);
+  if (rgbMatch) {
+    const [, r, g, b] = rgbMatch;
+    return [Number(r), Number(g), Number(b)];
+  }
+  const hexMatch = color.match(/^#([0-9a-f]{6})$/i);
+  if (hexMatch) {
+    const hex = hexMatch[1];
+    return [
+      parseInt(hex.slice(0, 2), 16),
+      parseInt(hex.slice(2, 4), 16),
+      parseInt(hex.slice(4, 6), 16),
+    ];
+  }
+  return null;
+}
 export const extendColorArray = (
   colorArray: string[],
   numDistricts: number,

--- a/app/src/app/utils/demography/demographyService.ts
+++ b/app/src/app/utils/demography/demographyService.ts
@@ -41,7 +41,7 @@ import {
 } from '@/app/store/demography/constants';
 import {ColumnarTableData} from '../ParquetWorker/parquetWorker.types';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
-import {evalColumnConfigs} from '@/app/store/demography/evaluationConfig';
+import {evalColumnConfigs} from '@/app/store/demography/demographyTableConfig';
 import {
   SUMMARY_TYPES,
   COALITION_UNIVERSES,

--- a/app/src/app/utils/demography/getAvailableColumnSets.ts
+++ b/app/src/app/utils/demography/getAvailableColumnSets.ts
@@ -1,9 +1,9 @@
-import {evalColumnConfigs} from '@/app/store/demography/evaluationConfig';
+import {evalColumnConfigs} from '@/app/store/demography/demographyTableConfig';
 import {choroplethMapVariables} from '@/app/store/demography/constants';
-import {AllEvaluationConfigs, AllMapConfigs, AllTabularColumns} from '../api/summaryStats';
+import {AllDemographyTableConfigs, AllMapConfigs, AllTabularColumns} from '../api/summaryStats';
 
 export function getAvailableColumnSets(availableColumns: AllTabularColumns[number][]) {
-  const evaluation: Record<string, AllEvaluationConfigs> = Object.fromEntries(
+  const evaluation: Record<string, AllDemographyTableConfigs> = Object.fromEntries(
     Object.entries(evalColumnConfigs)
       .map(([key, config]) => [
         key,


### PR DESCRIPTION

Four related gaps in the demography sidebar's Table view.

### Missing Total column

The table showed each district's race/ethnicity breakdown but never the row's own denominator. Total population has a home in the District overview panel, but total voting-age population had no UI surface anywhere once on the VAP tab.

**Fix:** add a Total column (raw `total_pop_20`/`total_vap_20`) to the TOTPOP/VAP table configs — never color-shaded, unaffected by the share/count toggle.

### Scrollbar covering table data

The nested table's scrollbar overlapped the rightmost column's numbers.

**Fix:** reserve padding inside `ConditionalScrollArea`'s scrolled content so the scrollbar has empty space to sit in instead of overlapping the data.

### Scrollbars sitting too close together

The nested table's scrollbar sat close enough to the sidebar's own outer scrollbar that reaching the next panel meant scrolling the inner list all the way down first.

**Fix:** shrink `ConditionalScrollArea`'s `ScrollArea` box width, so its scrollbar — which Radix renders at that box's edge, a sibling of the scrolled content, not inside it — sits a real gap away from the sidebar's outer scrollbar (padding inside the content, the fix above, never moves the scrollbar itself; these are two different reservations). Separately, make the sidebar's own outer scrollbar (`Sidebar.tsx`) sit flush against the true window edge instead of a padding-width short of it — the easiest possible target to grab, and it further separates it from the inner scrollbars for free. Took three passes to actually land: padding inside scrolled content doesn't touch the scrollbar itself (sibling, not descendant); a negative margin to bleed the ScrollArea past its container's padding got closer but left a remainder, because Radix's own built-in scrollbar margin sits on top of any box-level offset; landed on not applying right padding to the container at all, restoring it only where content actually needs the inset, plus zeroing Radix's own scrollbar-margin variable directly.

### Unreadable text on dark cells

Cells shaded dark by "color cells by values" kept default dark text — hard to read against a dark background. The same bug independently existed in `PartisanSection.tsx` on the separate Map Evaluation page.

**Fix:** a shared `getReadableTextColor` helper, used in both the demography table and `PartisanSection`, so dark cells get white text.

Along the way, renamed `Evaluation.tsx` → `DemographyTable.tsx` (and its `EVAL_MODES`/`EvalColumnConfiguration`/`evaluationConfig.ts` neighbors) — it was colliding in name with the unrelated Map Evaluation page.

## Tested

- [x] `bun run ts`, `bun run build`, and `docker-compose up pre-commit` clean.
- [x] Total column renders correct raw counts on both TOTPOP and VAP tabs, matches the District overview panel's numbers, and the "Overall" row shows the correct statewide sum.
- [x] Scrollbar no longer overlaps the rightmost column's data.
- [x] Sidebar's outer scrollbar sits flush against the true window edge (mouse reaches it at the screen's rightmost pixel, maximized window) and the gap to the inner per-panel scrollbar reads as comfortable (visual check — third pass, see the Fix note above for why the first two didn't fully close this).
- [x] Dark cells get white text and light cells keep default dark text, in both the demography table's scales and `PartisanSection` on the Map Evaluation page.

## Review required

- Double check the tested items above with other maps.

