### PR TITLE
Fix map removal in Catalog

### DIFF
--- a/app/src/app/components/RecentMapsList.tsx
+++ b/app/src/app/components/RecentMapsList.tsx
@@ -464,8 +464,8 @@ const RecentMapCard: React.FC<{
           <CopyLinkDropdown editUrl={editUrl} publicUrl={publicUrl} />
           {!active && (
             <AlertDialog.Root>
-              <AlertDialog.Trigger>
-                <Tooltip content="Remove from list">
+              <Tooltip content="Remove from list">
+                <AlertDialog.Trigger>
                   <IconButton
                     variant="ghost"
                     color="gray"
@@ -475,8 +475,8 @@ const RecentMapCard: React.FC<{
                   >
                     <TrashIcon />
                   </IconButton>
-                </Tooltip>
-              </AlertDialog.Trigger>
+                </AlertDialog.Trigger>
+              </Tooltip>
               <AlertDialog.Content maxWidth="400px">
                 <AlertDialog.Title>Remove map</AlertDialog.Title>
                 <AlertDialog.Description>

--- a/app/src/app/components/RecentMapsList.tsx
+++ b/app/src/app/components/RecentMapsList.tsx
@@ -477,7 +477,7 @@ const RecentMapCard: React.FC<{
                   </IconButton>
                 </AlertDialog.Trigger>
               </Tooltip>
-              <AlertDialog.Content maxWidth="400px">
+              <AlertDialog.Content maxWidth="400px" onClick={e => e.stopPropagation()}>
                 <AlertDialog.Title>Remove map</AlertDialog.Title>
                 <AlertDialog.Description>
                   This will remove the map from your recent list. This cannot be undone.


### PR DESCRIPTION
The delete confirmation dialog never opened because AlertDialog.Trigger slotted its onClick onto the Tooltip component, which doesn't forward it to the IconButton. Swap the nesting so the Trigger slots directly onto the button, matching the working CopyLinkDropdown pattern.
