### PR TITLE
Hotfix: Set num_districts_modifiable: false on fixed v2 map modules

### DIFF
--- a/backend/management/configs/v2_backend_config.yml
+++ b/backend/management/configs/v2_backend_config.yml
@@ -563,6 +563,7 @@ districtr_maps:
   gerrydb_table_name: al_districtr_view_v2
   name: AL Congressional Districts (7)
   num_districts: 7
+  num_districts_modifiable: false
   parent_layer: al_districtr_vtd_view_v2
   tiles_s3_path: tilesets/al_districtr_view_v2.pmtiles
 - child_layer: al_districtr_block_view_v2
@@ -570,6 +571,7 @@ districtr_maps:
   gerrydb_table_name: al_districtr_view_v2
   name: AL State Senate Districts (35)
   num_districts: 35
+  num_districts_modifiable: false
   parent_layer: al_districtr_vtd_view_v2
   tiles_s3_path: tilesets/al_districtr_view_v2.pmtiles
 - child_layer: al_districtr_block_view_v2
@@ -577,6 +579,7 @@ districtr_maps:
   gerrydb_table_name: al_districtr_view_v2
   name: AL State House Districts (105)
   num_districts: 105
+  num_districts_modifiable: false
   parent_layer: al_districtr_vtd_view_v2
   tiles_s3_path: tilesets/al_districtr_view_v2.pmtiles
 - child_layer: ak_districtr_block_view_v2
@@ -584,6 +587,7 @@ districtr_maps:
   gerrydb_table_name: ak_districtr_view_v2
   name: AK State Senate Districts (20)
   num_districts: 20
+  num_districts_modifiable: false
   parent_layer: ak_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ak_districtr_view_v2.pmtiles
 - child_layer: ak_districtr_block_view_v2
@@ -591,6 +595,7 @@ districtr_maps:
   gerrydb_table_name: ak_districtr_view_v2
   name: AK State House Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: ak_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ak_districtr_view_v2.pmtiles
 - child_layer: az_districtr_block_view_v2
@@ -598,6 +603,7 @@ districtr_maps:
   gerrydb_table_name: az_districtr_view_v2
   name: AZ Congressional Districts (9)
   num_districts: 9
+  num_districts_modifiable: false
   parent_layer: az_districtr_vtd_view_v2
   tiles_s3_path: tilesets/az_districtr_view_v2.pmtiles
 - child_layer: az_districtr_block_view_v2
@@ -605,6 +611,7 @@ districtr_maps:
   gerrydb_table_name: az_districtr_view_v2
   name: AZ State Senate Districts (30)
   num_districts: 30
+  num_districts_modifiable: false
   parent_layer: az_districtr_vtd_view_v2
   tiles_s3_path: tilesets/az_districtr_view_v2.pmtiles
 - child_layer: az_districtr_block_view_v2
@@ -612,6 +619,7 @@ districtr_maps:
   gerrydb_table_name: az_districtr_view_v2
   name: AZ State House Districts (60)
   num_districts: 60
+  num_districts_modifiable: false
   parent_layer: az_districtr_vtd_view_v2
   tiles_s3_path: tilesets/az_districtr_view_v2.pmtiles
 - child_layer: ar_districtr_block_view_v2
@@ -619,6 +627,7 @@ districtr_maps:
   gerrydb_table_name: ar_districtr_view_v2
   name: AR Congressional Districts (4)
   num_districts: 4
+  num_districts_modifiable: false
   parent_layer: ar_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ar_districtr_view_v2.pmtiles
 - child_layer: ar_districtr_block_view_v2
@@ -626,6 +635,7 @@ districtr_maps:
   gerrydb_table_name: ar_districtr_view_v2
   name: AR State Senate Districts (35)
   num_districts: 35
+  num_districts_modifiable: false
   parent_layer: ar_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ar_districtr_view_v2.pmtiles
 - child_layer: ar_districtr_block_view_v2
@@ -633,6 +643,7 @@ districtr_maps:
   gerrydb_table_name: ar_districtr_view_v2
   name: AR State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: ar_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ar_districtr_view_v2.pmtiles
 - child_layer: ca_districtr_block_view_v2
@@ -640,6 +651,7 @@ districtr_maps:
   gerrydb_table_name: ca_districtr_view_v2
   name: CA Congressional Districts (52)
   num_districts: 52
+  num_districts_modifiable: false
   parent_layer: ca_districtr_bg_view_v2
   tiles_s3_path: tilesets/ca_districtr_view_v2.pmtiles
 - child_layer: ca_districtr_block_view_v2
@@ -647,6 +659,7 @@ districtr_maps:
   gerrydb_table_name: ca_districtr_view_v2
   name: CA State Senate Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: ca_districtr_bg_view_v2
   tiles_s3_path: tilesets/ca_districtr_view_v2.pmtiles
 - child_layer: ca_districtr_block_view_v2
@@ -654,6 +667,7 @@ districtr_maps:
   gerrydb_table_name: ca_districtr_view_v2
   name: CA State House Districts (80)
   num_districts: 80
+  num_districts_modifiable: false
   parent_layer: ca_districtr_bg_view_v2
   tiles_s3_path: tilesets/ca_districtr_view_v2.pmtiles
 - child_layer: co_districtr_block_view_v2
@@ -661,6 +675,7 @@ districtr_maps:
   gerrydb_table_name: co_districtr_view_v2
   name: CO Congressional Districts (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: co_districtr_vtd_view_v2
   tiles_s3_path: tilesets/co_districtr_view_v2.pmtiles
 - child_layer: co_districtr_block_view_v2
@@ -668,6 +683,7 @@ districtr_maps:
   gerrydb_table_name: co_districtr_view_v2
   name: CO State Senate Districts (35)
   num_districts: 35
+  num_districts_modifiable: false
   parent_layer: co_districtr_vtd_view_v2
   tiles_s3_path: tilesets/co_districtr_view_v2.pmtiles
 - child_layer: co_districtr_block_view_v2
@@ -675,6 +691,7 @@ districtr_maps:
   gerrydb_table_name: co_districtr_view_v2
   name: CO State House Districts (65)
   num_districts: 65
+  num_districts_modifiable: false
   parent_layer: co_districtr_vtd_view_v2
   tiles_s3_path: tilesets/co_districtr_view_v2.pmtiles
 - child_layer: ct_districtr_block_view_v2
@@ -682,6 +699,7 @@ districtr_maps:
   gerrydb_table_name: ct_districtr_view_v2
   name: CT Congressional Districts (5)
   num_districts: 5
+  num_districts_modifiable: false
   parent_layer: ct_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ct_districtr_view_v2.pmtiles
 - child_layer: ct_districtr_block_view_v2
@@ -689,6 +707,7 @@ districtr_maps:
   gerrydb_table_name: ct_districtr_view_v2
   name: CT State Senate Districts (36)
   num_districts: 36
+  num_districts_modifiable: false
   parent_layer: ct_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ct_districtr_view_v2.pmtiles
 - child_layer: ct_districtr_block_view_v2
@@ -696,6 +715,7 @@ districtr_maps:
   gerrydb_table_name: ct_districtr_view_v2
   name: CT State House Districts (151)
   num_districts: 151
+  num_districts_modifiable: false
   parent_layer: ct_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ct_districtr_view_v2.pmtiles
 - child_layer: de_districtr_block_view_v2
@@ -703,6 +723,7 @@ districtr_maps:
   gerrydb_table_name: de_districtr_view_v2
   name: DE State Senate Districts (21)
   num_districts: 21
+  num_districts_modifiable: false
   parent_layer: de_districtr_vtd_view_v2
   tiles_s3_path: tilesets/de_districtr_view_v2.pmtiles
 - child_layer: de_districtr_block_view_v2
@@ -710,6 +731,7 @@ districtr_maps:
   gerrydb_table_name: de_districtr_view_v2
   name: DE State House Districts (41)
   num_districts: 41
+  num_districts_modifiable: false
   parent_layer: de_districtr_vtd_view_v2
   tiles_s3_path: tilesets/de_districtr_view_v2.pmtiles
 - child_layer: fl_districtr_block_view_v2
@@ -717,6 +739,7 @@ districtr_maps:
   gerrydb_table_name: fl_districtr_view_v2
   name: FL Congressional Districts (28)
   num_districts: 28
+  num_districts_modifiable: false
   parent_layer: fl_districtr_vtd_view_v2
   tiles_s3_path: tilesets/fl_districtr_view_v2.pmtiles
 - child_layer: fl_districtr_block_view_v2
@@ -724,6 +747,7 @@ districtr_maps:
   gerrydb_table_name: fl_districtr_view_v2
   name: FL State Senate Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: fl_districtr_vtd_view_v2
   tiles_s3_path: tilesets/fl_districtr_view_v2.pmtiles
 - child_layer: fl_districtr_block_view_v2
@@ -731,6 +755,7 @@ districtr_maps:
   gerrydb_table_name: fl_districtr_view_v2
   name: FL State House Districts (120)
   num_districts: 120
+  num_districts_modifiable: false
   parent_layer: fl_districtr_vtd_view_v2
   tiles_s3_path: tilesets/fl_districtr_view_v2.pmtiles
 - child_layer: ga_districtr_block_view_v2
@@ -738,6 +763,7 @@ districtr_maps:
   gerrydb_table_name: ga_districtr_view_v2
   name: GA Congressional Districts (14)
   num_districts: 14
+  num_districts_modifiable: false
   parent_layer: ga_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ga_districtr_view_v2.pmtiles
 - child_layer: ga_districtr_block_view_v2
@@ -745,6 +771,7 @@ districtr_maps:
   gerrydb_table_name: ga_districtr_view_v2
   name: GA State Senate Districts (56)
   num_districts: 56
+  num_districts_modifiable: false
   parent_layer: ga_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ga_districtr_view_v2.pmtiles
 - child_layer: ga_districtr_block_view_v2
@@ -752,6 +779,7 @@ districtr_maps:
   gerrydb_table_name: ga_districtr_view_v2
   name: GA State House Districts (180)
   num_districts: 180
+  num_districts_modifiable: false
   parent_layer: ga_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ga_districtr_view_v2.pmtiles
 - child_layer: hi_districtr_block_view_v2
@@ -759,6 +787,7 @@ districtr_maps:
   gerrydb_table_name: hi_districtr_view_v2
   name: HI Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: hi_districtr_bg_view_v2
   tiles_s3_path: tilesets/hi_districtr_view_v2.pmtiles
 - child_layer: hi_districtr_block_view_v2
@@ -766,6 +795,7 @@ districtr_maps:
   gerrydb_table_name: hi_districtr_view_v2
   name: HI State Senate Districts (25)
   num_districts: 25
+  num_districts_modifiable: false
   parent_layer: hi_districtr_bg_view_v2
   tiles_s3_path: tilesets/hi_districtr_view_v2.pmtiles
 - child_layer: hi_districtr_block_view_v2
@@ -773,6 +803,7 @@ districtr_maps:
   gerrydb_table_name: hi_districtr_view_v2
   name: HI State House Districts (51)
   num_districts: 51
+  num_districts_modifiable: false
   parent_layer: hi_districtr_bg_view_v2
   tiles_s3_path: tilesets/hi_districtr_view_v2.pmtiles
 - child_layer: id_districtr_block_view_v2
@@ -780,6 +811,7 @@ districtr_maps:
   gerrydb_table_name: id_districtr_view_v2
   name: ID Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: id_districtr_vtd_view_v2
   tiles_s3_path: tilesets/id_districtr_view_v2.pmtiles
 - child_layer: id_districtr_block_view_v2
@@ -787,6 +819,7 @@ districtr_maps:
   gerrydb_table_name: id_districtr_view_v2
   name: ID State Senate Districts (35)
   num_districts: 35
+  num_districts_modifiable: false
   parent_layer: id_districtr_vtd_view_v2
   tiles_s3_path: tilesets/id_districtr_view_v2.pmtiles
 - child_layer: id_districtr_block_view_v2
@@ -794,6 +827,7 @@ districtr_maps:
   gerrydb_table_name: id_districtr_view_v2
   name: ID State House Districts (70)
   num_districts: 70
+  num_districts_modifiable: false
   parent_layer: id_districtr_vtd_view_v2
   tiles_s3_path: tilesets/id_districtr_view_v2.pmtiles
 - child_layer: il_districtr_block_view_v2
@@ -801,6 +835,7 @@ districtr_maps:
   gerrydb_table_name: il_districtr_view_v2
   name: IL Congressional Districts (17)
   num_districts: 17
+  num_districts_modifiable: false
   parent_layer: il_districtr_vtd_view_v2
   tiles_s3_path: tilesets/il_districtr_view_v2.pmtiles
 - child_layer: il_districtr_block_view_v2
@@ -808,6 +843,7 @@ districtr_maps:
   gerrydb_table_name: il_districtr_view_v2
   name: IL State Senate Districts (59)
   num_districts: 59
+  num_districts_modifiable: false
   parent_layer: il_districtr_vtd_view_v2
   tiles_s3_path: tilesets/il_districtr_view_v2.pmtiles
 - child_layer: il_districtr_block_view_v2
@@ -815,6 +851,7 @@ districtr_maps:
   gerrydb_table_name: il_districtr_view_v2
   name: IL State House Districts (118)
   num_districts: 118
+  num_districts_modifiable: false
   parent_layer: il_districtr_vtd_view_v2
   tiles_s3_path: tilesets/il_districtr_view_v2.pmtiles
 - child_layer: in_districtr_block_view_v2
@@ -822,6 +859,7 @@ districtr_maps:
   gerrydb_table_name: in_districtr_view_v2
   name: IN Congressional Districts (9)
   num_districts: 9
+  num_districts_modifiable: false
   parent_layer: in_districtr_vtd_view_v2
   tiles_s3_path: tilesets/in_districtr_view_v2.pmtiles
 - child_layer: in_districtr_block_view_v2
@@ -829,6 +867,7 @@ districtr_maps:
   gerrydb_table_name: in_districtr_view_v2
   name: IN State Senate Districts (50)
   num_districts: 50
+  num_districts_modifiable: false
   parent_layer: in_districtr_vtd_view_v2
   tiles_s3_path: tilesets/in_districtr_view_v2.pmtiles
 - child_layer: in_districtr_block_view_v2
@@ -836,6 +875,7 @@ districtr_maps:
   gerrydb_table_name: in_districtr_view_v2
   name: IN State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: in_districtr_vtd_view_v2
   tiles_s3_path: tilesets/in_districtr_view_v2.pmtiles
 - child_layer: ia_districtr_block_view_v2
@@ -843,6 +883,7 @@ districtr_maps:
   gerrydb_table_name: ia_districtr_view_v2
   name: IA Congressional Districts (4)
   num_districts: 4
+  num_districts_modifiable: false
   parent_layer: ia_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ia_districtr_view_v2.pmtiles
 - child_layer: ia_districtr_block_view_v2
@@ -850,6 +891,7 @@ districtr_maps:
   gerrydb_table_name: ia_districtr_view_v2
   name: IA State Senate Districts (50)
   num_districts: 50
+  num_districts_modifiable: false
   parent_layer: ia_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ia_districtr_view_v2.pmtiles
 - child_layer: ia_districtr_block_view_v2
@@ -857,6 +899,7 @@ districtr_maps:
   gerrydb_table_name: ia_districtr_view_v2
   name: IA State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: ia_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ia_districtr_view_v2.pmtiles
 - child_layer: ks_districtr_block_view_v2
@@ -864,6 +907,7 @@ districtr_maps:
   gerrydb_table_name: ks_districtr_view_v2
   name: KS Congressional Districts (4)
   num_districts: 4
+  num_districts_modifiable: false
   parent_layer: ks_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ks_districtr_view_v2.pmtiles
 - child_layer: ks_districtr_block_view_v2
@@ -871,6 +915,7 @@ districtr_maps:
   gerrydb_table_name: ks_districtr_view_v2
   name: KS State Senate Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: ks_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ks_districtr_view_v2.pmtiles
 - child_layer: ks_districtr_block_view_v2
@@ -878,6 +923,7 @@ districtr_maps:
   gerrydb_table_name: ks_districtr_view_v2
   name: KS State House Districts (125)
   num_districts: 125
+  num_districts_modifiable: false
   parent_layer: ks_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ks_districtr_view_v2.pmtiles
 - child_layer: ky_districtr_block_view_v2
@@ -885,6 +931,7 @@ districtr_maps:
   gerrydb_table_name: ky_districtr_view_v2
   name: KY Congressional Districts (6)
   num_districts: 6
+  num_districts_modifiable: false
   parent_layer: ky_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ky_districtr_view_v2.pmtiles
 - child_layer: ky_districtr_block_view_v2
@@ -892,6 +939,7 @@ districtr_maps:
   gerrydb_table_name: ky_districtr_view_v2
   name: KY State Senate Districts (38)
   num_districts: 38
+  num_districts_modifiable: false
   parent_layer: ky_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ky_districtr_view_v2.pmtiles
 - child_layer: ky_districtr_block_view_v2
@@ -899,6 +947,7 @@ districtr_maps:
   gerrydb_table_name: ky_districtr_view_v2
   name: KY State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: ky_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ky_districtr_view_v2.pmtiles
 - child_layer: la_districtr_block_view_v2
@@ -906,6 +955,7 @@ districtr_maps:
   gerrydb_table_name: la_districtr_view_v2
   name: LA Congressional Districts (6)
   num_districts: 6
+  num_districts_modifiable: false
   parent_layer: la_districtr_vtd_view_v2
   tiles_s3_path: tilesets/la_districtr_view_v2.pmtiles
 - child_layer: la_districtr_block_view_v2
@@ -913,6 +963,7 @@ districtr_maps:
   gerrydb_table_name: la_districtr_view_v2
   name: LA State Senate Districts (39)
   num_districts: 39
+  num_districts_modifiable: false
   parent_layer: la_districtr_vtd_view_v2
   tiles_s3_path: tilesets/la_districtr_view_v2.pmtiles
 - child_layer: la_districtr_block_view_v2
@@ -920,6 +971,7 @@ districtr_maps:
   gerrydb_table_name: la_districtr_view_v2
   name: LA State House Districts (105)
   num_districts: 105
+  num_districts_modifiable: false
   parent_layer: la_districtr_vtd_view_v2
   tiles_s3_path: tilesets/la_districtr_view_v2.pmtiles
 - child_layer: me_districtr_block_view_v2
@@ -927,6 +979,7 @@ districtr_maps:
   gerrydb_table_name: me_districtr_view_v2
   name: ME Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: me_districtr_bg_view_v2
   tiles_s3_path: tilesets/me_districtr_view_v2.pmtiles
 - child_layer: me_districtr_block_view_v2
@@ -934,6 +987,7 @@ districtr_maps:
   gerrydb_table_name: me_districtr_view_v2
   name: ME State Senate Districts (35)
   num_districts: 35
+  num_districts_modifiable: false
   parent_layer: me_districtr_bg_view_v2
   tiles_s3_path: tilesets/me_districtr_view_v2.pmtiles
 - child_layer: me_districtr_block_view_v2
@@ -941,6 +995,7 @@ districtr_maps:
   gerrydb_table_name: me_districtr_view_v2
   name: ME State House Districts (151)
   num_districts: 151
+  num_districts_modifiable: false
   parent_layer: me_districtr_bg_view_v2
   tiles_s3_path: tilesets/me_districtr_view_v2.pmtiles
 - child_layer: md_districtr_block_view_v2
@@ -948,6 +1003,7 @@ districtr_maps:
   gerrydb_table_name: md_districtr_view_v2
   name: MD Congressional Districts (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: md_districtr_vtd_view_v2
   tiles_s3_path: tilesets/md_districtr_view_v2.pmtiles
 - child_layer: md_districtr_block_view_v2
@@ -955,6 +1011,7 @@ districtr_maps:
   gerrydb_table_name: md_districtr_view_v2
   name: MD State Senate Districts (47)
   num_districts: 47
+  num_districts_modifiable: false
   parent_layer: md_districtr_vtd_view_v2
   tiles_s3_path: tilesets/md_districtr_view_v2.pmtiles
 - child_layer: md_districtr_block_view_v2
@@ -962,6 +1019,7 @@ districtr_maps:
   gerrydb_table_name: md_districtr_view_v2
   name: MD State House Districts (141)
   num_districts: 141
+  num_districts_modifiable: false
   parent_layer: md_districtr_vtd_view_v2
   tiles_s3_path: tilesets/md_districtr_view_v2.pmtiles
 - child_layer: ma_districtr_block_view_v2
@@ -969,6 +1027,7 @@ districtr_maps:
   gerrydb_table_name: ma_districtr_view_v2
   name: MA Congressional Districts (9)
   num_districts: 9
+  num_districts_modifiable: false
   parent_layer: ma_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ma_districtr_view_v2.pmtiles
 - child_layer: ma_districtr_block_view_v2
@@ -976,6 +1035,7 @@ districtr_maps:
   gerrydb_table_name: ma_districtr_view_v2
   name: MA State Senate Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: ma_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ma_districtr_view_v2.pmtiles
 - child_layer: ma_districtr_block_view_v2
@@ -983,6 +1043,7 @@ districtr_maps:
   gerrydb_table_name: ma_districtr_view_v2
   name: MA State House Districts (160)
   num_districts: 160
+  num_districts_modifiable: false
   parent_layer: ma_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ma_districtr_view_v2.pmtiles
 - child_layer: mi_districtr_block_view_v2
@@ -990,6 +1051,7 @@ districtr_maps:
   gerrydb_table_name: mi_districtr_view_v2
   name: MI Congressional Districts (13)
   num_districts: 13
+  num_districts_modifiable: false
   parent_layer: mi_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mi_districtr_view_v2.pmtiles
 - child_layer: mi_districtr_block_view_v2
@@ -997,6 +1059,7 @@ districtr_maps:
   gerrydb_table_name: mi_districtr_view_v2
   name: MI State Senate Districts (38)
   num_districts: 38
+  num_districts_modifiable: false
   parent_layer: mi_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mi_districtr_view_v2.pmtiles
 - child_layer: mi_districtr_block_view_v2
@@ -1004,6 +1067,7 @@ districtr_maps:
   gerrydb_table_name: mi_districtr_view_v2
   name: MI State House Districts (110)
   num_districts: 110
+  num_districts_modifiable: false
   parent_layer: mi_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mi_districtr_view_v2.pmtiles
 - child_layer: mn_districtr_block_view_v2
@@ -1011,6 +1075,7 @@ districtr_maps:
   gerrydb_table_name: mn_districtr_view_v2
   name: MN Congressional Districts (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: mn_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mn_districtr_view_v2.pmtiles
 - child_layer: mn_districtr_block_view_v2
@@ -1018,6 +1083,7 @@ districtr_maps:
   gerrydb_table_name: mn_districtr_view_v2
   name: MN State Senate Districts (67)
   num_districts: 67
+  num_districts_modifiable: false
   parent_layer: mn_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mn_districtr_view_v2.pmtiles
 - child_layer: mn_districtr_block_view_v2
@@ -1025,6 +1091,7 @@ districtr_maps:
   gerrydb_table_name: mn_districtr_view_v2
   name: MN State House Districts (134)
   num_districts: 134
+  num_districts_modifiable: false
   parent_layer: mn_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mn_districtr_view_v2.pmtiles
 - child_layer: ms_districtr_block_view_v2
@@ -1032,6 +1099,7 @@ districtr_maps:
   gerrydb_table_name: ms_districtr_view_v2
   name: MS Congressional Districts (4)
   num_districts: 4
+  num_districts_modifiable: false
   parent_layer: ms_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ms_districtr_view_v2.pmtiles
 - child_layer: ms_districtr_block_view_v2
@@ -1039,6 +1107,7 @@ districtr_maps:
   gerrydb_table_name: ms_districtr_view_v2
   name: MS State Senate Districts (52)
   num_districts: 52
+  num_districts_modifiable: false
   parent_layer: ms_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ms_districtr_view_v2.pmtiles
 - child_layer: ms_districtr_block_view_v2
@@ -1046,6 +1115,7 @@ districtr_maps:
   gerrydb_table_name: ms_districtr_view_v2
   name: MS State House Districts (122)
   num_districts: 122
+  num_districts_modifiable: false
   parent_layer: ms_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ms_districtr_view_v2.pmtiles
 - child_layer: mo_districtr_block_view_v2
@@ -1053,6 +1123,7 @@ districtr_maps:
   gerrydb_table_name: mo_districtr_view_v2
   name: MO Congressional Districts (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: mo_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mo_districtr_view_v2.pmtiles
 - child_layer: mo_districtr_block_view_v2
@@ -1060,6 +1131,7 @@ districtr_maps:
   gerrydb_table_name: mo_districtr_view_v2
   name: MO State Senate Districts (34)
   num_districts: 34
+  num_districts_modifiable: false
   parent_layer: mo_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mo_districtr_view_v2.pmtiles
 - child_layer: mo_districtr_block_view_v2
@@ -1067,6 +1139,7 @@ districtr_maps:
   gerrydb_table_name: mo_districtr_view_v2
   name: MO State House Districts (163)
   num_districts: 163
+  num_districts_modifiable: false
   parent_layer: mo_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mo_districtr_view_v2.pmtiles
 - child_layer: mt_districtr_block_view_v2
@@ -1074,6 +1147,7 @@ districtr_maps:
   gerrydb_table_name: mt_districtr_view_v2
   name: MT Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: mt_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mt_districtr_view_v2.pmtiles
 - child_layer: mt_districtr_block_view_v2
@@ -1081,6 +1155,7 @@ districtr_maps:
   gerrydb_table_name: mt_districtr_view_v2
   name: MT State Senate Districts (50)
   num_districts: 50
+  num_districts_modifiable: false
   parent_layer: mt_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mt_districtr_view_v2.pmtiles
 - child_layer: mt_districtr_block_view_v2
@@ -1088,6 +1163,7 @@ districtr_maps:
   gerrydb_table_name: mt_districtr_view_v2
   name: MT State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: mt_districtr_vtd_view_v2
   tiles_s3_path: tilesets/mt_districtr_view_v2.pmtiles
 - child_layer: ne_districtr_block_view_v2
@@ -1095,6 +1171,7 @@ districtr_maps:
   gerrydb_table_name: ne_districtr_view_v2
   name: NE Congressional Districts (3)
   num_districts: 3
+  num_districts_modifiable: false
   parent_layer: ne_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ne_districtr_view_v2.pmtiles
 - child_layer: ne_districtr_block_view_v2
@@ -1102,6 +1179,7 @@ districtr_maps:
   gerrydb_table_name: ne_districtr_view_v2
   name: NE State Senate Districts (49)
   num_districts: 49
+  num_districts_modifiable: false
   parent_layer: ne_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ne_districtr_view_v2.pmtiles
 - child_layer: nv_districtr_block_view_v2
@@ -1109,6 +1187,7 @@ districtr_maps:
   gerrydb_table_name: nv_districtr_view_v2
   name: NV Congressional Districts (4)
   num_districts: 4
+  num_districts_modifiable: false
   parent_layer: nv_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nv_districtr_view_v2.pmtiles
 - child_layer: nv_districtr_block_view_v2
@@ -1116,6 +1195,7 @@ districtr_maps:
   gerrydb_table_name: nv_districtr_view_v2
   name: NV State Senate Districts (21)
   num_districts: 21
+  num_districts_modifiable: false
   parent_layer: nv_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nv_districtr_view_v2.pmtiles
 - child_layer: nv_districtr_block_view_v2
@@ -1123,6 +1203,7 @@ districtr_maps:
   gerrydb_table_name: nv_districtr_view_v2
   name: NV State House Districts (42)
   num_districts: 42
+  num_districts_modifiable: false
   parent_layer: nv_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nv_districtr_view_v2.pmtiles
 - child_layer: nh_districtr_block_view_v2
@@ -1130,6 +1211,7 @@ districtr_maps:
   gerrydb_table_name: nh_districtr_view_v2
   name: NH Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: nh_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nh_districtr_view_v2.pmtiles
 - child_layer: nh_districtr_block_view_v2
@@ -1137,6 +1219,7 @@ districtr_maps:
   gerrydb_table_name: nh_districtr_view_v2
   name: NH State Senate Districts (24)
   num_districts: 24
+  num_districts_modifiable: false
   parent_layer: nh_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nh_districtr_view_v2.pmtiles
 - child_layer: nh_districtr_block_view_v2
@@ -1144,6 +1227,7 @@ districtr_maps:
   gerrydb_table_name: nh_districtr_view_v2
   name: NH State House Districts (400)
   num_districts: 400
+  num_districts_modifiable: false
   parent_layer: nh_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nh_districtr_view_v2.pmtiles
 - child_layer: nj_districtr_block_view_v2
@@ -1151,6 +1235,7 @@ districtr_maps:
   gerrydb_table_name: nj_districtr_view_v2
   name: NJ Congressional Districts (12)
   num_districts: 12
+  num_districts_modifiable: false
   parent_layer: nj_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nj_districtr_view_v2.pmtiles
 - child_layer: nj_districtr_block_view_v2
@@ -1158,6 +1243,7 @@ districtr_maps:
   gerrydb_table_name: nj_districtr_view_v2
   name: NJ State Senate Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: nj_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nj_districtr_view_v2.pmtiles
 - child_layer: nj_districtr_block_view_v2
@@ -1165,6 +1251,7 @@ districtr_maps:
   gerrydb_table_name: nj_districtr_view_v2
   name: NJ State House Districts (80)
   num_districts: 80
+  num_districts_modifiable: false
   parent_layer: nj_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nj_districtr_view_v2.pmtiles
 - child_layer: nm_districtr_block_view_v2
@@ -1172,6 +1259,7 @@ districtr_maps:
   gerrydb_table_name: nm_districtr_view_v2
   name: NM Congressional Districts (3)
   num_districts: 3
+  num_districts_modifiable: false
   parent_layer: nm_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nm_districtr_view_v2.pmtiles
 - child_layer: nm_districtr_block_view_v2
@@ -1179,6 +1267,7 @@ districtr_maps:
   gerrydb_table_name: nm_districtr_view_v2
   name: NM State Senate Districts (42)
   num_districts: 42
+  num_districts_modifiable: false
   parent_layer: nm_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nm_districtr_view_v2.pmtiles
 - child_layer: nm_districtr_block_view_v2
@@ -1186,6 +1275,7 @@ districtr_maps:
   gerrydb_table_name: nm_districtr_view_v2
   name: NM State House Districts (70)
   num_districts: 70
+  num_districts_modifiable: false
   parent_layer: nm_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nm_districtr_view_v2.pmtiles
 - child_layer: ny_districtr_block_view_v2
@@ -1193,6 +1283,7 @@ districtr_maps:
   gerrydb_table_name: ny_districtr_view_v2
   name: NY Congressional Districts (26)
   num_districts: 26
+  num_districts_modifiable: false
   parent_layer: ny_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ny_districtr_view_v2.pmtiles
 - child_layer: ny_districtr_block_view_v2
@@ -1200,6 +1291,7 @@ districtr_maps:
   gerrydb_table_name: ny_districtr_view_v2
   name: NY State Senate Districts (63)
   num_districts: 63
+  num_districts_modifiable: false
   parent_layer: ny_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ny_districtr_view_v2.pmtiles
 - child_layer: ny_districtr_block_view_v2
@@ -1207,6 +1299,7 @@ districtr_maps:
   gerrydb_table_name: ny_districtr_view_v2
   name: NY State House Districts (150)
   num_districts: 150
+  num_districts_modifiable: false
   parent_layer: ny_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ny_districtr_view_v2.pmtiles
 - child_layer: nc_districtr_block_view_v2
@@ -1214,6 +1307,7 @@ districtr_maps:
   gerrydb_table_name: nc_districtr_view_v2
   name: NC Congressional Districts (14)
   num_districts: 14
+  num_districts_modifiable: false
   parent_layer: nc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nc_districtr_view_v2.pmtiles
 - child_layer: nc_districtr_block_view_v2
@@ -1221,6 +1315,7 @@ districtr_maps:
   gerrydb_table_name: nc_districtr_view_v2
   name: NC State Senate Districts (50)
   num_districts: 50
+  num_districts_modifiable: false
   parent_layer: nc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nc_districtr_view_v2.pmtiles
 - child_layer: nc_districtr_block_view_v2
@@ -1228,6 +1323,7 @@ districtr_maps:
   gerrydb_table_name: nc_districtr_view_v2
   name: NC State House Districts (120)
   num_districts: 120
+  num_districts_modifiable: false
   parent_layer: nc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nc_districtr_view_v2.pmtiles
 - child_layer: nd_districtr_block_view_v2
@@ -1235,6 +1331,7 @@ districtr_maps:
   gerrydb_table_name: nd_districtr_view_v2
   name: ND State Senate Districts (47)
   num_districts: 47
+  num_districts_modifiable: false
   parent_layer: nd_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nd_districtr_view_v2.pmtiles
 - child_layer: nd_districtr_block_view_v2
@@ -1242,6 +1339,7 @@ districtr_maps:
   gerrydb_table_name: nd_districtr_view_v2
   name: ND State House Districts (94)
   num_districts: 94
+  num_districts_modifiable: false
   parent_layer: nd_districtr_vtd_view_v2
   tiles_s3_path: tilesets/nd_districtr_view_v2.pmtiles
 - child_layer: oh_districtr_block_view_v2
@@ -1249,6 +1347,7 @@ districtr_maps:
   gerrydb_table_name: oh_districtr_view_v2
   name: OH Congressional Districts (15)
   num_districts: 15
+  num_districts_modifiable: false
   parent_layer: oh_districtr_vtd_view_v2
   tiles_s3_path: tilesets/oh_districtr_view_v2.pmtiles
 - child_layer: oh_districtr_block_view_v2
@@ -1256,6 +1355,7 @@ districtr_maps:
   gerrydb_table_name: oh_districtr_view_v2
   name: OH State Senate Districts (33)
   num_districts: 33
+  num_districts_modifiable: false
   parent_layer: oh_districtr_vtd_view_v2
   tiles_s3_path: tilesets/oh_districtr_view_v2.pmtiles
 - child_layer: oh_districtr_block_view_v2
@@ -1263,6 +1363,7 @@ districtr_maps:
   gerrydb_table_name: oh_districtr_view_v2
   name: OH State House Districts (99)
   num_districts: 99
+  num_districts_modifiable: false
   parent_layer: oh_districtr_vtd_view_v2
   tiles_s3_path: tilesets/oh_districtr_view_v2.pmtiles
 - child_layer: ok_districtr_block_view_v2
@@ -1270,6 +1371,7 @@ districtr_maps:
   gerrydb_table_name: ok_districtr_view_v2
   name: OK Congressional Districts (5)
   num_districts: 5
+  num_districts_modifiable: false
   parent_layer: ok_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ok_districtr_view_v2.pmtiles
 - child_layer: ok_districtr_block_view_v2
@@ -1277,6 +1379,7 @@ districtr_maps:
   gerrydb_table_name: ok_districtr_view_v2
   name: OK State Senate Districts (48)
   num_districts: 48
+  num_districts_modifiable: false
   parent_layer: ok_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ok_districtr_view_v2.pmtiles
 - child_layer: ok_districtr_block_view_v2
@@ -1284,6 +1387,7 @@ districtr_maps:
   gerrydb_table_name: ok_districtr_view_v2
   name: OK State House Districts (101)
   num_districts: 101
+  num_districts_modifiable: false
   parent_layer: ok_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ok_districtr_view_v2.pmtiles
 - child_layer: or_districtr_block_view_v2
@@ -1291,6 +1395,7 @@ districtr_maps:
   gerrydb_table_name: or_districtr_view_v2
   name: OR Congressional Districts (6)
   num_districts: 6
+  num_districts_modifiable: false
   parent_layer: or_districtr_bg_view_v2
   tiles_s3_path: tilesets/or_districtr_view_v2.pmtiles
 - child_layer: or_districtr_block_view_v2
@@ -1298,6 +1403,7 @@ districtr_maps:
   gerrydb_table_name: or_districtr_view_v2
   name: OR State Senate Districts (30)
   num_districts: 30
+  num_districts_modifiable: false
   parent_layer: or_districtr_bg_view_v2
   tiles_s3_path: tilesets/or_districtr_view_v2.pmtiles
 - child_layer: or_districtr_block_view_v2
@@ -1305,6 +1411,7 @@ districtr_maps:
   gerrydb_table_name: or_districtr_view_v2
   name: OR State House Districts (60)
   num_districts: 60
+  num_districts_modifiable: false
   parent_layer: or_districtr_bg_view_v2
   tiles_s3_path: tilesets/or_districtr_view_v2.pmtiles
 - child_layer: pa_districtr_block_view_v2
@@ -1312,6 +1419,7 @@ districtr_maps:
   gerrydb_table_name: pa_districtr_view_v2
   name: PA Congressional Districts (17)
   num_districts: 17
+  num_districts_modifiable: false
   parent_layer: pa_districtr_vtd_view_v2
   tiles_s3_path: tilesets/pa_districtr_view_v2.pmtiles
 - child_layer: pa_districtr_block_view_v2
@@ -1319,6 +1427,7 @@ districtr_maps:
   gerrydb_table_name: pa_districtr_view_v2
   name: PA State Senate Districts (50)
   num_districts: 50
+  num_districts_modifiable: false
   parent_layer: pa_districtr_vtd_view_v2
   tiles_s3_path: tilesets/pa_districtr_view_v2.pmtiles
 - child_layer: pa_districtr_block_view_v2
@@ -1326,6 +1435,7 @@ districtr_maps:
   gerrydb_table_name: pa_districtr_view_v2
   name: PA State House Districts (203)
   num_districts: 203
+  num_districts_modifiable: false
   parent_layer: pa_districtr_vtd_view_v2
   tiles_s3_path: tilesets/pa_districtr_view_v2.pmtiles
 - child_layer: ri_districtr_block_view_v2
@@ -1333,6 +1443,7 @@ districtr_maps:
   gerrydb_table_name: ri_districtr_view_v2
   name: RI Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: ri_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ri_districtr_view_v2.pmtiles
 - child_layer: ri_districtr_block_view_v2
@@ -1340,6 +1451,7 @@ districtr_maps:
   gerrydb_table_name: ri_districtr_view_v2
   name: RI State Senate Districts (38)
   num_districts: 38
+  num_districts_modifiable: false
   parent_layer: ri_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ri_districtr_view_v2.pmtiles
 - child_layer: ri_districtr_block_view_v2
@@ -1347,6 +1459,7 @@ districtr_maps:
   gerrydb_table_name: ri_districtr_view_v2
   name: RI State House Districts (75)
   num_districts: 75
+  num_districts_modifiable: false
   parent_layer: ri_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ri_districtr_view_v2.pmtiles
 - child_layer: sc_districtr_block_view_v2
@@ -1354,6 +1467,7 @@ districtr_maps:
   gerrydb_table_name: sc_districtr_view_v2
   name: SC Congressional Districts (7)
   num_districts: 7
+  num_districts_modifiable: false
   parent_layer: sc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/sc_districtr_view_v2.pmtiles
 - child_layer: sc_districtr_block_view_v2
@@ -1361,6 +1475,7 @@ districtr_maps:
   gerrydb_table_name: sc_districtr_view_v2
   name: SC State Senate Districts (46)
   num_districts: 46
+  num_districts_modifiable: false
   parent_layer: sc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/sc_districtr_view_v2.pmtiles
 - child_layer: sc_districtr_block_view_v2
@@ -1368,6 +1483,7 @@ districtr_maps:
   gerrydb_table_name: sc_districtr_view_v2
   name: SC State House Districts (124)
   num_districts: 124
+  num_districts_modifiable: false
   parent_layer: sc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/sc_districtr_view_v2.pmtiles
 - child_layer: sd_districtr_block_view_v2
@@ -1375,6 +1491,7 @@ districtr_maps:
   gerrydb_table_name: sd_districtr_view_v2
   name: SD State Senate Districts (35)
   num_districts: 35
+  num_districts_modifiable: false
   parent_layer: sd_districtr_vtd_view_v2
   tiles_s3_path: tilesets/sd_districtr_view_v2.pmtiles
 - child_layer: sd_districtr_block_view_v2
@@ -1382,6 +1499,7 @@ districtr_maps:
   gerrydb_table_name: sd_districtr_view_v2
   name: SD State House Districts (70)
   num_districts: 70
+  num_districts_modifiable: false
   parent_layer: sd_districtr_vtd_view_v2
   tiles_s3_path: tilesets/sd_districtr_view_v2.pmtiles
 - child_layer: tn_districtr_block_view_v2
@@ -1389,6 +1507,7 @@ districtr_maps:
   gerrydb_table_name: tn_districtr_view_v2
   name: TN Congressional Districts (9)
   num_districts: 9
+  num_districts_modifiable: false
   parent_layer: tn_districtr_vtd_view_v2
   tiles_s3_path: tilesets/tn_districtr_view_v2.pmtiles
 - child_layer: tn_districtr_block_view_v2
@@ -1396,6 +1515,7 @@ districtr_maps:
   gerrydb_table_name: tn_districtr_view_v2
   name: TN State Senate Districts (33)
   num_districts: 33
+  num_districts_modifiable: false
   parent_layer: tn_districtr_vtd_view_v2
   tiles_s3_path: tilesets/tn_districtr_view_v2.pmtiles
 - child_layer: tn_districtr_block_view_v2
@@ -1403,6 +1523,7 @@ districtr_maps:
   gerrydb_table_name: tn_districtr_view_v2
   name: TN State House Districts (99)
   num_districts: 99
+  num_districts_modifiable: false
   parent_layer: tn_districtr_vtd_view_v2
   tiles_s3_path: tilesets/tn_districtr_view_v2.pmtiles
 - child_layer: tx_districtr_block_view_v2
@@ -1410,6 +1531,7 @@ districtr_maps:
   gerrydb_table_name: tx_districtr_view_v2
   name: TX Congressional Districts (38)
   num_districts: 38
+  num_districts_modifiable: false
   parent_layer: tx_districtr_vtd_view_v2
   tiles_s3_path: tilesets/tx_districtr_view_v2.pmtiles
 - child_layer: tx_districtr_block_view_v2
@@ -1417,6 +1539,7 @@ districtr_maps:
   gerrydb_table_name: tx_districtr_view_v2
   name: TX State Senate Districts (31)
   num_districts: 31
+  num_districts_modifiable: false
   parent_layer: tx_districtr_vtd_view_v2
   tiles_s3_path: tilesets/tx_districtr_view_v2.pmtiles
 - child_layer: tx_districtr_block_view_v2
@@ -1424,6 +1547,7 @@ districtr_maps:
   gerrydb_table_name: tx_districtr_view_v2
   name: TX State House Districts (150)
   num_districts: 150
+  num_districts_modifiable: false
   parent_layer: tx_districtr_vtd_view_v2
   tiles_s3_path: tilesets/tx_districtr_view_v2.pmtiles
 - child_layer: ut_districtr_block_view_v2
@@ -1431,6 +1555,7 @@ districtr_maps:
   gerrydb_table_name: ut_districtr_view_v2
   name: UT Congressional Districts (4)
   num_districts: 4
+  num_districts_modifiable: false
   parent_layer: ut_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ut_districtr_view_v2.pmtiles
 - child_layer: ut_districtr_block_view_v2
@@ -1438,6 +1563,7 @@ districtr_maps:
   gerrydb_table_name: ut_districtr_view_v2
   name: UT State Senate Districts (29)
   num_districts: 29
+  num_districts_modifiable: false
   parent_layer: ut_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ut_districtr_view_v2.pmtiles
 - child_layer: ut_districtr_block_view_v2
@@ -1445,6 +1571,7 @@ districtr_maps:
   gerrydb_table_name: ut_districtr_view_v2
   name: UT State House Districts (75)
   num_districts: 75
+  num_districts_modifiable: false
   parent_layer: ut_districtr_vtd_view_v2
   tiles_s3_path: tilesets/ut_districtr_view_v2.pmtiles
 - child_layer: vt_districtr_block_view_v2
@@ -1452,6 +1579,7 @@ districtr_maps:
   gerrydb_table_name: vt_districtr_view_v2
   name: VT State Senate Districts (30)
   num_districts: 30
+  num_districts_modifiable: false
   parent_layer: vt_districtr_vtd_view_v2
   tiles_s3_path: tilesets/vt_districtr_view_v2.pmtiles
 - child_layer: vt_districtr_block_view_v2
@@ -1459,6 +1587,7 @@ districtr_maps:
   gerrydb_table_name: vt_districtr_view_v2
   name: VT State House Districts (150)
   num_districts: 150
+  num_districts_modifiable: false
   parent_layer: vt_districtr_vtd_view_v2
   tiles_s3_path: tilesets/vt_districtr_view_v2.pmtiles
 - child_layer: va_districtr_block_view_v2
@@ -1466,6 +1595,7 @@ districtr_maps:
   gerrydb_table_name: va_districtr_view_v2
   name: VA Congressional Districts (11)
   num_districts: 11
+  num_districts_modifiable: false
   parent_layer: va_districtr_vtd_view_v2
   tiles_s3_path: tilesets/va_districtr_view_v2.pmtiles
 - child_layer: va_districtr_block_view_v2
@@ -1473,6 +1603,7 @@ districtr_maps:
   gerrydb_table_name: va_districtr_view_v2
   name: VA State Senate Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: va_districtr_vtd_view_v2
   tiles_s3_path: tilesets/va_districtr_view_v2.pmtiles
 - child_layer: va_districtr_block_view_v2
@@ -1480,6 +1611,7 @@ districtr_maps:
   gerrydb_table_name: va_districtr_view_v2
   name: VA State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: va_districtr_vtd_view_v2
   tiles_s3_path: tilesets/va_districtr_view_v2.pmtiles
 - child_layer: wa_districtr_block_view_v2
@@ -1487,6 +1619,7 @@ districtr_maps:
   gerrydb_table_name: wa_districtr_view_v2
   name: WA Congressional Districts (10)
   num_districts: 10
+  num_districts_modifiable: false
   parent_layer: wa_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wa_districtr_view_v2.pmtiles
 - child_layer: wa_districtr_block_view_v2
@@ -1494,6 +1627,7 @@ districtr_maps:
   gerrydb_table_name: wa_districtr_view_v2
   name: WA State Senate Districts (49)
   num_districts: 49
+  num_districts_modifiable: false
   parent_layer: wa_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wa_districtr_view_v2.pmtiles
 - child_layer: wa_districtr_block_view_v2
@@ -1501,6 +1635,7 @@ districtr_maps:
   gerrydb_table_name: wa_districtr_view_v2
   name: WA State House Districts (98)
   num_districts: 98
+  num_districts_modifiable: false
   parent_layer: wa_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wa_districtr_view_v2.pmtiles
 - child_layer: wv_districtr_block_view_v2
@@ -1508,6 +1643,7 @@ districtr_maps:
   gerrydb_table_name: wv_districtr_view_v2
   name: WV Congressional Districts (2)
   num_districts: 2
+  num_districts_modifiable: false
   parent_layer: wv_districtr_bg_view_v2
   tiles_s3_path: tilesets/wv_districtr_view_v2.pmtiles
 - child_layer: wv_districtr_block_view_v2
@@ -1515,6 +1651,7 @@ districtr_maps:
   gerrydb_table_name: wv_districtr_view_v2
   name: WV State Senate Districts (34)
   num_districts: 34
+  num_districts_modifiable: false
   parent_layer: wv_districtr_bg_view_v2
   tiles_s3_path: tilesets/wv_districtr_view_v2.pmtiles
 - child_layer: wv_districtr_block_view_v2
@@ -1522,6 +1659,7 @@ districtr_maps:
   gerrydb_table_name: wv_districtr_view_v2
   name: WV State House Districts (100)
   num_districts: 100
+  num_districts_modifiable: false
   parent_layer: wv_districtr_bg_view_v2
   tiles_s3_path: tilesets/wv_districtr_view_v2.pmtiles
 - child_layer: wi_districtr_block_view_v2
@@ -1529,6 +1667,7 @@ districtr_maps:
   gerrydb_table_name: wi_districtr_view_v2
   name: WI Congressional Districts (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: wi_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wi_districtr_view_v2.pmtiles
 - child_layer: wi_districtr_block_view_v2
@@ -1536,6 +1675,7 @@ districtr_maps:
   gerrydb_table_name: wi_districtr_view_v2
   name: WI State Senate Districts (33)
   num_districts: 33
+  num_districts_modifiable: false
   parent_layer: wi_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wi_districtr_view_v2.pmtiles
 - child_layer: wi_districtr_block_view_v2
@@ -1543,6 +1683,7 @@ districtr_maps:
   gerrydb_table_name: wi_districtr_view_v2
   name: WI State House Districts (99)
   num_districts: 99
+  num_districts_modifiable: false
   parent_layer: wi_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wi_districtr_view_v2.pmtiles
 - child_layer: wy_districtr_block_view_v2
@@ -1550,6 +1691,7 @@ districtr_maps:
   gerrydb_table_name: wy_districtr_view_v2
   name: WY State Senate Districts (31)
   num_districts: 31
+  num_districts_modifiable: false
   parent_layer: wy_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wy_districtr_view_v2.pmtiles
 - child_layer: wy_districtr_block_view_v2
@@ -1557,6 +1699,7 @@ districtr_maps:
   gerrydb_table_name: wy_districtr_view_v2
   name: WY State House Districts (62)
   num_districts: 62
+  num_districts_modifiable: false
   parent_layer: wy_districtr_vtd_view_v2
   tiles_s3_path: tilesets/wy_districtr_view_v2.pmtiles
 - child_layer: dc_districtr_block_view_v2
@@ -1564,6 +1707,7 @@ districtr_maps:
   gerrydb_table_name: dc_districtr_view_v2
   name: DC Council Wards (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: dc_districtr_vtd_view_v2
   tiles_s3_path: tilesets/dc_districtr_view_v2.pmtiles
 # PR's Legislative Assembly also seats 11 senators and 11 representatives
@@ -1574,6 +1718,7 @@ districtr_maps:
   gerrydb_table_name: pr_districtr_view_v2
   name: PR Senate Districts (8)
   num_districts: 8
+  num_districts_modifiable: false
   parent_layer: pr_districtr_vtd_view_v2
   tiles_s3_path: tilesets/pr_districtr_view_v2.pmtiles
 - child_layer: pr_districtr_block_view_v2
@@ -1581,6 +1726,7 @@ districtr_maps:
   gerrydb_table_name: pr_districtr_view_v2
   name: PR House Districts (40)
   num_districts: 40
+  num_districts_modifiable: false
   parent_layer: pr_districtr_vtd_view_v2
   tiles_s3_path: tilesets/pr_districtr_view_v2.pmtiles
 


### PR DESCRIPTION
The fixed legislative modules (congressional/senate/house) omitted the flag, so the loader's DistrictrMapPublic default made them modifiable. Custom maps keep their explicit true.