### PR TITLE
Fix ideal_population on maps with a user-modified district count

### DIFF
--- a/backend/app/evaluation/context.py
+++ b/backend/app/evaluation/context.py
@@ -209,13 +209,29 @@ class DocumentEvaluationContext:
 
     @cached_property
     def ideal_population(self) -> int:
-        """Ideal population per district (total population ÷ map's number of districts)."""
-        num_districts = self._districtr_map.num_districts
+        """Ideal population per district (total population ÷ document's number of districts).
+
+        Falls back to the map's default when the document has not set its own
+        (e.g. `num_districts_modifiable` maps let the document override the map default).
+        """
+        num_districts = (
+            self._document.num_districts or self._districtr_map.num_districts
+        )
         if not num_districts:
-            raise ValueError(
-                f"DistrictrMap for document '{self.document_id}' has no num_districts set."
-            )
+            raise ValueError(f"Document '{self.document_id}' has no num_districts set.")
         return self.total_population // num_districts
+
+    @cached_property
+    def _document(self) -> Document:
+        """The Document row associated with this evaluation context."""
+        d = self.session.exec(
+            sqlmodel.select(Document).where(
+                sqlmodel.col(Document.document_id) == self.document_id
+            )
+        ).one_or_none()
+        if d is None:
+            raise ValueError(f"No Document found for document_id '{self.document_id}'.")
+        return d
 
     @cached_property
     def _districtr_map(self) -> DistrictrMap:

--- a/backend/app/evaluation/registry.py
+++ b/backend/app/evaluation/registry.py
@@ -87,7 +87,7 @@ METRICS: tuple[Metric[Any], ...] = (
     Metric[CompetitiveMetrics](
         key="competitiveness", version=1, compute=partisans.competitive_metrics
     ),
-    Metric[int](key="ideal_population", version=1, compute=validity.ideal_population),
+    Metric[int](key="ideal_population", version=2, compute=validity.ideal_population),
     Metric[dict[CountyGeoid, CountyPiecesInfo]](
         key="county_pieces", version=1, compute=splits.county_pieces
     ),
@@ -104,7 +104,7 @@ METRICS: tuple[Metric[Any], ...] = (
     ),
     Metric[dict[DistrictId, float]](key="reock", version=1, compute=compactness.reock),
     Metric[PopulationDeviationResults](
-        key="population_deviation", version=2, compute=validity.population_deviation
+        key="population_deviation", version=3, compute=validity.population_deviation
     ),
     Metric[AssignedUnitsResult](
         key="assigned_units", version=3, compute=validity.assigned_units

--- a/backend/tests/test_validity_metrics.py
+++ b/backend/tests/test_validity_metrics.py
@@ -325,6 +325,50 @@ def test_population_deviation(
     assert result["maximal_absolute_deviation"] == 350
 
 
+def test_population_deviation_uses_document_num_districts_override(
+    client, session: Session, simple_child_geos_nonshatterable_districtr_map
+):
+    """A document-level num_districts override (modifiable map) must change
+    population_deviation, not just ideal_population in isolation.
+
+    Same assignments/populations as test_population_deviation (zone 1=1400,
+    zone 2=700, total=2100) but the document overrides num_districts to 3
+    (map default is 2). ideal = 2100 // 3 = 700, so:
+        top_to_bottom_deviation = (1400-700)/700 = 1.0   (was 2/3 with ideal=1050)
+        maximal_absolute_deviation = max(|1400-700|, |700-700|) = 700  (was 350)
+    """
+    resp = client.post(
+        "/api/create_document", json={"districtr_map_slug": "simple_child_ns"}
+    )
+    assert resp.status_code == 201
+    document_id = resp.json()["document_id"]
+
+    _put_assignments(
+        client,
+        document_id,
+        [
+            ["000010000000001", 1],
+            ["000010000000002", 1],
+            ["000010000000003", 2],
+            ["000010000000004", 2],
+            ["000010000000005", 1],
+            ["000010000000006", 1],
+        ],
+    )
+
+    resp = client.put(f"/api/document/{document_id}/num_districts?num_districts=3")
+    assert resp.status_code == 200
+    session.expire_all()
+
+    ctx = DocumentEvaluationContext(
+        background_tasks=BackgroundTasks(), session=session, document_id=document_id
+    )
+    result = population_deviation(ctx)
+
+    assert result["top_to_bottom_deviation"] == pytest.approx(1.0, abs=1e-6)
+    assert result["maximal_absolute_deviation"] == 700
+
+
 # ── ideal_population ──────────────────────────────────────────────────────────
 
 
@@ -357,6 +401,36 @@ def test_ideal_population_uses_map_num_districts_not_assigned_count(
         background_tasks=BackgroundTasks(), session=session, document_id=document_id
     )
     assert ideal_population(ctx) == 1050
+
+
+def test_ideal_population_uses_document_override_on_modifiable_map(
+    client, session: Session, simple_child_geos_nonshatterable_districtr_map
+):
+    """On a num_districts_modifiable map, a document-level override must win over
+    the map's default num_districts (2) — total_pop=2100 // 3 = 700, not // 2 = 1050."""
+    resp = client.post(
+        "/api/create_document", json={"districtr_map_slug": "simple_child_ns"}
+    )
+    assert resp.status_code == 201
+    document_id = resp.json()["document_id"]
+    _put_assignments(
+        client,
+        document_id,
+        [
+            ["000010000000001", 1],
+            ["000010000000002", 1],
+            ["000010000000003", 1],
+        ],
+    )
+
+    resp = client.put(f"/api/document/{document_id}/num_districts?num_districts=3")
+    assert resp.status_code == 200
+    session.expire_all()
+
+    ctx = DocumentEvaluationContext(
+        background_tasks=BackgroundTasks(), session=session, document_id=document_id
+    )
+    assert ideal_population(ctx) == 700
 
 
 # ── malformed state: parent and children coexist in assignments ───────────────


### PR DESCRIPTION
`DocumentEvaluationContext.ideal_population` (`backend/app/evaluation/context.py`) divided total population by `DistrictrMap.num_districts` — the map's static default — regardless of what the user actually set. On a `num_districts_modifiable` map, the real district count lives on `Document.num_districts`, which the frontend lets users change per plan. Any document that overrode the count got `ideal_population` (and the `population_deviation` metric that depends on it) computed against the wrong denominator.

**Fix:** coalesce `Document.num_districts` over `DistrictrMap.num_districts`, matching the same pattern already used in `dependencies.py` and `main.py` for reading the effective district count elsewhere in the backend.

Added regression tests in `test_validity_metrics.py` covering both the `ideal_population` and `population_deviation` metrics under a document-level override, alongside the existing map-default-only case.

Also bumped the `ideal_population` and `population_deviation` metric versions in `registry.py`, since existing cached evaluation rows computed the old (map-default-only) value — this forces recomputation on next read instead of serving stale numbers.
