### PR TITLE
Render district numbers above population numbers at shared centroids

### DIFF
--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -4,6 +4,7 @@ import {
   SELECTION_POINTS_SOURCE_ID_CHILD,
   ZONE_LABEL_SOURCE_ID,
   ZONE_LABEL_LAYER_IDS,
+  MAP_LAYER_ANCHOR_IDS,
 } from '@/app/constants/map/layerIds';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
 import {useMapStore} from '@/app/store/mapStore';
@@ -21,9 +22,9 @@ import {FilterSpecification} from 'maplibre-gl';
 export const MetaLayers: React.FC<{isDemographicMap?: boolean}> = ({isDemographicMap}) => {
   return (
     <>
+      {!isDemographicMap && <ZoneNumbersLayer />}
       <PopulationTextLayer />
       <PopulationTextLayer child />
-      {!isDemographicMap && <ZoneNumbersLayer />}
     </>
   );
 };
@@ -79,6 +80,7 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
       id={`POPULATION_TEXT_${child ? 'CHILD' : 'PARENT'}`}
       type="symbol"
       source={child ? SELECTION_POINTS_SOURCE_ID_CHILD : SELECTION_POINTS_SOURCE_ID}
+      beforeId={MAP_LAYER_ANCHOR_IDS.reference}
       filter={populationFilter}
       layout={{
         'text-field': ['get', 'total_pop_20'],

--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -38,6 +38,12 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
   const showPopulationNumbers = useMapControlsStore(
     state => state.mapOptions.showPopulationNumbers
   );
+  // ZoneNumbersLayer renders under this same condition, at the same
+  // centroids — nudge population numbers clear of the district-number
+  // circle so the two never visually collide.
+  const showZoneNumbers = useMapControlsStore(state => state.mapOptions.showZoneNumbers);
+  const showPaintedDistricts = useMapControlsStore(state => state.mapOptions.showPaintedDistricts);
+  const avoidsZoneNumber = showZoneNumbers && showPaintedDistricts;
 
   // Create filter based on which population numbers to show
   const populationFilter = useMemo<FilterSpecification>(() => {
@@ -99,7 +105,9 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
           28,
         ],
         'text-anchor': 'center',
-        'text-offset': [0, 0],
+        // In ems, so it scales with text-size same as the district-number
+        // circle scales with zoom — keeps clearance consistent.
+        'text-offset': avoidsZoneNumber ? [0, 1.6] : [0, 0],
         // padding
         'text-padding': 0,
         'text-allow-overlap': ['step', ['zoom'], false, 12, true],

--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -243,7 +243,7 @@ const ZoneNumbersLayer = () => {
         paint={{
           'circle-color': '#fff',
           'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 10, 10, 15, 15, 18],
-          'circle-opacity': 0.8,
+          'circle-opacity': 0.9,
           'circle-stroke-color': ZONE_LABEL_STYLE(colorScheme) || '#000',
           'circle-stroke-width': ['interpolate', ['linear'], ['zoom'], 5, 1.5, 15, 2.5],
         }}

--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -38,12 +38,6 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
   const showPopulationNumbers = useMapControlsStore(
     state => state.mapOptions.showPopulationNumbers
   );
-  // ZoneNumbersLayer renders under this same condition, at the same
-  // centroids — nudge population numbers clear of the district-number
-  // circle so the two never visually collide.
-  const showZoneNumbers = useMapControlsStore(state => state.mapOptions.showZoneNumbers);
-  const showPaintedDistricts = useMapControlsStore(state => state.mapOptions.showPaintedDistricts);
-  const avoidsZoneNumber = showZoneNumbers && showPaintedDistricts;
 
   // Create filter based on which population numbers to show
   const populationFilter = useMemo<FilterSpecification>(() => {
@@ -105,9 +99,7 @@ const PopulationTextLayer: React.FC<{child?: boolean}> = ({child = false}) => {
           28,
         ],
         'text-anchor': 'center',
-        // In ems, so it scales with text-size same as the district-number
-        // circle scales with zoom — keeps clearance consistent.
-        'text-offset': avoidsZoneNumber ? [0, 1.6] : [0, 0],
+        'text-offset': [0, 0],
         // padding
         'text-padding': 0,
         'text-allow-overlap': ['step', ['zoom'], false, 12, true],

--- a/app/src/app/components/Map/PointLayers/MetaLayers.tsx
+++ b/app/src/app/components/Map/PointLayers/MetaLayers.tsx
@@ -21,9 +21,9 @@ import {FilterSpecification} from 'maplibre-gl';
 export const MetaLayers: React.FC<{isDemographicMap?: boolean}> = ({isDemographicMap}) => {
   return (
     <>
-      {!isDemographicMap && <ZoneNumbersLayer />}
       <PopulationTextLayer />
       <PopulationTextLayer child />
+      {!isDemographicMap && <ZoneNumbersLayer />}
     </>
   );
 };

--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -40,7 +40,8 @@ export default function NotFound() {
               Looking for a page from the original Districtr? Try{' '}
               <Link href={legacyUrl} target="_blank" rel="noopener noreferrer">
                 {legacyUrl.replace('https://', '')}
-              </Link>.
+              </Link>
+              .
             </Text>
           )}
           <Link href="/">Back to the Districtr 2.0 home page</Link>


### PR DESCRIPTION
District-number and block/precinct population-count labels are both symbol layers placed at the same centroid, with identical `text-anchor`/`text-offset`. Neither passed a `beforeId`, so each was appending itself to the absolute top of the layer stack the moment its own data source became ready — a race, not something set by render order. Population's source resolves later in practice, so it consistently won and hid the district number underneath.

**Fix:** give the population-text layers `beforeId: MAP_LAYER_ANCHOR_IDS.reference` (the same anchor `CountyLayers` already uses). That anchor is created before any real layer mounts, so population now lands in a fixed position instead of racing for the top; the zone-number layer, left unanchored, always ends up above it.

Correct stacking order wasn't quite enough on its own: the district-number circle wasn't fully opaque, so the population digits underneath still showed through.

**Fix:** `circle-opacity` on the district-number background circle, `0.8 -> 0.9`, so it sufficiently hides the population number beneath it.
