### PR TITLE
Fix: VAP overlay memory

### DIFF
--- a/app/src/app/components/Toolbar/Settings.tsx
+++ b/app/src/app/components/Toolbar/Settings.tsx
@@ -19,14 +19,12 @@ import {ColorChangeModal} from './ColorChangeModal';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
 import {ACCESS_STATES} from '@constants/document/state';
 import {DEMOGRAPHIC_MODES} from '@constants/map/demographicMode';
-import {SUMMARY_TYPES} from '@constants/demography/summary';
+import {SUMMARY_TYPES, type OverlayGroup} from '@constants/demography/summary';
 import {OVERLAY_OPACITY} from '@/app/constants/document/limits';
 import {
   activateOverlayGroup,
-  getOverlayVariable,
   overlayGroupVariables,
   overlayMemory,
-  type OverlayGroup,
 } from '@utils/demography/overlayMemory';
 
 /** Layers
@@ -56,7 +54,7 @@ export const ToolSettings: React.FC = () => {
   const overlayOn = mapOptions.demographicDisplayMode !== undefined;
   const allGroups: OverlayGroup[] = ['demography', 'election'];
   const overlayGroups: Array<{group: OverlayGroup; label: string}> = (
-    superDraw ? allGroups : allGroups.filter(group => getOverlayVariable(group))
+    superDraw ? allGroups : allGroups.filter(group => overlayMemory.variables[group])
   )
     .filter(group => overlayGroupVariables(group).length > 0)
     .map(group => ({

--- a/app/src/app/components/Toolbar/Settings.tsx
+++ b/app/src/app/components/Toolbar/Settings.tsx
@@ -19,9 +19,15 @@ import {ColorChangeModal} from './ColorChangeModal';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
 import {ACCESS_STATES} from '@constants/document/state';
 import {DEMOGRAPHIC_MODES} from '@constants/map/demographicMode';
-import {SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
+import {SUMMARY_TYPES} from '@constants/demography/summary';
 import {OVERLAY_OPACITY} from '@/app/constants/document/limits';
-import {activateOverlayGroup, overlayMemory} from '@utils/demography/overlayMemory';
+import {
+  activateOverlayGroup,
+  getOverlayVariable,
+  overlayGroupVariables,
+  overlayMemory,
+  type OverlayGroup,
+} from '@utils/demography/overlayMemory';
 
 /** Layers
  * This component is responsible for rendering the layers that can be toggled
@@ -43,30 +49,21 @@ export const ToolSettings: React.FC = () => {
   // Overlay layer: one selection among none / demographic / election (the
   // groups are mutually exclusive, so this is a mode picker, not independent
   // checkboxes). Super Draw offers every group with data on this map; Draw
-  // offers each group the user has toggled on so far — either alone is
-  // enough, both appear once both have been used.
+  // offers each group once it's actually been used.
   const electionVariables = availableMapVariables[SUMMARY_TYPES.VOTERHISTORY] ?? [];
   const isElectionVariable = electionVariables.some(v => v.value === variable);
   // "On" means either display mode — overlay or the side-by-side comparison.
   const overlayOn = mapOptions.demographicDisplayMode !== undefined;
-  const allGroups = [SUMMARY_TYPES.TOTPOP, SUMMARY_TYPES.VOTERHISTORY] as SummaryType[];
-  const overlayGroups: Array<{group: SummaryType; label: string}> = (
-    superDraw
-      ? allGroups
-      : allGroups.filter(
-          group => overlayMemory.variables[group] || overlayMemory.lastGroup === group
-        )
+  const allGroups: OverlayGroup[] = ['demography', 'election'];
+  const overlayGroups: Array<{group: OverlayGroup; label: string}> = (
+    superDraw ? allGroups : allGroups.filter(group => getOverlayVariable(group))
   )
-    .filter(group => (availableMapVariables[group] ?? []).length > 0)
+    .filter(group => overlayGroupVariables(group).length > 0)
     .map(group => ({
       group,
-      label: group === SUMMARY_TYPES.VOTERHISTORY ? 'Election' : 'Demographic',
+      label: group === 'election' ? 'Election' : 'Demographic',
     }));
-  const overlayValue = !overlayOn
-    ? 'none'
-    : isElectionVariable
-      ? SUMMARY_TYPES.VOTERHISTORY
-      : SUMMARY_TYPES.TOTPOP;
+  const overlayValue = !overlayOn ? 'none' : isElectionVariable ? 'election' : 'demography';
 
   const handleOverlayChange = (value: string) => {
     if (value === 'none') {
@@ -85,7 +82,7 @@ export const ToolSettings: React.FC = () => {
       });
       return;
     }
-    activateOverlayGroup(value as SummaryType);
+    activateOverlayGroup(value as OverlayGroup);
   };
 
   return (

--- a/app/src/app/components/sidebar/MapPanel.tsx
+++ b/app/src/app/components/sidebar/MapPanel.tsx
@@ -36,6 +36,7 @@ import {
   isCoalitionUniverse,
   CoalitionUniverse,
   SUMMARY_TYPES,
+  toOverlayGroup,
   type SummaryType,
 } from '@constants/demography/summary';
 import {COALITION_VARIABLE_BY_UNIVERSE, DemographyVariable} from '@constants/demography/coalition';
@@ -43,7 +44,7 @@ import {getCoalitionLabel, getSelectedCoalitionColumns} from '@/app/utils/demogr
 import {MAP_MODES} from '@constants/map/mode';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {DEMOGRAPHIC_MODES} from '@constants/map/demographicMode';
-import {overlayMemory, setOverlayVariable, toOverlayGroup} from '@utils/demography/overlayMemory';
+import {overlayMemory} from '@utils/demography/overlayMemory';
 
 type MapPanelProps = {
   columnGroup: keyof typeof choroplethMapVariables;
@@ -176,7 +177,8 @@ export const MapPanel: React.FC<MapPanelProps> = ({columnGroup}) => {
     if (newMode) {
       overlayMemory.displayMode = newMode;
       const effectiveVariable = mapVariableConfig ? variable : currentVariableList[0]?.value;
-      if (effectiveVariable) setOverlayVariable(toOverlayGroup(columnGroup), effectiveVariable);
+      if (effectiveVariable)
+        overlayMemory.variables[toOverlayGroup(columnGroup)] = effectiveVariable;
     }
     if (!mapVariableConfig && currentVariableList.length) {
       setVariable(currentVariableList[0].value);
@@ -221,7 +223,7 @@ export const MapPanel: React.FC<MapPanelProps> = ({columnGroup}) => {
   const handleChangeVariable = (newVariable: DemographyVariable) => {
     setVariable(newVariable);
     // Remember the choice so the Visual settings overlay toggle restores it.
-    setOverlayVariable(toOverlayGroup(columnGroup), newVariable);
+    overlayMemory.variables[toOverlayGroup(columnGroup)] = newVariable;
   };
 
   const handleChangePercent = (usePercent: boolean) => {

--- a/app/src/app/components/sidebar/MapPanel.tsx
+++ b/app/src/app/components/sidebar/MapPanel.tsx
@@ -43,7 +43,7 @@ import {getCoalitionLabel, getSelectedCoalitionColumns} from '@/app/utils/demogr
 import {MAP_MODES} from '@constants/map/mode';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {DEMOGRAPHIC_MODES} from '@constants/map/demographicMode';
-import {overlayMemory} from '@utils/demography/overlayMemory';
+import {memoryKey, overlayMemory} from '@utils/demography/overlayMemory';
 
 type MapPanelProps = {
   columnGroup: keyof typeof choroplethMapVariables;
@@ -177,7 +177,7 @@ export const MapPanel: React.FC<MapPanelProps> = ({columnGroup}) => {
       overlayMemory.displayMode = newMode;
       overlayMemory.lastGroup = columnGroup;
       const effectiveVariable = mapVariableConfig ? variable : currentVariableList[0]?.value;
-      if (effectiveVariable) overlayMemory.variables[columnGroup] = effectiveVariable;
+      if (effectiveVariable) overlayMemory.variables[memoryKey(columnGroup)] = effectiveVariable;
     }
     if (!mapVariableConfig && currentVariableList.length) {
       setVariable(currentVariableList[0].value);
@@ -222,7 +222,7 @@ export const MapPanel: React.FC<MapPanelProps> = ({columnGroup}) => {
   const handleChangeVariable = (newVariable: DemographyVariable) => {
     setVariable(newVariable);
     // Remember the choice so the Visual settings overlay toggle restores it.
-    overlayMemory.variables[columnGroup] = newVariable;
+    overlayMemory.variables[memoryKey(columnGroup)] = newVariable;
     overlayMemory.lastGroup = columnGroup;
   };
 

--- a/app/src/app/components/sidebar/MapPanel.tsx
+++ b/app/src/app/components/sidebar/MapPanel.tsx
@@ -43,7 +43,7 @@ import {getCoalitionLabel, getSelectedCoalitionColumns} from '@/app/utils/demogr
 import {MAP_MODES} from '@constants/map/mode';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {DEMOGRAPHIC_MODES} from '@constants/map/demographicMode';
-import {memoryKey, overlayMemory} from '@utils/demography/overlayMemory';
+import {overlayMemory, setOverlayVariable, toOverlayGroup} from '@utils/demography/overlayMemory';
 
 type MapPanelProps = {
   columnGroup: keyof typeof choroplethMapVariables;
@@ -171,13 +171,12 @@ export const MapPanel: React.FC<MapPanelProps> = ({columnGroup}) => {
   const handleSetMapMode = (newMode: MapControlsStore['mapOptions']['demographicDisplayMode']) => {
     setMapOptions({demographicDisplayMode: newMode});
     // Toggling a layer on registers it with the Visual settings toggle:
-    // remember the display mode (overlay vs. comparison), the group, and the
-    // variable it's showing.
+    // remember the display mode (overlay vs. comparison) and the variable
+    // it's showing.
     if (newMode) {
       overlayMemory.displayMode = newMode;
-      overlayMemory.lastGroup = columnGroup;
       const effectiveVariable = mapVariableConfig ? variable : currentVariableList[0]?.value;
-      if (effectiveVariable) overlayMemory.variables[memoryKey(columnGroup)] = effectiveVariable;
+      if (effectiveVariable) setOverlayVariable(toOverlayGroup(columnGroup), effectiveVariable);
     }
     if (!mapVariableConfig && currentVariableList.length) {
       setVariable(currentVariableList[0].value);
@@ -222,8 +221,7 @@ export const MapPanel: React.FC<MapPanelProps> = ({columnGroup}) => {
   const handleChangeVariable = (newVariable: DemographyVariable) => {
     setVariable(newVariable);
     // Remember the choice so the Visual settings overlay toggle restores it.
-    overlayMemory.variables[memoryKey(columnGroup)] = newVariable;
-    overlayMemory.lastGroup = columnGroup;
+    setOverlayVariable(toOverlayGroup(columnGroup), newVariable);
   };
 
   const handleChangePercent = (usePercent: boolean) => {

--- a/app/src/app/constants/demography/summary.ts
+++ b/app/src/app/constants/demography/summary.ts
@@ -20,3 +20,19 @@ export const TOTAL_COLUMN: Record<SummaryType, string | undefined> = {
   TOTPOP: 'total_pop_20',
   VOTERHISTORY: undefined,
 } as const;
+
+/**
+ * The two top-level choropleth overlay toggles. Coarser than SummaryType:
+ * the population overlay spans both the TOTPOP and VAP statistical
+ * universes as one merged control, not two.
+ */
+export type OverlayGroup = 'demography' | 'election';
+
+export const OVERLAY_GROUP_SUMMARY_TYPES: Record<OverlayGroup, SummaryType[]> = {
+  demography: [SUMMARY_TYPES.TOTPOP, SUMMARY_TYPES.VAP],
+  election: [SUMMARY_TYPES.VOTERHISTORY],
+};
+
+/** Which overlay group a statistical universe's variables belong to. */
+export const toOverlayGroup = (summaryType: SummaryType): OverlayGroup =>
+  summaryType === SUMMARY_TYPES.VOTERHISTORY ? 'election' : 'demography';

--- a/app/src/app/utils/demography/overlayMemory.ts
+++ b/app/src/app/utils/demography/overlayMemory.ts
@@ -1,4 +1,4 @@
-import {isCoalitionUniverse, SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
+import {SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
 import type {DemographyVariable} from '@constants/demography/coalition';
 import {useDemographyStore} from '@store/demography/demographyStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
@@ -6,13 +6,35 @@ import {useToolbarStore} from '@store/toolbarStore';
 import {DEMOGRAPHIC_MODES, type DemographicMode} from '@constants/map/demographicMode';
 
 /**
- * Last-used choropleth config per layer type, so the Visual settings overlay
- * toggles can restore it after the overlay is turned off. Module state:
- * survives panel unmounts and mode switches, resets on page load.
+ * The two top-level choropleth overlay toggles. Coarser than SummaryType:
+ * the population overlay spans both the TOTPOP and VAP statistical
+ * universes as one merged control, not two.
+ */
+export type OverlayGroup = 'demography' | 'election';
+
+const GROUP_SUMMARY_TYPES: Record<OverlayGroup, SummaryType[]> = {
+  demography: [SUMMARY_TYPES.TOTPOP, SUMMARY_TYPES.VAP],
+  election: [SUMMARY_TYPES.VOTERHISTORY],
+};
+
+/** Which overlay group a statistical universe's variables belong to. */
+export const toOverlayGroup = (summaryType: SummaryType): OverlayGroup =>
+  summaryType === SUMMARY_TYPES.VOTERHISTORY ? 'election' : 'demography';
+
+/** Every variable available on this map for an overlay group's universe(s). */
+export const overlayGroupVariables = (group: OverlayGroup) =>
+  GROUP_SUMMARY_TYPES[group].flatMap(
+    summaryType => useDemographyStore.getState().availableColumnSets.map[summaryType] ?? []
+  );
+
+/**
+ * Last-used choropleth variable per overlay group, so the Visual settings
+ * overlay toggles can restore it after the overlay is turned off. Module
+ * state: survives panel unmounts and mode switches, resets on page load.
  */
 export const overlayMemory: {
-  variables: Partial<Record<SummaryType, DemographyVariable>>;
-  lastGroup: SummaryType | null;
+  demographyVariable: DemographyVariable | null;
+  electionVariable: DemographyVariable | null;
   /** Overlay-mode preset captured when the overlay is toggled off from Visual
    * settings, restored on the next activation — so the toggles round-trip the
    * same opacity/painted-districts state the panel controls set. */
@@ -22,42 +44,39 @@ export const overlayMemory: {
    * so activating a choropleth layer reuses the user's last choice. */
   displayMode: DemographicMode | null;
 } = {
-  variables: {},
-  lastGroup: null,
+  demographyVariable: null,
+  electionVariable: null,
   overlayOpacity: null,
   showPaintedDistricts: null,
   displayMode: null,
 };
 
-/**
- * TOTPOP and VAP present as one merged population choropleth (the Map Layer
- * dropdown spans both universes), so they share one memory slot rather than
- * two — otherwise a VAP pick is never restored, since only 'TOTPOP' ever
- * gets reactivated (Visual settings' "Demographic" toggle has no separate
- * VAP button).
- */
-export const memoryKey = (group: SummaryType): SummaryType =>
-  isCoalitionUniverse(group) ? SUMMARY_TYPES.TOTPOP : group;
+export const getOverlayVariable = (group: OverlayGroup): DemographyVariable | null =>
+  group === 'election' ? overlayMemory.electionVariable : overlayMemory.demographyVariable;
+
+export const setOverlayVariable = (group: OverlayGroup, variable: DemographyVariable): void => {
+  if (group === 'election') overlayMemory.electionVariable = variable;
+  else overlayMemory.demographyVariable = variable;
+};
 
 /**
- * Turn the choropleth overlay on for a column group, restoring the last-used
- * variable (or defaulting to the group's first). The single writer of
- * overlayMemory's activation state — used by the Visual settings toggles and
- * the sidebar Map Layer tabs. No-op (returns false) when the group has no
- * variables on this map, so a data-less group can never activate a foreign
- * variable or poison the memory.
+ * Turn the choropleth overlay on for an overlay group, restoring the
+ * last-used variable (or defaulting to the group's first). The single
+ * writer of overlayMemory's activation state — used by the Visual settings
+ * toggles and the sidebar Map Layer tabs. No-op (returns false) when the
+ * group has no variables on this map, so a data-less group can never
+ * activate a foreign variable or poison the memory.
  */
-export const activateOverlayGroup = (group: SummaryType): boolean => {
+export const activateOverlayGroup = (group: OverlayGroup): boolean => {
   const demography = useDemographyStore.getState();
-  const variables = demography.availableColumnSets.map[group] ?? [];
+  const variables = overlayGroupVariables(group);
   if (!variables.length) return false;
   let variable = demography.variable;
   if (!variables.some(v => v.value === variable)) {
-    variable = overlayMemory.variables[memoryKey(group)] ?? variables[0].value;
+    variable = getOverlayVariable(group) ?? variables[0].value;
     demography.setVariable(variable);
   }
-  overlayMemory.lastGroup = group;
-  overlayMemory.variables[memoryKey(group)] = variable;
+  setOverlayVariable(group, variable);
   // Reuse the last-used display mode; side-by-side is a Super Draw feature,
   // so plain Draw always falls back to the overlay.
   const displayMode =

--- a/app/src/app/utils/demography/overlayMemory.ts
+++ b/app/src/app/utils/demography/overlayMemory.ts
@@ -33,8 +33,7 @@ export const overlayGroupVariables = (group: OverlayGroup) =>
  * state: survives panel unmounts and mode switches, resets on page load.
  */
 export const overlayMemory: {
-  demographyVariable: DemographyVariable | null;
-  electionVariable: DemographyVariable | null;
+  variables: Record<OverlayGroup, DemographyVariable | null>;
   /** Overlay-mode preset captured when the overlay is toggled off from Visual
    * settings, restored on the next activation — so the toggles round-trip the
    * same opacity/painted-districts state the panel controls set. */
@@ -44,19 +43,17 @@ export const overlayMemory: {
    * so activating a choropleth layer reuses the user's last choice. */
   displayMode: DemographicMode | null;
 } = {
-  demographyVariable: null,
-  electionVariable: null,
+  variables: {demography: null, election: null},
   overlayOpacity: null,
   showPaintedDistricts: null,
   displayMode: null,
 };
 
 export const getOverlayVariable = (group: OverlayGroup): DemographyVariable | null =>
-  group === 'election' ? overlayMemory.electionVariable : overlayMemory.demographyVariable;
+  overlayMemory.variables[group];
 
 export const setOverlayVariable = (group: OverlayGroup, variable: DemographyVariable): void => {
-  if (group === 'election') overlayMemory.electionVariable = variable;
-  else overlayMemory.demographyVariable = variable;
+  overlayMemory.variables[group] = variable;
 };
 
 /**

--- a/app/src/app/utils/demography/overlayMemory.ts
+++ b/app/src/app/utils/demography/overlayMemory.ts
@@ -1,29 +1,13 @@
-import {SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
+import {OVERLAY_GROUP_SUMMARY_TYPES, type OverlayGroup} from '@constants/demography/summary';
 import type {DemographyVariable} from '@constants/demography/coalition';
 import {useDemographyStore} from '@store/demography/demographyStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {useToolbarStore} from '@store/toolbarStore';
 import {DEMOGRAPHIC_MODES, type DemographicMode} from '@constants/map/demographicMode';
 
-/**
- * The two top-level choropleth overlay toggles. Coarser than SummaryType:
- * the population overlay spans both the TOTPOP and VAP statistical
- * universes as one merged control, not two.
- */
-export type OverlayGroup = 'demography' | 'election';
-
-const GROUP_SUMMARY_TYPES: Record<OverlayGroup, SummaryType[]> = {
-  demography: [SUMMARY_TYPES.TOTPOP, SUMMARY_TYPES.VAP],
-  election: [SUMMARY_TYPES.VOTERHISTORY],
-};
-
-/** Which overlay group a statistical universe's variables belong to. */
-export const toOverlayGroup = (summaryType: SummaryType): OverlayGroup =>
-  summaryType === SUMMARY_TYPES.VOTERHISTORY ? 'election' : 'demography';
-
 /** Every variable available on this map for an overlay group's universe(s). */
 export const overlayGroupVariables = (group: OverlayGroup) =>
-  GROUP_SUMMARY_TYPES[group].flatMap(
+  OVERLAY_GROUP_SUMMARY_TYPES[group].flatMap(
     summaryType => useDemographyStore.getState().availableColumnSets.map[summaryType] ?? []
   );
 
@@ -49,13 +33,6 @@ export const overlayMemory: {
   displayMode: null,
 };
 
-export const getOverlayVariable = (group: OverlayGroup): DemographyVariable | null =>
-  overlayMemory.variables[group];
-
-export const setOverlayVariable = (group: OverlayGroup, variable: DemographyVariable): void => {
-  overlayMemory.variables[group] = variable;
-};
-
 /**
  * Turn the choropleth overlay on for an overlay group, restoring the
  * last-used variable (or defaulting to the group's first). The single
@@ -70,10 +47,10 @@ export const activateOverlayGroup = (group: OverlayGroup): boolean => {
   if (!variables.length) return false;
   let variable = demography.variable;
   if (!variables.some(v => v.value === variable)) {
-    variable = getOverlayVariable(group) ?? variables[0].value;
+    variable = overlayMemory.variables[group] ?? variables[0].value;
     demography.setVariable(variable);
   }
-  setOverlayVariable(group, variable);
+  overlayMemory.variables[group] = variable;
   // Reuse the last-used display mode; side-by-side is a Super Draw feature,
   // so plain Draw always falls back to the overlay.
   const displayMode =

--- a/app/src/app/utils/demography/overlayMemory.ts
+++ b/app/src/app/utils/demography/overlayMemory.ts
@@ -1,4 +1,4 @@
-import type {SummaryType} from '@constants/demography/summary';
+import {isCoalitionUniverse, SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
 import type {DemographyVariable} from '@constants/demography/coalition';
 import {useDemographyStore} from '@store/demography/demographyStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
@@ -30,6 +30,16 @@ export const overlayMemory: {
 };
 
 /**
+ * TOTPOP and VAP present as one merged population choropleth (the Map Layer
+ * dropdown spans both universes), so they share one memory slot rather than
+ * two — otherwise a VAP pick is never restored, since only 'TOTPOP' ever
+ * gets reactivated (Visual settings' "Demographic" toggle has no separate
+ * VAP button).
+ */
+export const memoryKey = (group: SummaryType): SummaryType =>
+  isCoalitionUniverse(group) ? SUMMARY_TYPES.TOTPOP : group;
+
+/**
  * Turn the choropleth overlay on for a column group, restoring the last-used
  * variable (or defaulting to the group's first). The single writer of
  * overlayMemory's activation state — used by the Visual settings toggles and
@@ -43,11 +53,11 @@ export const activateOverlayGroup = (group: SummaryType): boolean => {
   if (!variables.length) return false;
   let variable = demography.variable;
   if (!variables.some(v => v.value === variable)) {
-    variable = overlayMemory.variables[group] ?? variables[0].value;
+    variable = overlayMemory.variables[memoryKey(group)] ?? variables[0].value;
     demography.setVariable(variable);
   }
   overlayMemory.lastGroup = group;
-  overlayMemory.variables[group] = variable;
+  overlayMemory.variables[memoryKey(group)] = variable;
   // Reuse the last-used display mode; side-by-side is a Super Draw feature,
   // so plain Draw always falls back to the overlay.
   const displayMode =


### PR DESCRIPTION
Picking a VAP variable (e.g. "VAP Black") as the map's choropleth overlay, then toggling the overlay off and back on in Visual Settings, resets the selection to a generic "Total" instead of restoring "VAP Black." Doing the identical sequence with a TOTPOP variable works correctly.

Visual Settings' "Demographic" toggle only ever calls `activateOverlayGroup('TOTPOP')` — there's no separate VAP button. `overlayMemory` kept a variable slot per `SummaryType` (TOTPOP/VAP/VOTERHISTORY — a statistical-universe taxonomy), so a VAP pick was written correctly but never read back: the reactivation path only ever checks the TOTPOP slot. TOTPOP round-tripped fine only because its own write and read already shared a key. Using `SummaryType` to drive the toggle's own, coarser concept (which of two buttons is active) is what made this possible in the first place.

**Fix:** introduce `OverlayGroup` (`'demography' | 'election'`) as the toggle's own type, independent of `SummaryType` — alongside `SummaryType` in `constants/demography/summary.ts`, since it's pure taxonomy with no store dependency. `overlayMemory` stores its remembered variable as `Record<OverlayGroup, DemographyVariable | null>` — a dict again, but keyed by the correct concept this time, so it carries none of the taxonomy conflation the old `SummaryType`-keyed one did. `toOverlayGroup(summaryType)` maps a variable's actual universe to its overlay group; `activateOverlayGroup` and the sidebar's Map Layer tab both index `overlayMemory.variables` by it directly instead of touching `SummaryType` values as memory keys. TOTPOP and VAP now always land in the same (`'demography'`) slot, so a VAP pick survives a toggle off/on exactly like a TOTPOP pick does.

Also removes `overlayMemory.lastGroup`: `activateOverlayGroup`'s own memory write was already unconditional, making it redundant on that path.
