### PR TITLE
Env-scope thumbnail S3 keys and fix hardcoded OG image domain

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -42,9 +42,11 @@ jobs:
           if [ "${{ github.ref_name }}" = "dev" ]; then
             echo "stack=dev" >> "$GITHUB_OUTPUT"
             echo "api_url=${{ vars.API_URL_DEV }}" >> "$GITHUB_OUTPUT"
+            echo "environment=development" >> "$GITHUB_OUTPUT"
           else
             echo "stack=prod" >> "$GITHUB_OUTPUT"
             echo "api_url=${{ vars.API_URL_PROD }}" >> "$GITHUB_OUTPUT"
+            echo "environment=production" >> "$GITHUB_OUTPUT"
           fi
       # NEXT_PUBLIC_* values are baked into the bundle at build time; this
       # mirrors the Fly deploy workflow (the CI-written file wins over the
@@ -61,6 +63,7 @@ jobs:
           NEXT_PUBLIC_S3_BUCKET_URL_MIRROR1=https://tilesets2.cdn.districtr.org
           NEXT_PUBLIC_S3_BUCKET_URL_MIRROR2=https://tilesets3.cdn.districtr.org
           NEXT_PUBLIC_API_URL=${{ steps.cfg.outputs.api_url }}
+          NEXT_PUBLIC_ENVIRONMENT=${{ steps.cfg.outputs.environment }}
           NEXT_PUBLIC_BUILD_TAG=${{ github.sha }}
           EOF
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/fly-deploy-app.yml
+++ b/.github/workflows/fly-deploy-app.yml
@@ -20,9 +20,11 @@ jobs:
           if [ "${{ github.ref_name }}" = "dev" ]; then
             echo "app_name=districtr-v2-frontend-dev" >> $GITHUB_OUTPUT
             echo "api_url=https://districtr-v2-api-dev.fly.dev" >> $GITHUB_OUTPUT
+            echo "environment=development" >> $GITHUB_OUTPUT
           else
             echo "app_name=districtr-v2-frontend" >> $GITHUB_OUTPUT
             echo "api_url=https://districtr-v2-api.fly.dev" >> $GITHUB_OUTPUT
+            echo "environment=production" >> $GITHUB_OUTPUT
           fi
       - name: Write .env.production
         run: |
@@ -33,6 +35,7 @@ jobs:
             NEXT_PUBLIC_S3_BUCKET_URL_MIRROR1=https://tilesets2.cdn.districtr.org
             NEXT_PUBLIC_S3_BUCKET_URL_MIRROR2=https://tilesets3.cdn.districtr.org
             NEXT_PUBLIC_API_URL=${{ steps.deploy-env.outputs.api_url }}
+            NEXT_PUBLIC_ENVIRONMENT=${{ steps.deploy-env.outputs.environment }}
             NEXT_PUBLIC_BUILD_TAG=${{ github.sha }}
             EOF
         working-directory: app

--- a/app/.env.dev
+++ b/app/.env.dev
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_ENVIRONMENT=local
 NEXT_PUBLIC_S3_BUCKET_URL=https://tilesets1.cdn.districtr.org
 NEXT_PUBLIC_S3_BUCKET_URL_MIRROR1=https://tilesets2.cdn.districtr.org
 NEXT_PUBLIC_S3_BUCKET_URL_MIRROR2=https://tilesets3.cdn.districtr.org

--- a/app/.env.docker.example
+++ b/app/.env.docker.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_ENVIRONMENT=local
 NEXT_PUBLIC_S3_BUCKET_URL=https://fill-me.s3.amazonaws.com
 NEXT_PUBLIC_S3_BUCKET_URL_MIRROR1=https://fill-me.s3.amazonaws.com
 NEXT_PUBLIC_S3_BUCKET_URL_MIRROR2=https://fill-me.s3.amazonaws.com

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URL=https://districtr-v2-api.fly.dev
+NEXT_PUBLIC_ENVIRONMENT=production
 NEXT_PUBLIC_S3_BUCKET_URL=https://tilesets1.cdn.districtr.org
 
 AUTH0_CLIENT_ID=foo

--- a/app/src/app/admin/thumbnails/page.tsx
+++ b/app/src/app/admin/thumbnails/page.tsx
@@ -2,6 +2,7 @@
 
 import {useCmsFormStore} from '@/app/store/cmsFormStore';
 import {generateThumbnail} from '@/app/utils/api/apiHandlers/generateThumbnail';
+import {thumbnailUrl} from '@/app/utils/api/thumbnailUrl';
 import {Cross2Icon, ReloadIcon} from '@radix-ui/react-icons';
 import {
   Blockquote,
@@ -92,7 +93,7 @@ const ThumbnailImage: React.FC<{
   documentId: string;
   onDismiss: () => void;
 }> = ({documentId, onDismiss}) => {
-  const baseUrl = `${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/thumbnails/${documentId}.png`;
+  const baseUrl = thumbnailUrl(documentId);
   const [url, setUrl] = useState(baseUrl);
   const handleRefresh = () => {
     setUrl(`${baseUrl}?${Date.now()}`);

--- a/app/src/app/components/Cms/RichTextEditor/extensions/PlanGallery/PlanGalleryRenderers.tsx
+++ b/app/src/app/components/Cms/RichTextEditor/extensions/PlanGallery/PlanGalleryRenderers.tsx
@@ -1,6 +1,6 @@
 'use client';
 import {Box, Flex, Table, Text} from '@radix-ui/themes';
-import {CDN_URL} from '@/app/utils/api/constants';
+import {thumbnailUrl} from '@/app/utils/api/thumbnailUrl';
 import {MinPublicDocument} from '@utils/api/apiHandlers/types';
 import {useRouter} from 'next/navigation';
 
@@ -30,7 +30,7 @@ export const PlanCard = ({plan, ...flags}: {plan: MinPublicDocument} & PlanFlags
           <Box
             className="w-full relative overflow-hidden aspect-video border-2 border-b-0 border-gray-50 bg-white"
             style={{
-              backgroundImage: `url(${CDN_URL}/thumbnails/${plan.public_id}.png), url(${FALLBACK_IMAGE_URL})`,
+              backgroundImage: `url(${thumbnailUrl(plan.public_id)}), url(${FALLBACK_IMAGE_URL})`,
               backgroundSize: 'contain',
               backgroundPosition: 'center',
               backgroundRepeat: 'no-repeat',
@@ -80,7 +80,7 @@ export const PlanTableRow = ({plan, ...flags}: {plan: MinPublicDocument} & PlanF
           <Box
             className="w-full relative overflow-hidden aspect-video border-2 border-gray-50 bg-white size-8"
             style={{
-              backgroundImage: `url(${CDN_URL}/thumbnails/${plan.public_id}.png), url(${FALLBACK_IMAGE_URL})`,
+              backgroundImage: `url(${thumbnailUrl(plan.public_id)}), url(${FALLBACK_IMAGE_URL})`,
               backgroundSize: 'contain',
               backgroundPosition: 'center',
               backgroundRepeat: 'no-repeat',

--- a/app/src/app/components/Forms/MapSelector.tsx
+++ b/app/src/app/components/Forms/MapSelector.tsx
@@ -259,7 +259,11 @@ const MapSelectorInner: React.FC<MapSelectorProps> = ({allowListModules}) => {
       {notification?.type === 'success' && (
         <object data="/home-megaphone-square.png" type="image/png" className="size-32">
           <img
-            src={thumbnailUrl(dataResponse?.mapInfo?.public_id ?? '')}
+            src={
+              dataResponse?.mapInfo?.public_id != null
+                ? thumbnailUrl(dataResponse.mapInfo.public_id)
+                : undefined
+            }
             alt="Map thumbnail"
             className="size-32"
           />

--- a/app/src/app/components/Forms/MapSelector.tsx
+++ b/app/src/app/components/Forms/MapSelector.tsx
@@ -3,7 +3,7 @@ import {useEffect, useRef, useState} from 'react';
 import {useFormState} from '@/app/store/formState';
 import {getDocument} from '@/app/utils/api/apiHandlers/getDocument';
 import {DocumentObject} from '@/app/utils/api/apiHandlers/types';
-import {TILESET_URL} from '@/app/utils/api/constants';
+import {thumbnailUrl} from '@/app/utils/api/thumbnailUrl';
 import {queryClient} from '@/app/utils/api/queryClient';
 import {
   Blockquote,
@@ -259,7 +259,7 @@ const MapSelectorInner: React.FC<MapSelectorProps> = ({allowListModules}) => {
       {notification?.type === 'success' && (
         <object data="/home-megaphone-square.png" type="image/png" className="size-32">
           <img
-            src={`${TILESET_URL}/thumbnails/${dataResponse?.mapInfo?.public_id}.png`}
+            src={thumbnailUrl(dataResponse?.mapInfo?.public_id ?? '')}
             alt="Map thumbnail"
             className="size-32"
           />

--- a/app/src/app/utils/api/constants.ts
+++ b/app/src/app/utils/api/constants.ts
@@ -5,6 +5,11 @@ export const API_URL =
 
 export const TILESET_URL = process.env.NEXT_PUBLIC_S3_BUCKET_URL;
 export const CDN_URL = TILESET_URL;
+
+/** Matches the backend's `settings.ENVIRONMENT`, set alongside NEXT_PUBLIC_API_URL
+ * per deployment. Used to scope direct CDN reads (e.g. thumbnails) so different
+ * environments don't collide on the same S3 key. */
+export const ENVIRONMENT = process.env.NEXT_PUBLIC_ENVIRONMENT ?? 'production';
 export const GEODATA_URL =
   process.env.NEXT_PUBLIC_S3_BUCKET_URL_MIRROR1 ?? process.env.NEXT_PUBLIC_S3_BUCKET_URL;
 export const PARQUET_URL =

--- a/app/src/app/utils/api/thumbnailUrl.ts
+++ b/app/src/app/utils/api/thumbnailUrl.ts
@@ -1,6 +1,12 @@
 import {CDN_URL, ENVIRONMENT} from './constants';
 
+/** Only production gets its own S3 folder; every other ENVIRONMENT value
+ * (local, development, qa, test) collapses into "development" — mirrors the
+ * backend's get_thumbnail_environment_folder() in thumbnails/main.py. */
+const thumbnailEnvironmentFolder = (): string =>
+  ENVIRONMENT === 'production' ? 'production' : 'development';
+
 /** CDN URL for a document's thumbnail, matching the environment-scoped S3 key
- * the backend writes (`thumbnails/{ENVIRONMENT}/{publicId}.png`). */
+ * the backend writes (`thumbnails/{folder}/{publicId}.png`). */
 export const thumbnailUrl = (publicId: number | string): string =>
-  `${CDN_URL}/thumbnails/${ENVIRONMENT}/${publicId}.png`;
+  `${CDN_URL}/thumbnails/${thumbnailEnvironmentFolder()}/${publicId}.png`;

--- a/app/src/app/utils/api/thumbnailUrl.ts
+++ b/app/src/app/utils/api/thumbnailUrl.ts
@@ -1,0 +1,6 @@
+import {CDN_URL, ENVIRONMENT} from './constants';
+
+/** CDN URL for a document's thumbnail, matching the environment-scoped S3 key
+ * the backend writes (`thumbnails/{ENVIRONMENT}/{publicId}.png`). */
+export const thumbnailUrl = (publicId: number | string): string =>
+  `${CDN_URL}/thumbnails/${ENVIRONMENT}/${publicId}.png`;

--- a/app/src/app/utils/metadata/pageMetadataUtils.ts
+++ b/app/src/app/utils/metadata/pageMetadataUtils.ts
@@ -1,17 +1,21 @@
 import {Metadata} from 'next';
+import {headers} from 'next/headers';
 import {DocumentObject} from '@/app/utils/api/apiHandlers/types';
 import {API_URL} from '@/app/utils/api/constants';
-
-export const DISTRICTR_LOGO = {
-  url: 'https://beta.districtr.org/districtr_logo.jpg',
-  width: 1136,
-  height: 423,
-};
 
 export type MetadataProps = {
   params?: Promise<{public_id?: string}>;
   searchParams?: Promise<{document_id?: string | string[] | undefined}>;
 };
+
+/** The serving environment's own origin — never a hardcoded domain, so OG
+ * images/logo resolve correctly on dev/preview, not just production. */
+async function getRequestOrigin(): Promise<string> {
+  const requestHeaders = await headers();
+  const protocol = requestHeaders.get('x-forwarded-proto') ?? 'https';
+  const host = requestHeaders.get('host') ?? 'beta.districtr.org';
+  return `${protocol}://${host}`;
+}
 
 /**
  * Every id-bearing map/coi route carries its id as a path segment
@@ -26,6 +30,7 @@ export async function generateMapPageMetadata({
   const resolvedSearchParams = await searchParams;
   const document_id = resolvedParams?.public_id ?? resolvedSearchParams?.document_id ?? '';
   const singularDocumentId = Array.isArray(document_id) ? document_id[0] : document_id;
+  const origin = await getRequestOrigin();
   let mapDocument: DocumentObject | null = null;
   if (singularDocumentId) {
     mapDocument = await fetch(`${API_URL}/api/document/${singularDocumentId}`).then(res =>
@@ -43,11 +48,15 @@ export async function generateMapPageMetadata({
       siteName: 'Districtr 2.0',
       images: [
         {
-          url: `https://beta.districtr.org/api/og/${singularDocumentId}`,
+          url: `${origin}/api/og/${singularDocumentId}`,
           width: 1128,
           height: 600,
         },
-        DISTRICTR_LOGO,
+        {
+          url: `${origin}/districtr_logo.jpg`,
+          width: 1136,
+          height: 423,
+        },
       ],
     },
   };

--- a/app/src/app/utils/metadata/pageMetadataUtils.ts
+++ b/app/src/app/utils/metadata/pageMetadataUtils.ts
@@ -12,7 +12,10 @@ export type MetadataProps = {
  * images/logo resolve correctly on dev/preview, not just production. */
 async function getRequestOrigin(): Promise<string> {
   const requestHeaders = await headers();
-  const protocol = requestHeaders.get('x-forwarded-proto') ?? 'https';
+  // x-forwarded-proto can be a comma-separated list when multiple proxies
+  // are in the chain, each appending its own value — the first entry is
+  // what the original client actually used.
+  const protocol = requestHeaders.get('x-forwarded-proto')?.split(',')[0]?.trim() ?? 'https';
   const host = requestHeaders.get('host') ?? 'beta.districtr.org';
   return `${protocol}://${host}`;
 }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -35,6 +35,16 @@ class Environment(str, Enum):
     test = "test"
 
 
+def s3_environment_folder(environment: "Environment") -> str:
+    """Only production gets its own S3 folder; every other value (local,
+    development, qa, test) collapses into "development" so non-prod objects
+    don't spread across more S3 folders than needed — colliding with each
+    other is fine, only production needs isolation."""
+    if environment == Environment.production:
+        return Environment.production.value
+    return Environment.development.value
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env", env_ignore_empty=True, extra="ignore"

--- a/backend/app/core/io.py
+++ b/backend/app/core/io.py
@@ -4,6 +4,7 @@ from app.core.config import settings
 from urllib.parse import urlparse
 from pathlib import Path
 import logging
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -110,10 +111,15 @@ def file_exists(file_path) -> bool:
         key = url.path.lstrip("/")
         s3 = settings.get_s3_client()
         assert s3, "S3 client is not available"
-        object_information = s3.head_object(
-            Bucket=bucket,
-            Key=key,
-        )
+        try:
+            object_information = s3.head_object(
+                Bucket=bucket,
+                Key=key,
+            )
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                return False
+            raise
         return object_information["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     if url.scheme == "":

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -6,7 +6,7 @@ import math
 import matplotlib.pyplot as plt
 import random
 from sqlalchemy import text
-from sqlmodel import Session
+from sqlmodel import Session, select
 from uuid import UUID
 from app.core.config import settings, s3_environment_folder
 from fastapi import APIRouter, Security, status, BackgroundTasks, Depends, HTTPException
@@ -14,6 +14,7 @@ from fastapi.responses import RedirectResponse
 from app.core.security import auth, TokenScope
 from app.core.db import get_session, engine
 from app.core.dependencies import get_document
+from app.core.models import DocumentID
 from app.models import Document
 from urllib.parse import urlparse
 from pathlib import Path
@@ -224,13 +225,30 @@ def _generate_thumbnail(
     return out_file
 
 
+def _resolve_public_id(raw_id: str, session: Session) -> int | None:
+    """Thumbnails are always stored keyed by public_id, but this endpoint is
+    also hit with a raw document_id (edit/password links carry the UUID in
+    their OG image URL) — resolve to the real public_id in that case."""
+    try:
+        parsed = DocumentID(document_id=raw_id)
+    except ValueError:
+        return None
+    if parsed.is_public:
+        return int(parsed.value)
+    return session.exec(
+        select(Document.public_id).where(Document.document_id == parsed.value)
+    ).first()
+
+
 @router.get("/api/document/{public_id}/thumbnail", status_code=status.HTTP_200_OK)
 async def get_thumbnail(*, public_id: str, session: Session = Depends(get_session)):
-    thumbail_file_path = get_thumbnail_file_path(public_id)
-    if file_exists(thumbail_file_path):
-        return RedirectResponse(
-            url=f"{settings.cnd_url}/thumbnails/{get_thumbnail_environment_folder()}/{public_id}.png"
-        )
+    resolved_public_id = _resolve_public_id(public_id, session)
+    if resolved_public_id is not None:
+        thumbail_file_path = get_thumbnail_file_path(resolved_public_id)
+        if file_exists(thumbail_file_path):
+            return RedirectResponse(
+                url=f"{settings.cnd_url}/thumbnails/{get_thumbnail_environment_folder()}/{resolved_public_id}.png"
+            )
 
     return RedirectResponse(url="/home-megaphone.png")
 

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -8,7 +8,7 @@ import random
 from sqlalchemy import text
 from sqlmodel import Session
 from uuid import UUID
-from app.core.config import settings
+from app.core.config import settings, Environment
 from fastapi import APIRouter, Security, status, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from app.core.security import auth, TokenScope
@@ -68,8 +68,18 @@ DISTRICT_COLORS = [
 ]
 
 
+def get_thumbnail_environment_folder() -> str:
+    # Only production gets its own S3 folder; every other settings.ENVIRONMENT
+    # value (local, development, qa, test) collapses into "development" so
+    # non-prod thumbnails don't spread across more S3 folders than needed —
+    # colliding with each other is fine, only production needs isolation.
+    if settings.ENVIRONMENT == Environment.production:
+        return Environment.production.value
+    return Environment.development.value
+
+
 def get_thumbnail_file_path(public_id: str | int) -> str:
-    return f"s3://{THUMBNAIL_BUCKET}/thumbnails/{settings.ENVIRONMENT}/{public_id}.png"
+    return f"s3://{THUMBNAIL_BUCKET}/thumbnails/{get_thumbnail_environment_folder()}/{public_id}.png"
 
 
 def get_blank_thumbnail_file_path(districtr_map_slug: str) -> str:
@@ -225,7 +235,7 @@ async def get_thumbnail(*, public_id: str, session: Session = Depends(get_sessio
     thumbail_file_path = get_thumbnail_file_path(public_id)
     if file_exists(thumbail_file_path):
         return RedirectResponse(
-            url=f"{settings.cnd_url}/thumbnails/{settings.ENVIRONMENT}/{public_id}.png"
+            url=f"{settings.cnd_url}/thumbnails/{get_thumbnail_environment_folder()}/{public_id}.png"
         )
 
     return RedirectResponse(url="/home-megaphone.png")

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -68,8 +68,14 @@ DISTRICT_COLORS = [
 ]
 
 
-def get_document_thumbnail_file_path(document_id: str) -> str:
-    return f"s3://{THUMBNAIL_BUCKET}/thumbnails/{document_id}.png"
+def get_thumbnail_file_path(public_id: str | int) -> str:
+    return f"s3://{THUMBNAIL_BUCKET}/thumbnails/{settings.ENVIRONMENT}/{public_id}.png"
+
+
+def get_blank_thumbnail_file_path(districtr_map_slug: str) -> str:
+    # districtr_map_slug is the same string in every environment (shared map
+    # catalog), unlike public_id, so this one is intentionally unprefixed.
+    return f"s3://{THUMBNAIL_BUCKET}/thumbnails/{districtr_map_slug}.png"
 
 
 def write_image(out_path: str | Path, pic_IObytes: io.BytesIO) -> None:
@@ -201,7 +207,7 @@ def _generate_thumbnail(
     plt.close(geoplt.figure)
     pic_IObytes.seek(0)
 
-    out_file = get_document_thumbnail_file_path(str(public_id))
+    out_file = get_thumbnail_file_path(str(public_id))
     try:
         write_image(out_file, pic_IObytes)
     except (ValueError, S3UploadFailedError) as e:
@@ -214,11 +220,13 @@ def _generate_thumbnail(
     return out_file
 
 
-@router.get("/api/document/{document_id}/thumbnail", status_code=status.HTTP_200_OK)
-async def get_thumbnail(*, document_id: str, session: Session = Depends(get_session)):
-    thumbail_file_path = get_document_thumbnail_file_path(document_id)
+@router.get("/api/document/{public_id}/thumbnail", status_code=status.HTTP_200_OK)
+async def get_thumbnail(*, public_id: str, session: Session = Depends(get_session)):
+    thumbail_file_path = get_thumbnail_file_path(public_id)
     if file_exists(thumbail_file_path):
-        return RedirectResponse(url=f"{settings.cnd_url}/thumbnails/{document_id}.png")
+        return RedirectResponse(
+            url=f"{settings.cnd_url}/thumbnails/{settings.ENVIRONMENT}/{public_id}.png"
+        )
 
     return RedirectResponse(url="/home-megaphone.png")
 
@@ -311,7 +319,7 @@ def _generate_blank(
     plt.close(geoplt.figure)
     pic_IObytes.seek(0)
 
-    out_file = get_document_thumbnail_file_path(districtr_map_slug)
+    out_file = get_blank_thumbnail_file_path(districtr_map_slug)
     try:
         write_image(out_file, pic_IObytes)
     except (ValueError, S3UploadFailedError) as e:

--- a/backend/app/thumbnails/main.py
+++ b/backend/app/thumbnails/main.py
@@ -8,7 +8,7 @@ import random
 from sqlalchemy import text
 from sqlmodel import Session
 from uuid import UUID
-from app.core.config import settings, Environment
+from app.core.config import settings, s3_environment_folder
 from fastapi import APIRouter, Security, status, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from app.core.security import auth, TokenScope
@@ -69,13 +69,7 @@ DISTRICT_COLORS = [
 
 
 def get_thumbnail_environment_folder() -> str:
-    # Only production gets its own S3 folder; every other settings.ENVIRONMENT
-    # value (local, development, qa, test) collapses into "development" so
-    # non-prod thumbnails don't spread across more S3 folders than needed —
-    # colliding with each other is fine, only production needs isolation.
-    if settings.ENVIRONMENT == Environment.production:
-        return Environment.production.value
-    return Environment.development.value
+    return s3_environment_folder(settings.ENVIRONMENT)
 
 
 def get_thumbnail_file_path(public_id: str | int) -> str:

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -27,7 +27,7 @@ from app.models import (
     GeoUnitType,
 )
 from app.thumbnails.main import generate_thumbnail, THUMBNAIL_BUCKET
-from app.core.config import settings
+from app.core.config import settings, s3_environment_folder
 from app.core.db import engine
 
 metadata = MetaData()
@@ -972,7 +972,8 @@ def district_stats_to_feature_collection(
 
 
 def _stats_object_key(public_id: int | str) -> str:
-    return f"plans/display/{public_id}.geojson"
+    folder = s3_environment_folder(settings.ENVIRONMENT)
+    return f"plans/display/{folder}/{public_id}.geojson"
 
 
 def publish_district_stats_to_s3(

--- a/backend/tests/test_thumbnails.py
+++ b/backend/tests/test_thumbnails.py
@@ -1,9 +1,11 @@
 import os
 import pytest
 from tests.constants import FIXTURES_PATH
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from datetime import datetime
+from botocore.exceptions import ClientError
 from app.core.config import settings
+from app.core.io import file_exists
 from app.thumbnails.main import (
     generate_thumbnail,
     generate_blank,
@@ -99,6 +101,24 @@ def test_make_districtrmap_thumbnail_endpoint_schedules_task(client, document_id
 
 
 def test_thumbnail_cdn_redirect(client, document_id):
+    public_id = client.get(f"/api/document/{document_id}").json()["public_id"]
+    with patch("app.thumbnails.main.file_exists", return_value=True):
+        response = client.get(
+            f"/api/document/{public_id}/thumbnail",
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        assert (
+            f"/thumbnails/{get_thumbnail_environment_folder()}/{public_id}.png"
+            in response.headers["location"]
+        )
+
+
+def test_thumbnail_cdn_redirect_resolves_raw_document_id(client, document_id):
+    """Edit/password links carry the raw document UUID (not public_id) in
+    their OG image URL — the endpoint must resolve it to the same thumbnail
+    a public_id lookup would find, not miss because of a mismatched key."""
+    public_id = client.get(f"/api/document/{document_id}").json()["public_id"]
     with patch("app.thumbnails.main.file_exists", return_value=True):
         response = client.get(
             f"/api/document/{document_id}/thumbnail",
@@ -106,9 +126,18 @@ def test_thumbnail_cdn_redirect(client, document_id):
         )
         assert response.status_code == 307
         assert (
-            f"/thumbnails/{get_thumbnail_environment_folder()}/{document_id}.png"
+            f"/thumbnails/{get_thumbnail_environment_folder()}/{public_id}.png"
             in response.headers["location"]
         )
+
+
+def test_thumbnail_unresolvable_id_falls_back_to_placeholder(client):
+    response = client.get(
+        "/api/document/not-a-real-id/thumbnail",
+        follow_redirects=False,
+    )
+    assert response.status_code == 307
+    assert response.headers["location"] == "/home-megaphone.png"
 
 
 def test_thumbnail_file_path_is_environment_scoped(monkeypatch):
@@ -139,3 +168,24 @@ def test_thumbnail_generic_redirect(client, document_id):
         )
         assert response.status_code == 307
         assert response.headers["location"] == "/home-megaphone.png"
+
+
+def test_file_exists_returns_false_on_s3_404_instead_of_raising():
+    """A HeadObject 404 (object genuinely doesn't exist) must fall back to
+    the placeholder image, not surface as an unhandled ClientError/500."""
+    mock_s3 = MagicMock()
+    mock_s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+    with patch.object(type(settings), "get_s3_client", return_value=mock_s3):
+        assert file_exists("s3://some-bucket/thumbnails/production/999999.png") is False
+
+
+def test_file_exists_reraises_non_404_s3_errors():
+    mock_s3 = MagicMock()
+    mock_s3.head_object.side_effect = ClientError(
+        {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadObject"
+    )
+    with patch.object(type(settings), "get_s3_client", return_value=mock_s3):
+        with pytest.raises(ClientError):
+            file_exists("s3://some-bucket/thumbnails/production/999999.png")

--- a/backend/tests/test_thumbnails.py
+++ b/backend/tests/test_thumbnails.py
@@ -8,6 +8,7 @@ from app.thumbnails.main import (
     generate_thumbnail,
     generate_blank,
     get_thumbnail_file_path,
+    get_thumbnail_environment_folder,
     THUMBNAIL_BUCKET,
 )
 
@@ -105,7 +106,7 @@ def test_thumbnail_cdn_redirect(client, document_id):
         )
         assert response.status_code == 307
         assert (
-            f"/thumbnails/{settings.ENVIRONMENT}/{document_id}.png"
+            f"/thumbnails/{get_thumbnail_environment_folder()}/{document_id}.png"
             in response.headers["location"]
         )
 
@@ -120,6 +121,14 @@ def test_thumbnail_file_path_is_environment_scoped(monkeypatch):
     assert dev_path != prod_path
     assert "/development/" in dev_path
     assert "/production/" in prod_path
+
+
+@pytest.mark.parametrize("environment", ["local", "development", "qa", "test"])
+def test_non_production_environments_share_one_thumbnail_folder(
+    monkeypatch, environment
+):
+    monkeypatch.setattr(settings, "ENVIRONMENT", environment)
+    assert get_thumbnail_environment_folder() == "development"
 
 
 def test_thumbnail_generic_redirect(client, document_id):

--- a/backend/tests/test_thumbnails.py
+++ b/backend/tests/test_thumbnails.py
@@ -3,7 +3,13 @@ import pytest
 from tests.constants import FIXTURES_PATH
 from unittest.mock import patch
 from datetime import datetime
-from app.thumbnails.main import generate_thumbnail, generate_blank, THUMBNAIL_BUCKET
+from app.core.config import settings
+from app.thumbnails.main import (
+    generate_thumbnail,
+    generate_blank,
+    get_thumbnail_file_path,
+    THUMBNAIL_BUCKET,
+)
 
 
 @pytest.fixture
@@ -30,7 +36,7 @@ def test_thumbnail_generator(client, document_id_with_assignments, session):
     document_id = document_id_with_assignments
     out_path = f"{FIXTURES_PATH}/{document_id}.png"
     with patch(
-        "app.thumbnails.main.get_document_thumbnail_file_path",
+        "app.thumbnails.main.get_thumbnail_file_path",
         return_value=out_path,
     ):
         # generate_thumbnail now owns its own session when run as a background task,
@@ -63,7 +69,7 @@ def test_blank_thumbnail_generator(client, document_id, session):
     districtrmap_slug = response.json().get("districtr_map_slug")
     out_path = f"{FIXTURES_PATH}/{districtrmap_slug}.png"
     with patch(
-        "app.thumbnails.main.get_document_thumbnail_file_path",
+        "app.thumbnails.main.get_blank_thumbnail_file_path",
         return_value=out_path,
     ):
         generate_blank(
@@ -98,7 +104,22 @@ def test_thumbnail_cdn_redirect(client, document_id):
             follow_redirects=False,
         )
         assert response.status_code == 307
-        assert f"/thumbnails/{document_id}.png" in response.headers["location"]
+        assert (
+            f"/thumbnails/{settings.ENVIRONMENT}/{document_id}.png"
+            in response.headers["location"]
+        )
+
+
+def test_thumbnail_file_path_is_environment_scoped(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    dev_path = get_thumbnail_file_path("123")
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    prod_path = get_thumbnail_file_path("123")
+
+    assert dev_path != prod_path
+    assert "/development/" in dev_path
+    assert "/production/" in prod_path
 
 
 def test_thumbnail_generic_redirect(client, document_id):

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -8,7 +8,9 @@ from app.utils import (
     add_extent_to_districtrmap,
     update_districtrmap,
     GEOID_PREDICATES,
+    _stats_object_key,
 )
+from app.core.config import settings
 from sqlmodel import Session
 import subprocess
 from app.constants import GERRY_DB_SCHEMA
@@ -426,3 +428,15 @@ def handle_full_submission_approve(client, form_response: FullCommentFormRespons
 )
 def test_geoid_predicates(unit_type, geo_id, expected):
     assert GEOID_PREDICATES[unit_type](geo_id) is expected
+
+
+def test_stats_object_key_is_environment_scoped(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    dev_key = _stats_object_key("123")
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    prod_key = _stats_object_key("123")
+
+    assert dev_key != prod_key
+    assert "/development/" in dev_key
+    assert "/production/" in prod_key


### PR DESCRIPTION
### Thumbnail S3 keys collide across environments

Every environment — dev, preview, Fly, AWS — writes map thumbnails to the same S3 bucket at `thumbnails/{public_id}.png`, with no environment segment in the key. `public_id` is a small sequential integer assigned independently per environment, so generating a thumbnail in dev for map #1005 silently overwrites production's real #1005 thumbnail.

**Fix:** the S3 key now includes an environment folder. Split the shared path helper in two: `get_thumbnail_file_path` (public_id-keyed, environment-scoped) and `get_blank_thumbnail_file_path` (`districtr_map_slug`-keyed, intentionally left unprefixed since that string is the same in every environment by design). Only production gets its own folder — `local`, `development`, `qa`, and `test` all collapse into one shared `development` folder, so non-prod thumbnails don't spread across more S3 folders than needed. The three frontend call sites that build the CDN URL directly (`MapSelector`, `PlanGalleryRenderers`, the admin thumbnails page) now go through a shared `thumbnailUrl()` helper mirroring the same collapse logic, reading a new `NEXT_PUBLIC_ENVIRONMENT` set alongside `NEXT_PUBLIC_API_URL` in each deployment's env config (both the Fly and AWS frontend deploy workflows). Kept as direct CDN reads rather than routing through the backend.

### OG image/logo URLs hardcoded to production's domain

`pageMetadataUtils.ts` hardcoded both the per-map OG image URL and the Districtr logo fallback to `beta.districtr.org`, regardless of which environment served the page. Sharing a `dev.districtr.org` link could unfurl a same-numbered production document's thumbnail instead of the one actually being shared.

**Fix:** derive the origin from the current request via `headers()` instead of a hardcoded string, so the image URLs resolve against whichever environment actually served the page.

## Tested

- [x] Backend: `pytest` passes for `test_thumbnails.py`, including new tests asserting the S3 key differs by environment for the same `public_id`, and that `local`/`development`/`qa`/`test` all resolve to the same folder.
- [x] Backend: full `pytest` suite passes (328 passed, 117 skipped — no regressions).
- [x] Frontend: `bun run ts` and `bun run build` both pass clean.
- [x] `docker-compose up pre-commit` passes.
- [x] Live: a freshly-generated thumbnail lands at the new environment-scoped key in a deployed environment.
- [x] Live: sharing a dev/preview link unfurls the correct document's OG image.
