### PR TITLE
Pill population meters: extract DistrictMeters from draw-mode-simplified

### DIFF
--- a/app/src/app/components/sidebar/ConditionalScrollArea.tsx
+++ b/app/src/app/components/sidebar/ConditionalScrollArea.tsx
@@ -15,6 +15,11 @@ import {ScrollArea} from '@radix-ui/themes';
 const DATA_GUTTER = '0.75rem';
 const OUTER_SCROLLBAR_GAP = '0.75rem';
 
+// Total width the scrollbar treatment takes off the content's right edge (box
+// shrink + inner gutter). Header/axis strips rendered outside the ScrollArea
+// must reserve the same amount to stay column-aligned with the rows.
+export const SCROLL_RESERVED_WIDTH = `calc(${DATA_GUTTER} + ${OUTER_SCROLLBAR_GAP})`;
+
 export const ConditionalScrollArea: React.FC<{
   children: React.ReactNode;
   shouldUseScrollableRows: boolean;

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -211,9 +211,20 @@ export const DistrictMeters = () => {
           <Flex gap="2" px="1" pb="1" align="end">
             {showDistrictNumbers && <Box style={{width: numColWidth, flexShrink: 0}} />}
             {showRowIcons && (
-              /* justify-end aligns the lock-all over the rows' lock icons
-                 (second of the two icons in the cluster). */
-              <Flex align="center" justify="end" style={{width: ICONS_WIDTH, flexShrink: 0}}>
+              /* Mirrors the rows' icon cluster exactly — an invisible twin of
+                 the comment button, then the lock — so the lock-all lands
+                 directly above the rows' lock icons (ghost-margin quirks
+                 included). */
+              <Flex align="center" gap="1" style={{width: ICONS_WIDTH, flexShrink: 0}}>
+                <IconButton
+                  variant="ghost"
+                  size="1"
+                  aria-hidden
+                  tabIndex={-1}
+                  style={{visibility: 'hidden'}}
+                >
+                  <LockOpen2Icon />
+                </IconButton>
                 <HelpTip tip="districtLock" openDelay={HELP_TIP_FAST_DELAY}>
                   <IconButton
                     onClick={toggleLockAllAreas}

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -186,19 +186,24 @@ export const DistrictMeters = () => {
             {showRowIcons && <Box style={{width: ICONS_WIDTH, flexShrink: 0}} />}
             <Box flexGrow="1" style={{position: 'relative', alignSelf: 'stretch'}}>
               {!!idealPopulation && tickFraction !== undefined && (
-                <Text
-                  size="1"
-                  color="gray"
-                  style={{
-                    position: 'absolute',
-                    left: `${tickFraction * 100}%`,
-                    bottom: 0,
-                    transform: 'translateX(-50%)',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  Ideal {formatNumber(idealPopulation, NUMBER_FORMATS.STRING)}
-                </Text>
+                /* The label itself is the help trigger — an extra info icon
+                   would crowd the header strip. */
+                <HelpTip tip="idealPopulation" openDelay={HELP_TIP_FAST_DELAY}>
+                  <Text
+                    size="1"
+                    color="gray"
+                    className="cursor-help"
+                    style={{
+                      position: 'absolute',
+                      left: `${tickFraction * 100}%`,
+                      bottom: 0,
+                      transform: 'translateX(-50%)',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Ideal {formatNumber(idealPopulation, NUMBER_FORMATS.STRING)}
+                  </Text>
+                </HelpTip>
               )}
             </Box>
             {showPopNumbers && (

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -43,10 +43,10 @@ const ROW_HEIGHT = 40;
 const TICK_OVERHANG = (ROW_HEIGHT - BAR_HEIGHT) / 2;
 // A playful spring so bars visibly *land* when population changes.
 const BAR_SPRING = 'width 350ms cubic-bezier(0.34, 1.56, 0.64, 1)';
-// Off-the-scale arrow: shaft ends in a triangular head that's taller than the
-// bar, signaling the bar extends beyond the chart.
-const ARROW_HEAD_WIDTH = 16;
-const ARROW_HEAD_OVERHANG = 6;
+// Off-the-scale arrow: shaft ends in a long, slim triangular head just proud
+// of the bar's height, signaling the bar extends beyond the chart.
+const ARROW_HEAD_WIDTH = 28;
+const ARROW_HEAD_OVERHANG = 3;
 
 // Scoreboard-style stat labels: small caps, wide tracking.
 const STAT_LABEL_STYLE: React.CSSProperties = {

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -1,0 +1,394 @@
+'use client';
+import React, {useState} from 'react';
+import {Box, Button, Flex, IconButton, Text, Tooltip} from '@radix-ui/themes';
+import {EyeNoneIcon, EyeOpenIcon, LockClosedIcon, LockOpen2Icon} from '@radix-ui/react-icons';
+import {useMapStore} from '@store/mapStore';
+import {useMapControlsStore} from '@store/mapControlsStore';
+import {useToolbarStore} from '@store/toolbarStore';
+import {useZonePopulations} from '@/app/hooks/useDemography';
+import {useSummaryStats} from '@/app/hooks/useSummaryStats';
+import {useZoneColorGetter} from '@/app/hooks/useZoneColor';
+import {useSelectCommunity} from '@/app/hooks/useSelectCommunity';
+import {ZoneDescriptionPopover} from './ZoneDescriptionPopover';
+import {ConditionalScrollArea} from '../ConditionalScrollArea';
+import {ShowAllDistrictsButton} from '../ShowAllDistrictsButton';
+import {formatNumber} from '@utils/numbers';
+import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
+import {useUiHintStore} from '@store/uiHintStore';
+import {NUMBER_FORMATS} from '@constants/demography/format';
+import {ACCESS_STATES} from '@constants/document/state';
+
+const POP_COL_WIDTH = 112;
+// Bars stop growing on wide sidebars; everything (label strip, rows,
+// scoreboard) shares the cap so columns stay aligned.
+const MAX_METERS_WIDTH = 560;
+const ROW_SCROLL_THRESHOLD = 10;
+// Small plans default to showing every district; larger ones start with
+// started-only.
+const SHOW_ALL_DEFAULT_MAX = 10;
+// Ideal population sits at a fixed tick partway along the track, so a bar can
+// visibly cross it: the darker excess segment past the tick shows how far over
+// a district is (up to 1/IDEAL_TICK = 125% of ideal before clamping).
+const IDEAL_TICK = 0.8;
+const BAR_HEIGHT = 24;
+// Row rhythm: two lines of text (24px + 16px) plus 4px padding either side.
+const ROW_HEIGHT = 48;
+// The per-row ideal-line segment overhangs the bar by this much on each side
+// so the segments join into one continuous line across stacked rows.
+const TICK_OVERHANG = (ROW_HEIGHT - BAR_HEIGHT) / 2;
+// A playful spring so bars visibly *land* when population changes.
+const BAR_SPRING = 'width 350ms cubic-bezier(0.34, 1.56, 0.64, 1)';
+// Arrow tip depth for bars pinned at the end of the track.
+const ARROW_DEPTH = BAR_HEIGHT / 2;
+
+// Scoreboard-style stat labels: small caps, wide tracking.
+const STAT_LABEL_STYLE: React.CSSProperties = {
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  fontSize: 11,
+};
+
+// Unicode minus to match the tabular figures.
+const signedNumber = (value: number) =>
+  `${value < 0 ? '−' : '+'}${formatNumber(Math.abs(value), NUMBER_FORMATS.STRING)}`;
+const signedPercent = (value: number, ideal: number) =>
+  `${value < 0 ? '−' : '+'}${formatNumber(Math.abs(value / ideal), NUMBER_FORMATS.PERCENT)}`;
+
+/**
+ * District overview as a set of population meters: each district's colored bar
+ * fills toward a shared ideal line; population past ideal renders in a darker
+ * shade of the district color. Rows lead with their district number and show
+ * population plus signed deviation. Bars pinned at the track's end (125% of
+ * ideal and beyond) turn their row text red and sharpen into an arrow. A
+ * plan-wide scoreboard (unassigned, top-to-bottom deviation, max deviation)
+ * sits at the bottom.
+ */
+export const DistrictMeters = () => {
+  const {populationData} = useZonePopulations();
+  const {summaryStats} = useSummaryStats();
+  const idealPopulation = summaryStats?.idealpop;
+  const selectedZone = useMapControlsStore(state => state.selectedZone);
+  const lockPaintedAreas = useMapControlsStore(state => state.mapOptions.lockPaintedAreas);
+  const setLockedZones = useMapControlsStore(state => state.setLockedZones);
+  const higlightUnassigned = useMapControlsStore(
+    state => state.mapOptions.higlightUnassigned ?? false
+  );
+  const setMapOptions = useMapControlsStore(state => state.setMapOptions);
+  const requestSidebarTab = useUiHintStore(state => state.requestSidebarTab);
+  const isEditing = useMapControlsStore(state => state.isEditing);
+  const superDraw = useToolbarStore(state => state.superDraw);
+  const access = useMapStore(state => state.mapStatus?.access);
+  const getZoneColor = useZoneColorGetter();
+  const selectCommunity = useSelectCommunity();
+
+  // Both Draw and Super Draw default to started-districts-only (small plans
+  // default to all); null = no explicit choice yet.
+  const [showAllOverride, setShowAllOverride] = useState<boolean | null>(null);
+  const showAll = showAllOverride ?? populationData.length < SHOW_ALL_DEFAULT_MAX;
+  const startedData = populationData.filter(d => (d.total_pop_20 ?? 0) > 0);
+  const visibleData = showAll ? populationData : startedData;
+  const hiddenCount = populationData.length - startedData.length;
+
+  const isReadOnly = access === ACCESS_STATES.READ;
+  const populations = populationData.map(d => d.total_pop_20 ?? 0);
+  // Largest minus smallest district population, unstarted districts included.
+  const topToBottom =
+    populations.length > 0 ? Math.max(...populations) - Math.min(...populations) : undefined;
+  // The single worst signed deviation from ideal across districts.
+  const maxDeviation = idealPopulation
+    ? populations.reduce(
+        (worst, pop) =>
+          Math.abs(pop - idealPopulation) > Math.abs(worst) ? pop - idealPopulation : worst,
+        0
+      )
+    : undefined;
+  const unassigned = summaryStats?.unassigned;
+  const allAssigned = unassigned === 0;
+
+  const handleLockChange = (zone: number) => {
+    if (lockPaintedAreas.includes(zone)) {
+      setLockedZones(lockPaintedAreas.filter(f => f !== zone));
+    } else {
+      setLockedZones([...lockPaintedAreas, zone]);
+    }
+  };
+
+  const handleFindUnassigned = () => {
+    requestSidebarTab('stats');
+  };
+
+  // Fixed number column sized to the widest district number so every bar
+  // starts at the same x.
+  const numColWidth = `${String(populationData.length).length + 1}ch`;
+
+  return (
+    <Flex direction="column" gap="0" mt="2" style={{maxWidth: MAX_METERS_WIDTH, width: '100%'}}>
+      {/* The ideal population, labeled where its line crosses the bars. */}
+      {!!idealPopulation && (
+        <Flex gap="2" px="1" pb="1">
+          {/* Mirrors the rows' leading number column so the label's x-scale
+              matches the bars' tick. */}
+          <Box style={{width: numColWidth, flexShrink: 0}} />
+          <Box flexGrow="1" style={{position: 'relative', height: 18}}>
+            <Text
+              size="1"
+              color="gray"
+              style={{
+                position: 'absolute',
+                left: `${IDEAL_TICK * 100}%`,
+                bottom: 0,
+                transform: 'translateX(-50%)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Ideal {formatNumber(idealPopulation, NUMBER_FORMATS.STRING)}
+            </Text>
+          </Box>
+          <Box style={{width: POP_COL_WIDTH, flexShrink: 0}} />
+        </Flex>
+      )}
+      <ConditionalScrollArea
+        shouldUseScrollableRows={visibleData.length > ROW_SCROLL_THRESHOLD}
+        maxHeight="60vh"
+      >
+        <Flex direction="column" gap="0">
+          {visibleData.map(d => {
+            const population = d.total_pop_20 ?? 0;
+            const fill = idealPopulation ? population / idealPopulation : 0;
+            // Off the scale: the bar is pinned at the track's end (>=125% of
+            // ideal). Only then does the row go red and grow an arrow tip.
+            const offScale = !!idealPopulation && fill >= 1 / IDEAL_TICK;
+            const color = getZoneColor(d.zone);
+            // Population past ideal renders as a darker shade of the
+            // district's own color.
+            const overflowColor = `color-mix(in srgb, ${color} 70%, black)`;
+            const locked = lockPaintedAreas.includes(d.zone);
+            const deviation = idealPopulation ? population - idealPopulation : undefined;
+            return (
+              <Flex
+                key={d.zone}
+                align="center"
+                gap="2"
+                px="1"
+                onClick={() => selectCommunity(d.zone)}
+                className={`cursor-pointer rounded-md transition-colors duration-150 ${
+                  selectedZone === d.zone ? 'bg-[var(--accent-3)]' : 'hover:bg-[var(--gray-2)]'
+                }`}
+                style={{height: ROW_HEIGHT}}
+                data-testid={`district-meter-row-${d.zone}`}
+              >
+                <Text
+                  size="2"
+                  color={offScale ? 'red' : 'gray'}
+                  weight={selectedZone === d.zone ? 'bold' : 'regular'}
+                  style={{
+                    width: numColWidth,
+                    flexShrink: 0,
+                    textAlign: 'right',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {d.zone}
+                </Text>
+                {/* Comment and per-district lock are Super Draw features; plain
+                    Draw rows are just the number, bar, and totals. Icons manage
+                    their own interactions; don't let clicks re-select the row. */}
+                {superDraw && isEditing && (
+                  <Flex align="center" gap="1" flexShrink="0" onClick={e => e.stopPropagation()}>
+                    <ZoneDescriptionPopover zone={d.zone} color={color} />
+                    <Tooltip
+                      content={
+                        locked
+                          ? 'Unlock this district to allow painting over it'
+                          : "Lock this district so it can't be painted over"
+                      }
+                    >
+                      <IconButton
+                        onClick={() => handleLockChange(d.zone)}
+                        variant="ghost"
+                        size="1"
+                        disabled={isReadOnly}
+                        aria-label={
+                          locked ? `Unlock district ${d.zone}` : `Lock district ${d.zone}`
+                        }
+                      >
+                        {locked ? <LockClosedIcon /> : <LockOpen2Icon />}
+                      </IconButton>
+                    </Tooltip>
+                  </Flex>
+                )}
+                <Box flexGrow="1" style={{height: BAR_HEIGHT, position: 'relative'}}>
+                  {/* Track clips the fills; the tick renders outside it so it
+                      can overhang the bar's height. */}
+                  <Box
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      borderRadius: 99,
+                      background: 'var(--gray-a4)',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <Box
+                      style={{
+                        width: `${Math.min(1, fill) * IDEAL_TICK * 100}%`,
+                        height: '100%',
+                        background: color,
+                        transition: BAR_SPRING,
+                      }}
+                    />
+                    {/* Population past ideal crosses the tick in a darker shade
+                        of the district color; pinned at the track's end it
+                        sharpens into an arrow — beyond the scale. */}
+                    {fill > 1 && (
+                      <Box
+                        style={{
+                          position: 'absolute',
+                          left: `${IDEAL_TICK * 100}%`,
+                          top: 0,
+                          bottom: 0,
+                          width: `${(Math.min(fill, 1 / IDEAL_TICK) - 1) * IDEAL_TICK * 100}%`,
+                          background: overflowColor,
+                          transition: BAR_SPRING,
+                          ...(offScale
+                            ? {
+                                clipPath: `polygon(0 0, calc(100% - ${ARROW_DEPTH}px) 0, 100% 50%, calc(100% - ${ARROW_DEPTH}px) 100%, 0 100%)`,
+                              }
+                            : {}),
+                        }}
+                      />
+                    )}
+                  </Box>
+                  {/* Per-row segment of the shared ideal line; the overhang
+                      bridges the gap to the neighboring rows' bars so the line
+                      reads as continuous. */}
+                  <Box
+                    style={{
+                      position: 'absolute',
+                      left: `${IDEAL_TICK * 100}%`,
+                      top: -TICK_OVERHANG,
+                      bottom: -TICK_OVERHANG,
+                      width: 2,
+                      marginLeft: -1,
+                      background: 'var(--gray-a6)',
+                    }}
+                  />
+                </Box>
+                {/* Population with its signed deviation right below. */}
+                <Flex
+                  direction="column"
+                  align="end"
+                  justify="center"
+                  style={{width: POP_COL_WIDTH, flexShrink: 0}}
+                >
+                  <Text
+                    size="3"
+                    weight="medium"
+                    color={offScale ? 'red' : undefined}
+                    style={{fontVariantNumeric: 'tabular-nums', lineHeight: '24px'}}
+                  >
+                    {formatNumber(population, NUMBER_FORMATS.STRING)}
+                  </Text>
+                  {deviation !== undefined && !!idealPopulation && (
+                    <Text
+                      size="1"
+                      color={offScale ? 'red' : 'gray'}
+                      style={{fontVariantNumeric: 'tabular-nums', lineHeight: '16px'}}
+                    >
+                      {signedNumber(deviation)} ({signedPercent(deviation, idealPopulation)})
+                    </Text>
+                  )}
+                </Flex>
+              </Flex>
+            );
+          })}
+        </Flex>
+      </ConditionalScrollArea>
+      <ShowAllDistrictsButton
+        showAll={showAll}
+        onToggle={() => setShowAllOverride(!showAll)}
+        total={populationData.length}
+        hiddenCount={hiddenCount}
+      />
+      {/* Plan-wide scoreboard: always visible, even with unstarted districts. */}
+      <Flex
+        gap="4"
+        px="1"
+        pt="3"
+        mt="2"
+        justify="between"
+        wrap="wrap"
+        style={{borderTop: '1px solid var(--gray-4)'}}
+      >
+        <Flex direction="column">
+          <Text color="gray" style={STAT_LABEL_STYLE}>
+            Unassigned
+          </Text>
+          <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>
+            {unassigned !== undefined ? formatNumber(unassigned, NUMBER_FORMATS.STRING) : '—'}
+          </Text>
+          {!allAssigned && isEditing && (
+            <Flex gap="2" mt="1">
+              {/* Same toggle-button treatment as Lock painted. */}
+              <Button
+                size="1"
+                variant={higlightUnassigned ? 'solid' : 'surface'}
+                color="gray"
+                highContrast={higlightUnassigned}
+                onClick={() => setMapOptions({higlightUnassigned: !higlightUnassigned})}
+                aria-pressed={higlightUnassigned}
+              >
+                {higlightUnassigned ? <EyeOpenIcon /> : <EyeNoneIcon />}
+                Show on map
+              </Button>
+              <Button
+                size="1"
+                variant="ghost"
+                onClick={handleFindUnassigned}
+                style={{fontWeight: 600}}
+              >
+                Find areas →
+              </Button>
+            </Flex>
+          )}
+        </Flex>
+        <Flex direction="column">
+          <Flex align="center" gap="0">
+            <Text color="gray" style={STAT_LABEL_STYLE}>
+              Top-to-bottom
+            </Text>
+            <HelpTip tip="topToBottomDeviation" openDelay={HELP_TIP_FAST_DELAY} />
+          </Flex>
+          <Flex align="baseline" gap="1">
+            <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>
+              {topToBottom !== undefined ? formatNumber(topToBottom, NUMBER_FORMATS.STRING) : '—'}
+            </Text>
+            {topToBottom !== undefined && !!idealPopulation && (
+              <Text size="1" color="gray" style={{fontVariantNumeric: 'tabular-nums'}}>
+                {formatNumber(topToBottom / idealPopulation, NUMBER_FORMATS.PERCENT)}
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+        <Flex direction="column" align="end">
+          <Flex align="center" gap="0">
+            <Text color="gray" style={STAT_LABEL_STYLE}>
+              Max deviation
+            </Text>
+            <HelpTip tip="maxDeviation" openDelay={HELP_TIP_FAST_DELAY} />
+          </Flex>
+          <Flex align="baseline" gap="1">
+            <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>
+              {maxDeviation !== undefined ? signedNumber(maxDeviation) : '—'}
+            </Text>
+            {maxDeviation !== undefined && !!idealPopulation && (
+              <Text size="1" color="gray" style={{fontVariantNumeric: 'tabular-nums'}}>
+                {signedPercent(maxDeviation, idealPopulation)}
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -5,6 +5,7 @@ import {EyeNoneIcon, EyeOpenIcon, LockClosedIcon, LockOpen2Icon} from '@radix-ui
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {useToolbarStore} from '@store/toolbarStore';
+import {useChartStore} from '@store/chartStore';
 import {useZonePopulations} from '@/app/hooks/useDemography';
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {useZoneColorGetter} from '@/app/hooks/useZoneColor';
@@ -18,7 +19,11 @@ import {useUiHintStore} from '@store/uiHintStore';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {ACCESS_STATES} from '@constants/document/state';
 
-const POP_COL_WIDTH = 112;
+const POP_COL_WIDTH = 76;
+const DEV_COL_WIDTH = 76;
+// Mirrors the rows' Super Draw icon cluster (two size-1 icon buttons + gap) so
+// the header strip's x-scale matches the bars' when icons are showing.
+const ICONS_WIDTH = 52;
 // Bars stop growing on wide sidebars; everything (label strip, rows,
 // scoreboard) shares the cap so columns stay aligned.
 const MAX_METERS_WIDTH = 560;
@@ -31,21 +36,32 @@ const SHOW_ALL_DEFAULT_MAX = 10;
 // a district is (up to 1/IDEAL_TICK = 125% of ideal before clamping).
 const IDEAL_TICK = 0.8;
 const BAR_HEIGHT = 24;
-// Row rhythm: two lines of text (24px + 16px) plus 4px padding either side.
-const ROW_HEIGHT = 48;
+// Row rhythm: one line of column text beside a 24px bar, plus breathing room.
+const ROW_HEIGHT = 40;
 // The per-row ideal-line segment overhangs the bar by this much on each side
 // so the segments join into one continuous line across stacked rows.
 const TICK_OVERHANG = (ROW_HEIGHT - BAR_HEIGHT) / 2;
 // A playful spring so bars visibly *land* when population changes.
 const BAR_SPRING = 'width 350ms cubic-bezier(0.34, 1.56, 0.64, 1)';
-// Arrow tip depth for bars pinned at the end of the track.
-const ARROW_DEPTH = BAR_HEIGHT / 2;
+// Off-the-scale arrow: shaft ends in a triangular head that's taller than the
+// bar, signaling the bar extends beyond the chart.
+const ARROW_HEAD_WIDTH = 16;
+const ARROW_HEAD_OVERHANG = 6;
 
 // Scoreboard-style stat labels: small caps, wide tracking.
 const STAT_LABEL_STYLE: React.CSSProperties = {
   textTransform: 'uppercase',
   letterSpacing: '0.08em',
   fontSize: 11,
+};
+
+// Column headers read bottom-to-top over the number columns.
+const COL_LABEL_STYLE: React.CSSProperties = {
+  writingMode: 'vertical-rl',
+  transform: 'rotate(180deg)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontSize: 10,
 };
 
 // Unicode minus to match the tabular figures.
@@ -58,10 +74,14 @@ const signedPercent = (value: number, ideal: number) =>
  * District overview as a set of population meters: each district's colored bar
  * fills toward a shared ideal line; population past ideal renders in a darker
  * shade of the district color. Rows lead with their district number and show
- * population plus signed deviation. Bars pinned at the track's end (125% of
- * ideal and beyond) turn their row text red and sharpen into an arrow. A
- * plan-wide scoreboard (unassigned, top-to-bottom deviation, max deviation)
- * sits at the bottom.
+ * population and signed deviation in labeled columns. Bars pinned at the
+ * track's end (125% of ideal and beyond) turn their row text red and become an
+ * arrow pointing off the chart. A plan-wide scoreboard (unassigned,
+ * top-to-bottom deviation, max deviation) sits at the bottom.
+ *
+ * Honors the population chart settings (chartStore): column visibility, bar
+ * scaling (zero-to-ideal vs. current range), and the target-deviation band
+ * around the ideal line.
  */
 export const DistrictMeters = () => {
   const {populationData} = useZonePopulations();
@@ -78,6 +98,7 @@ export const DistrictMeters = () => {
   const isEditing = useMapControlsStore(state => state.isEditing);
   const superDraw = useToolbarStore(state => state.superDraw);
   const access = useMapStore(state => state.mapStatus?.access);
+  const chartOptions = useChartStore(state => state.chartOptions);
   const getZoneColor = useZoneColorGetter();
   const selectCommunity = useSelectCommunity();
 
@@ -88,9 +109,28 @@ export const DistrictMeters = () => {
   const startedData = populationData.filter(d => (d.total_pop_20 ?? 0) > 0);
   const visibleData = showAll ? populationData : startedData;
   const hiddenCount = populationData.length - startedData.length;
+  const nothingStarted = startedData.length === 0;
+
+  // Population chart settings (the settings popover in Super Draw).
+  const showDistrictNumbers = chartOptions.popShowDistrictNumbers;
+  const showPopNumbers = chartOptions.popShowPopNumbers;
+  const showDeviations = chartOptions.popShowTopBottomDeviation;
+  const scaleToCurrent = chartOptions.popBarScaleToCurrent;
+  const targetDeviation = chartOptions.popTargetPopDeviation;
 
   const isReadOnly = access === ACCESS_STATES.READ;
   const populations = populationData.map(d => d.total_pop_20 ?? 0);
+  const maxPopulation = populations.length > 0 ? Math.max(...populations) : 0;
+  // Population represented by the full track. Zero-to-ideal mode fixes the
+  // scale at 125% of ideal (so ideal sits at the IDEAL_TICK); current-range
+  // mode stretches the largest bar to the track's end instead.
+  const scaleTotal = idealPopulation
+    ? scaleToCurrent
+      ? Math.max(maxPopulation, idealPopulation)
+      : idealPopulation / IDEAL_TICK
+    : undefined;
+  const tickFraction = idealPopulation && scaleTotal ? idealPopulation / scaleTotal : undefined;
+
   // Largest minus smallest district population, unstarted districts included.
   const topToBottom =
     populations.length > 0 ? Math.max(...populations) - Math.min(...populations) : undefined;
@@ -120,196 +160,292 @@ export const DistrictMeters = () => {
   // Fixed number column sized to the widest district number so every bar
   // starts at the same x.
   const numColWidth = `${String(populationData.length).length + 1}ch`;
+  const showRowIcons = superDraw && isEditing;
+
+  // The target-deviation band brackets the ideal line; rendered per row (like
+  // the tick) so it reads as one continuous band.
+  const band =
+    targetDeviation && idealPopulation && scaleTotal
+      ? {
+          left: Math.max(0, (idealPopulation - targetDeviation) / scaleTotal),
+          right: Math.min(1, (idealPopulation + targetDeviation) / scaleTotal),
+        }
+      : undefined;
 
   return (
     <Flex direction="column" gap="0" mt="2" style={{maxWidth: MAX_METERS_WIDTH, width: '100%'}}>
-      {/* The ideal population, labeled where its line crosses the bars. */}
-      {!!idealPopulation && (
-        <Flex gap="2" px="1" pb="1">
-          {/* Mirrors the rows' leading number column so the label's x-scale
-              matches the bars' tick. */}
-          <Box style={{width: numColWidth, flexShrink: 0}} />
-          <Box flexGrow="1" style={{position: 'relative', height: 18}}>
-            <Text
-              size="1"
-              color="gray"
-              style={{
-                position: 'absolute',
-                left: `${IDEAL_TICK * 100}%`,
-                bottom: 0,
-                transform: 'translateX(-50%)',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Ideal {formatNumber(idealPopulation, NUMBER_FORMATS.STRING)}
-            </Text>
-          </Box>
-          <Box style={{width: POP_COL_WIDTH, flexShrink: 0}} />
-        </Flex>
-      )}
-      <ConditionalScrollArea
-        shouldUseScrollableRows={visibleData.length > ROW_SCROLL_THRESHOLD}
-        maxHeight="60vh"
-      >
-        <Flex direction="column" gap="0">
-          {visibleData.map(d => {
-            const population = d.total_pop_20 ?? 0;
-            const fill = idealPopulation ? population / idealPopulation : 0;
-            // Off the scale: the bar is pinned at the track's end (>=125% of
-            // ideal). Only then does the row go red and grow an arrow tip.
-            const offScale = !!idealPopulation && fill >= 1 / IDEAL_TICK;
-            const color = getZoneColor(d.zone);
-            // Population past ideal renders as a darker shade of the
-            // district's own color.
-            const overflowColor = `color-mix(in srgb, ${color} 70%, black)`;
-            const locked = lockPaintedAreas.includes(d.zone);
-            const deviation = idealPopulation ? population - idealPopulation : undefined;
-            return (
-              <Flex
-                key={d.zone}
-                align="center"
-                gap="2"
-                px="1"
-                onClick={() => selectCommunity(d.zone)}
-                className={`cursor-pointer rounded-md transition-colors duration-150 ${
-                  selectedZone === d.zone ? 'bg-[var(--accent-3)]' : 'hover:bg-[var(--gray-2)]'
-                }`}
-                style={{height: ROW_HEIGHT}}
-                data-testid={`district-meter-row-${d.zone}`}
-              >
+      {nothingStarted ? (
+        <Text color="gray" size="2" my="4" style={{textAlign: 'center'}}>
+          Start painting to see population bars
+        </Text>
+      ) : (
+        <>
+          {/* Header strip: vertical column labels, and the ideal population
+              labeled where its line crosses the bars. */}
+          <Flex gap="2" px="1" pb="1" align="end">
+            {showDistrictNumbers && <Box style={{width: numColWidth, flexShrink: 0}} />}
+            {showRowIcons && <Box style={{width: ICONS_WIDTH, flexShrink: 0}} />}
+            <Box flexGrow="1" style={{position: 'relative', alignSelf: 'stretch'}}>
+              {!!idealPopulation && tickFraction !== undefined && (
                 <Text
-                  size="2"
-                  color={offScale ? 'red' : 'gray'}
-                  weight={selectedZone === d.zone ? 'bold' : 'regular'}
+                  size="1"
+                  color="gray"
                   style={{
-                    width: numColWidth,
-                    flexShrink: 0,
-                    textAlign: 'right',
-                    fontVariantNumeric: 'tabular-nums',
+                    position: 'absolute',
+                    left: `${tickFraction * 100}%`,
+                    bottom: 0,
+                    transform: 'translateX(-50%)',
+                    whiteSpace: 'nowrap',
                   }}
                 >
-                  {d.zone}
+                  Ideal {formatNumber(idealPopulation, NUMBER_FORMATS.STRING)}
                 </Text>
-                {/* Comment and per-district lock are Super Draw features; plain
-                    Draw rows are just the number, bar, and totals. Icons manage
-                    their own interactions; don't let clicks re-select the row. */}
-                {superDraw && isEditing && (
-                  <Flex align="center" gap="1" flexShrink="0" onClick={e => e.stopPropagation()}>
-                    <ZoneDescriptionPopover zone={d.zone} color={color} />
-                    <Tooltip
-                      content={
-                        locked
-                          ? 'Unlock this district to allow painting over it'
-                          : "Lock this district so it can't be painted over"
-                      }
-                    >
-                      <IconButton
-                        onClick={() => handleLockChange(d.zone)}
-                        variant="ghost"
-                        size="1"
-                        disabled={isReadOnly}
-                        aria-label={
-                          locked ? `Unlock district ${d.zone}` : `Lock district ${d.zone}`
-                        }
-                      >
-                        {locked ? <LockClosedIcon /> : <LockOpen2Icon />}
-                      </IconButton>
-                    </Tooltip>
-                  </Flex>
-                )}
-                <Box flexGrow="1" style={{height: BAR_HEIGHT, position: 'relative'}}>
-                  {/* Track clips the fills; the tick renders outside it so it
-                      can overhang the bar's height. */}
-                  <Box
-                    style={{
-                      position: 'absolute',
-                      inset: 0,
-                      borderRadius: 99,
-                      background: 'var(--gray-a4)',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    <Box
-                      style={{
-                        width: `${Math.min(1, fill) * IDEAL_TICK * 100}%`,
-                        height: '100%',
-                        background: color,
-                        transition: BAR_SPRING,
-                      }}
-                    />
-                    {/* Population past ideal crosses the tick in a darker shade
-                        of the district color; pinned at the track's end it
-                        sharpens into an arrow — beyond the scale. */}
-                    {fill > 1 && (
-                      <Box
-                        style={{
-                          position: 'absolute',
-                          left: `${IDEAL_TICK * 100}%`,
-                          top: 0,
-                          bottom: 0,
-                          width: `${(Math.min(fill, 1 / IDEAL_TICK) - 1) * IDEAL_TICK * 100}%`,
-                          background: overflowColor,
-                          transition: BAR_SPRING,
-                          ...(offScale
-                            ? {
-                                clipPath: `polygon(0 0, calc(100% - ${ARROW_DEPTH}px) 0, 100% 50%, calc(100% - ${ARROW_DEPTH}px) 100%, 0 100%)`,
-                              }
-                            : {}),
-                        }}
-                      />
-                    )}
-                  </Box>
-                  {/* Per-row segment of the shared ideal line; the overhang
-                      bridges the gap to the neighboring rows' bars so the line
-                      reads as continuous. */}
-                  <Box
-                    style={{
-                      position: 'absolute',
-                      left: `${IDEAL_TICK * 100}%`,
-                      top: -TICK_OVERHANG,
-                      bottom: -TICK_OVERHANG,
-                      width: 2,
-                      marginLeft: -1,
-                      background: 'var(--gray-a6)',
-                    }}
-                  />
-                </Box>
-                {/* Population with its signed deviation right below. */}
-                <Flex
-                  direction="column"
-                  align="end"
-                  justify="center"
-                  style={{width: POP_COL_WIDTH, flexShrink: 0}}
-                >
-                  <Text
-                    size="3"
-                    weight="medium"
-                    color={offScale ? 'red' : undefined}
-                    style={{fontVariantNumeric: 'tabular-nums', lineHeight: '24px'}}
-                  >
-                    {formatNumber(population, NUMBER_FORMATS.STRING)}
-                  </Text>
-                  {deviation !== undefined && !!idealPopulation && (
-                    <Text
-                      size="1"
-                      color={offScale ? 'red' : 'gray'}
-                      style={{fontVariantNumeric: 'tabular-nums', lineHeight: '16px'}}
-                    >
-                      {signedNumber(deviation)} ({signedPercent(deviation, idealPopulation)})
-                    </Text>
-                  )}
-                </Flex>
+              )}
+            </Box>
+            {showPopNumbers && (
+              <Flex justify="center" style={{width: POP_COL_WIDTH, flexShrink: 0}}>
+                <Text color="gray" style={COL_LABEL_STYLE}>
+                  Population
+                </Text>
               </Flex>
-            );
-          })}
-        </Flex>
-      </ConditionalScrollArea>
-      <ShowAllDistrictsButton
-        showAll={showAll}
-        onToggle={() => setShowAllOverride(!showAll)}
-        total={populationData.length}
-        hiddenCount={hiddenCount}
-      />
+            )}
+            {showDeviations && (
+              <Flex justify="center" style={{width: DEV_COL_WIDTH, flexShrink: 0}}>
+                <Text color="gray" style={COL_LABEL_STYLE}>
+                  Deviation
+                </Text>
+              </Flex>
+            )}
+          </Flex>
+          <ConditionalScrollArea
+            shouldUseScrollableRows={visibleData.length > ROW_SCROLL_THRESHOLD}
+            maxHeight="60vh"
+          >
+            <Flex direction="column" gap="0">
+              {visibleData.map(d => {
+                const population = d.total_pop_20 ?? 0;
+                const fill = scaleTotal ? population / scaleTotal : 0;
+                // Off the scale: the bar is pinned at the track's end (only
+                // possible in zero-to-ideal scaling, at >=125% of ideal). The
+                // row goes red and the bar becomes an arrow off the chart.
+                const offScale = !!scaleTotal && !scaleToCurrent && fill >= 1;
+                const color = getZoneColor(d.zone);
+                // Population past ideal renders as a darker shade of the
+                // district's own color.
+                const overflowColor = `color-mix(in srgb, ${color} 70%, black)`;
+                const locked = lockPaintedAreas.includes(d.zone);
+                const deviation = idealPopulation ? population - idealPopulation : undefined;
+                const overflowsIdeal =
+                  tickFraction !== undefined && !!idealPopulation && population > idealPopulation;
+                return (
+                  <Flex
+                    key={d.zone}
+                    align="center"
+                    gap="2"
+                    px="1"
+                    onClick={() => selectCommunity(d.zone)}
+                    className={`cursor-pointer rounded-md transition-colors duration-150 ${
+                      selectedZone === d.zone ? 'bg-[var(--accent-3)]' : 'hover:bg-[var(--gray-2)]'
+                    }`}
+                    style={{height: ROW_HEIGHT}}
+                    data-testid={`district-meter-row-${d.zone}`}
+                  >
+                    {showDistrictNumbers && (
+                      <Text
+                        size="2"
+                        color={offScale ? 'red' : 'gray'}
+                        weight={selectedZone === d.zone ? 'bold' : 'regular'}
+                        style={{
+                          width: numColWidth,
+                          flexShrink: 0,
+                          textAlign: 'right',
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {d.zone}
+                      </Text>
+                    )}
+                    {/* Comment and per-district lock are Super Draw features; plain
+                        Draw rows are just the number, bar, and totals. Icons manage
+                        their own interactions; don't let clicks re-select the row. */}
+                    {showRowIcons && (
+                      <Flex
+                        align="center"
+                        gap="1"
+                        flexShrink="0"
+                        style={{width: ICONS_WIDTH}}
+                        onClick={e => e.stopPropagation()}
+                      >
+                        <ZoneDescriptionPopover zone={d.zone} color={color} />
+                        <Tooltip
+                          content={
+                            locked
+                              ? 'Unlock this district to allow painting over it'
+                              : "Lock this district so it can't be painted over"
+                          }
+                        >
+                          <IconButton
+                            onClick={() => handleLockChange(d.zone)}
+                            variant="ghost"
+                            size="1"
+                            disabled={isReadOnly}
+                            aria-label={
+                              locked ? `Unlock district ${d.zone}` : `Lock district ${d.zone}`
+                            }
+                          >
+                            {locked ? <LockClosedIcon /> : <LockOpen2Icon />}
+                          </IconButton>
+                        </Tooltip>
+                      </Flex>
+                    )}
+                    <Box flexGrow="1" style={{height: BAR_HEIGHT, position: 'relative'}}>
+                      {offScale && tickFraction !== undefined ? (
+                        /* Off the scale: no pill track — the bar itself becomes
+                           an arrow. Rounded cap on the left, darker shaft past
+                           the ideal line, and an oversized head extending past
+                           the bar's height: this district is off the chart. */
+                        <>
+                          <Box
+                            style={{
+                              position: 'absolute',
+                              top: 0,
+                              bottom: 0,
+                              left: 0,
+                              width: `${tickFraction * 100}%`,
+                              background: color,
+                              borderRadius: '99px 0 0 99px',
+                            }}
+                          />
+                          <Box
+                            style={{
+                              position: 'absolute',
+                              top: 0,
+                              bottom: 0,
+                              left: `${tickFraction * 100}%`,
+                              right: ARROW_HEAD_WIDTH - 1,
+                              background: overflowColor,
+                            }}
+                          />
+                          <Box
+                            style={{
+                              position: 'absolute',
+                              right: 0,
+                              top: -ARROW_HEAD_OVERHANG,
+                              bottom: -ARROW_HEAD_OVERHANG,
+                              width: ARROW_HEAD_WIDTH,
+                              background: overflowColor,
+                              clipPath: 'polygon(0 0, 100% 50%, 0 100%)',
+                            }}
+                          />
+                        </>
+                      ) : (
+                        <Box
+                          style={{
+                            position: 'absolute',
+                            inset: 0,
+                            borderRadius: 99,
+                            background: 'var(--gray-a4)',
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <Box
+                            style={{
+                              width: `${Math.min(fill, tickFraction ?? 1) * 100}%`,
+                              height: '100%',
+                              background: color,
+                              transition: BAR_SPRING,
+                            }}
+                          />
+                          {/* Population past ideal crosses the tick in a darker
+                              shade of the district color. */}
+                          {overflowsIdeal && tickFraction !== undefined && (
+                            <Box
+                              style={{
+                                position: 'absolute',
+                                left: `${tickFraction * 100}%`,
+                                top: 0,
+                                bottom: 0,
+                                width: `${(Math.min(fill, 1) - tickFraction) * 100}%`,
+                                background: overflowColor,
+                                transition: BAR_SPRING,
+                              }}
+                            />
+                          )}
+                        </Box>
+                      )}
+                      {/* Target-deviation band bracketing the ideal line. */}
+                      {band && (
+                        <Box
+                          style={{
+                            position: 'absolute',
+                            left: `${band.left * 100}%`,
+                            width: `${(band.right - band.left) * 100}%`,
+                            top: -TICK_OVERHANG,
+                            bottom: -TICK_OVERHANG,
+                            background: 'var(--gray-a3)',
+                            pointerEvents: 'none',
+                          }}
+                        />
+                      )}
+                      {/* Per-row segment of the shared ideal line; the overhang
+                          bridges the gap to the neighboring rows' bars so the
+                          line reads as continuous. */}
+                      {tickFraction !== undefined && (
+                        <Box
+                          style={{
+                            position: 'absolute',
+                            left: `${tickFraction * 100}%`,
+                            top: -TICK_OVERHANG,
+                            bottom: -TICK_OVERHANG,
+                            width: 2,
+                            marginLeft: -1,
+                            background: 'var(--gray-a6)',
+                          }}
+                        />
+                      )}
+                    </Box>
+                    {showPopNumbers && (
+                      <Text
+                        size="2"
+                        weight="medium"
+                        color={offScale ? 'red' : undefined}
+                        style={{
+                          width: POP_COL_WIDTH,
+                          flexShrink: 0,
+                          textAlign: 'right',
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {formatNumber(population, NUMBER_FORMATS.STRING)}
+                      </Text>
+                    )}
+                    {showDeviations && (
+                      <Text
+                        size="2"
+                        color={offScale ? 'red' : 'gray'}
+                        style={{
+                          width: DEV_COL_WIDTH,
+                          flexShrink: 0,
+                          textAlign: 'right',
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {deviation !== undefined ? signedNumber(deviation) : '—'}
+                      </Text>
+                    )}
+                  </Flex>
+                );
+              })}
+            </Flex>
+          </ConditionalScrollArea>
+          <ShowAllDistrictsButton
+            showAll={showAll}
+            onToggle={() => setShowAllOverride(!showAll)}
+            total={populationData.length}
+            hiddenCount={hiddenCount}
+          />
+        </>
+      )}
       {/* Plan-wide scoreboard: always visible, even with unstarted districts. */}
       <Flex
         gap="4"
@@ -353,7 +489,7 @@ export const DistrictMeters = () => {
           )}
         </Flex>
         <Flex direction="column">
-          <Flex align="center" gap="0">
+          <Flex align="center" gap="1">
             <Text color="gray" style={STAT_LABEL_STYLE}>
               Top-to-bottom
             </Text>
@@ -371,7 +507,7 @@ export const DistrictMeters = () => {
           </Flex>
         </Flex>
         <Flex direction="column" align="end">
-          <Flex align="center" gap="0">
+          <Flex align="center" gap="1">
             <Text color="gray" style={STAT_LABEL_STYLE}>
               Max deviation
             </Text>

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -89,11 +89,15 @@ export const DistrictMeters = () => {
   const selectedZone = useMapControlsStore(state => state.selectedZone);
   const lockPaintedAreas = useMapControlsStore(state => state.mapOptions.lockPaintedAreas);
   const setLockedZones = useMapControlsStore(state => state.setLockedZones);
+  const toggleLockAllAreas = useMapControlsStore(state => state.toggleLockAllAreas);
   const higlightUnassigned = useMapControlsStore(
     state => state.mapOptions.higlightUnassigned ?? false
   );
   const setMapOptions = useMapControlsStore(state => state.setMapOptions);
   const requestSidebarTab = useUiHintStore(state => state.requestSidebarTab);
+  const stackedSidebar = useToolbarStore(state => state.stackedSidebar);
+  const sidebarPanels = useMapControlsStore(state => state.sidebarPanels);
+  const setSidebarPanels = useMapControlsStore(state => state.setSidebarPanels);
   const isEditing = useMapControlsStore(state => state.isEditing);
   const superDraw = useToolbarStore(state => state.superDraw);
   const access = useMapStore(state => state.mapStatus?.access);
@@ -152,6 +156,8 @@ export const DistrictMeters = () => {
   const unassigned = summaryStats?.unassigned;
   const allAssigned = unassigned === 0;
 
+  const allLocked =
+    populationData.length > 0 && populationData.every(d => lockPaintedAreas.includes(d.zone));
   const handleLockChange = (zone: number) => {
     if (lockPaintedAreas.includes(zone)) {
       setLockedZones(lockPaintedAreas.filter(f => f !== zone));
@@ -161,6 +167,19 @@ export const DistrictMeters = () => {
   };
 
   const handleFindUnassigned = () => {
+    // Super Draw's stacked layout has no workflow tabs mounted (their request
+    // would be discarded); open the validity accordion card directly instead.
+    if (superDraw && stackedSidebar) {
+      if (!sidebarPanels.includes('mapValidation')) {
+        setSidebarPanels([...sidebarPanels, 'mapValidation']);
+      }
+      setTimeout(() => {
+        document
+          .querySelector('[data-testid="data-panel-mapValidation"]')
+          ?.scrollIntoView({behavior: 'smooth', block: 'start'});
+      }, 100);
+      return;
+    }
     requestSidebarTab('stats');
   };
 
@@ -191,7 +210,23 @@ export const DistrictMeters = () => {
               labeled where its line crosses the bars. */}
           <Flex gap="2" px="1" pb="1" align="end">
             {showDistrictNumbers && <Box style={{width: numColWidth, flexShrink: 0}} />}
-            {showRowIcons && <Box style={{width: ICONS_WIDTH, flexShrink: 0}} />}
+            {showRowIcons && (
+              /* justify-end aligns the lock-all over the rows' lock icons
+                 (second of the two icons in the cluster). */
+              <Flex align="center" justify="end" style={{width: ICONS_WIDTH, flexShrink: 0}}>
+                <HelpTip tip="districtLock" openDelay={HELP_TIP_FAST_DELAY}>
+                  <IconButton
+                    onClick={toggleLockAllAreas}
+                    variant="ghost"
+                    size="1"
+                    disabled={isReadOnly}
+                    aria-label={allLocked ? 'Unlock all districts' : 'Lock all districts'}
+                  >
+                    {allLocked ? <LockClosedIcon /> : <LockOpen2Icon />}
+                  </IconButton>
+                </HelpTip>
+              </Flex>
+            )}
             <Box flexGrow="1" style={{position: 'relative', alignSelf: 'stretch'}}>
               {!!idealPopulation && tickFraction !== undefined && (
                 /* The label itself is the help trigger — an extra info icon
@@ -269,8 +304,20 @@ export const DistrictMeters = () => {
                     align="center"
                     gap="2"
                     px="1"
+                    // Row-as-button keeps keyboard selection reachable (the
+                    // old per-row IconButton was focusable); a real <button>
+                    // can't wrap the nested lock/comment controls.
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Select district ${d.zone}`}
                     onClick={() => selectCommunity(d.zone)}
-                    className={`cursor-pointer rounded-md transition-colors duration-150 ${
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        selectCommunity(d.zone);
+                      }
+                    }}
+                    className={`cursor-pointer rounded-md transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-8)] ${
                       selectedZone === d.zone ? 'bg-[var(--accent-3)]' : 'hover:bg-[var(--gray-2)]'
                     }`}
                     style={{height: ROW_HEIGHT}}
@@ -490,7 +537,7 @@ export const DistrictMeters = () => {
             {unassigned !== undefined ? formatNumber(unassigned, NUMBER_FORMATS.STRING) : '—'}
           </Text>
           {!allAssigned && isEditing && (
-            <Flex gap="2" mt="1">
+            <Flex gap="3" mt="1" align="center">
               {/* Same toggle-button treatment as Lock painted. */}
               <Button
                 size="1"
@@ -507,7 +554,9 @@ export const DistrictMeters = () => {
                 size="1"
                 variant="ghost"
                 onClick={handleFindUnassigned}
-                style={{fontWeight: 600}}
+                // Neutralize the ghost variant's optical negative margins so
+                // the two buttons sit on one line at matching heights.
+                style={{fontWeight: 600, margin: 0}}
               >
                 Find areas →
               </Button>

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -34,7 +34,7 @@ const ICONS_WIDTH = 56;
 // margin eats half of it: measured against the rendered rows, its real trailing
 // space is 4px, not 8. The header's invisible twin uses the measured value —
 // copying the mr-2 class instead puts the lock-all 4px right of the rows'.
-const TWIN_TRAIL = 4;
+const TWIN_TRAIL = 6;
 // Bars stop growing on wide sidebars; everything (label strip, rows,
 // scoreboard) shares the cap so columns stay aligned.
 const MAX_METERS_WIDTH = 560;

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -55,10 +55,9 @@ const STAT_LABEL_STYLE: React.CSSProperties = {
   fontSize: 11,
 };
 
-// Column headers read bottom-to-top over the number columns.
+// Column headers over the number columns; kept terse ("Pop") so they fit the
+// column width horizontally.
 const COL_LABEL_STYLE: React.CSSProperties = {
-  writingMode: 'vertical-rl',
-  transform: 'rotate(180deg)',
   textTransform: 'uppercase',
   letterSpacing: '0.06em',
   fontSize: 10,
@@ -203,18 +202,30 @@ export const DistrictMeters = () => {
               )}
             </Box>
             {showPopNumbers && (
-              <Flex justify="center" style={{width: POP_COL_WIDTH, flexShrink: 0}}>
-                <Text color="gray" style={COL_LABEL_STYLE}>
-                  Population
-                </Text>
-              </Flex>
+              <Text
+                color="gray"
+                style={{
+                  ...COL_LABEL_STYLE,
+                  width: POP_COL_WIDTH,
+                  flexShrink: 0,
+                  textAlign: 'right',
+                }}
+              >
+                Pop
+              </Text>
             )}
             {showDeviations && (
-              <Flex justify="center" style={{width: DEV_COL_WIDTH, flexShrink: 0}}>
-                <Text color="gray" style={COL_LABEL_STYLE}>
-                  Deviation
-                </Text>
-              </Flex>
+              <Text
+                color="gray"
+                style={{
+                  ...COL_LABEL_STYLE,
+                  width: DEV_COL_WIDTH,
+                  flexShrink: 0,
+                  textAlign: 'right',
+                }}
+              >
+                Deviation
+              </Text>
             )}
           </Flex>
           <ConditionalScrollArea

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -1,7 +1,13 @@
 'use client';
 import React, {useEffect, useState} from 'react';
 import {Box, Button, Flex, IconButton, Text, Tooltip} from '@radix-ui/themes';
-import {EyeNoneIcon, EyeOpenIcon, LockClosedIcon, LockOpen2Icon} from '@radix-ui/react-icons';
+import {
+  ChevronRightIcon,
+  EyeNoneIcon,
+  EyeOpenIcon,
+  LockClosedIcon,
+  LockOpen2Icon,
+} from '@radix-ui/react-icons';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {useToolbarStore} from '@store/toolbarStore';
@@ -11,19 +17,24 @@ import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {useZoneColorGetter} from '@/app/hooks/useZoneColor';
 import {useSelectCommunity} from '@/app/hooks/useSelectCommunity';
 import {ZoneDescriptionPopover} from './ZoneDescriptionPopover';
-import {ConditionalScrollArea} from '../ConditionalScrollArea';
+import {ConditionalScrollArea, SCROLL_RESERVED_WIDTH} from '../ConditionalScrollArea';
 import {ShowAllDistrictsButton} from '../ShowAllDistrictsButton';
 import {formatNumber} from '@utils/numbers';
 import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
-import {useUiHintStore} from '@store/uiHintStore';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {ACCESS_STATES} from '@constants/document/state';
 
 const POP_COL_WIDTH = 76;
 const DEV_COL_WIDTH = 76;
-// Mirrors the rows' Super Draw icon cluster (two size-1 icon buttons + gap) so
-// the header strip's x-scale matches the bars' when icons are showing.
-const ICONS_WIDTH = 52;
+// Mirrors the rows' Super Draw icon cluster so the header strip's x-scale
+// matches the bars' when icons are showing: two size-1 icon buttons (24px), the
+// cluster gap (4px), and the comment button's trailing space (TWIN_TRAIL).
+const ICONS_WIDTH = 56;
+// ZoneDescriptionPopover's trigger carries mr-2, but its ghost-variant negative
+// margin eats half of it: measured against the rendered rows, its real trailing
+// space is 4px, not 8. The header's invisible twin uses the measured value —
+// copying the mr-2 class instead puts the lock-all 4px right of the rows'.
+const TWIN_TRAIL = 4;
 // Bars stop growing on wide sidebars; everything (label strip, rows,
 // scoreboard) shares the cap so columns stay aligned.
 const MAX_METERS_WIDTH = 560;
@@ -43,16 +54,26 @@ const ROW_HEIGHT = 40;
 const TICK_OVERHANG = (ROW_HEIGHT - BAR_HEIGHT) / 2;
 // A playful spring so bars visibly *land* when population changes.
 const BAR_SPRING = 'width 350ms cubic-bezier(0.34, 1.56, 0.64, 1)';
-// Off-the-scale arrow: shaft ends in a long, slim triangular head just proud
-// of the bar's height, signaling the bar extends beyond the chart.
-const ARROW_HEAD_WIDTH = 28;
-const ARROW_HEAD_OVERHANG = 3;
+// Off-the-scale bars end flat, with one chevron per 25% over ideal (capped at
+// three) marking how far past the track the district runs.
+const CHEVRON_STEP = 0.25;
+const MAX_CHEVRONS = 3;
 
 // Scoreboard-style stat labels: small caps, wide tracking.
 const STAT_LABEL_STYLE: React.CSSProperties = {
   textTransform: 'uppercase',
   letterSpacing: '0.08em',
   fontSize: 11,
+};
+
+// A row's numeric cells. Digits sit ~1.5px above their line box's center (the
+// descender space below the baseline goes unused), so they read as floating
+// high beside the geometrically-centered bar; the nudge optically centers them.
+const NUM_CELL_STYLE: React.CSSProperties = {
+  flexShrink: 0,
+  textAlign: 'right',
+  fontVariantNumeric: 'tabular-nums',
+  transform: 'translateY(1.5px)',
 };
 
 // Column headers over the number columns; kept terse ("Pop") so they fit the
@@ -69,18 +90,43 @@ const signedNumber = (value: number) =>
 const signedPercent = (value: number, ideal: number) =>
   `${value < 0 ? '−' : '+'}${formatNumber(Math.abs(value / ideal), NUMBER_FORMATS.PERCENT)}`;
 
+// Population past ideal darkens toward black as the overage grows: the excess
+// segment starts 30% black at the ideal line and is fully black at 100% over.
+const overflowColorFor = (color: string, population: number, ideal?: number) => {
+  const overRatio = ideal ? Math.min(1, Math.max(0, (population - ideal) / ideal)) : 0;
+  return `color-mix(in srgb, ${color} ${Math.round(70 * (1 - overRatio))}%, black)`;
+};
+
+// Chevrons stacked at the bar's flat end: one per 25% over ideal, three max.
+const chevronCount = (population: number, ideal: number) =>
+  Math.min(MAX_CHEVRONS, Math.floor((population - ideal) / ideal / CHEVRON_STEP));
+
+/** "Keeps going" marker on an off-the-scale bar's end. */
+const OffScaleChevrons: React.FC<{count: number}> = ({count}) => (
+  <Flex
+    align="center"
+    aria-hidden
+    style={{position: 'absolute', top: 0, bottom: 0, right: 4, color: 'white'}}
+  >
+    {Array.from({length: count}, (_, i) => (
+      // Overlapped so the chevrons read as one ">>" cluster, not spaced icons.
+      <ChevronRightIcon key={i} style={{marginRight: i < count - 1 ? -6 : 0}} />
+    ))}
+  </Flex>
+);
+
 /**
  * District overview as a set of population meters: each district's colored bar
  * fills toward a shared ideal line; population past ideal renders in a darker
  * shade of the district color. Rows lead with their district number and show
  * population and signed deviation in labeled columns. Bars pinned at the
- * track's end (125% of ideal and beyond) turn their row text red and become an
- * arrow pointing off the chart. A plan-wide scoreboard (unassigned,
- * top-to-bottom deviation, max deviation) sits at the bottom.
+ * track's end (125% of ideal and beyond) turn their row text red and carry a
+ * chevron per 25% over ideal. A plan-wide scoreboard (unassigned, top-to-bottom
+ * deviation, max deviation) sits at the bottom; the two deviation stats only
+ * resolve once every district is started.
  *
- * Honors the population chart settings (chartStore): column visibility, bar
- * scaling (zero-to-ideal vs. current range), and the target-deviation band
- * around the ideal line.
+ * Honors the population chart settings (chartStore): column visibility and the
+ * target-deviation band around the ideal line.
  */
 export const DistrictMeters = () => {
   const {populationData} = useZonePopulations();
@@ -94,10 +140,6 @@ export const DistrictMeters = () => {
     state => state.mapOptions.higlightUnassigned ?? false
   );
   const setMapOptions = useMapControlsStore(state => state.setMapOptions);
-  const requestSidebarTab = useUiHintStore(state => state.requestSidebarTab);
-  const stackedSidebar = useToolbarStore(state => state.stackedSidebar);
-  const sidebarPanels = useMapControlsStore(state => state.sidebarPanels);
-  const setSidebarPanels = useMapControlsStore(state => state.setSidebarPanels);
   const isEditing = useMapControlsStore(state => state.isEditing);
   const superDraw = useToolbarStore(state => state.superDraw);
   const access = useMapStore(state => state.mapStatus?.access);
@@ -105,8 +147,8 @@ export const DistrictMeters = () => {
   const setChartOptions = useChartStore(state => state.setChartOptions);
 
   // Plain Draw has no chart-settings UI, so leaving Super Draw resets the
-  // options — otherwise hidden columns or alternate scaling would be stranded
-  // with no way to undo them.
+  // options — otherwise hidden columns or a target-deviation band would be
+  // stranded with no way to undo them.
   useEffect(() => {
     if (!superDraw) setChartOptions(DEFAULT_CHART_OPTIONS);
   }, [superDraw, setChartOptions]);
@@ -118,41 +160,45 @@ export const DistrictMeters = () => {
   const [showAllOverride, setShowAllOverride] = useState<boolean | null>(null);
   const showAll = showAllOverride ?? populationData.length < SHOW_ALL_DEFAULT_MAX;
   const startedData = populationData.filter(d => (d.total_pop_20 ?? 0) > 0);
-  const visibleData = showAll ? populationData : startedData;
-  const hiddenCount = populationData.length - startedData.length;
+  // The selected district always gets a row, started or not: picking an empty
+  // district to draw into and having no bar appear reads as a broken panel.
+  const visibleData = showAll
+    ? populationData
+    : populationData.filter(d => (d.total_pop_20 ?? 0) > 0 || d.zone === selectedZone);
+  const hiddenCount = showAll
+    ? populationData.length - startedData.length
+    : populationData.length - visibleData.length;
   const nothingStarted = startedData.length === 0;
 
   // Population chart settings (the settings popover in Super Draw).
   const showDistrictNumbers = chartOptions.popShowDistrictNumbers;
   const showPopNumbers = chartOptions.popShowPopNumbers;
   const showDeviations = chartOptions.popShowTopBottomDeviation;
-  const scaleToCurrent = chartOptions.popBarScaleToCurrent;
   const targetDeviation = chartOptions.popTargetPopDeviation;
 
   const isReadOnly = access === ACCESS_STATES.READ;
   const populations = populationData.map(d => d.total_pop_20 ?? 0);
-  const maxPopulation = populations.length > 0 ? Math.max(...populations) : 0;
-  // Population represented by the full track. Zero-to-ideal mode fixes the
-  // scale at 125% of ideal (so ideal sits at the IDEAL_TICK); current-range
-  // mode stretches the largest bar to the track's end instead.
-  const scaleTotal = idealPopulation
-    ? scaleToCurrent
-      ? Math.max(maxPopulation, idealPopulation)
-      : idealPopulation / IDEAL_TICK
-    : undefined;
+  // Population represented by the full track: 125% of ideal, so ideal sits at
+  // the IDEAL_TICK.
+  const scaleTotal = idealPopulation ? idealPopulation / IDEAL_TICK : undefined;
   const tickFraction = idealPopulation && scaleTotal ? idealPopulation / scaleTotal : undefined;
 
-  // Largest minus smallest district population, unstarted districts included.
-  const topToBottom =
-    populations.length > 0 ? Math.max(...populations) - Math.min(...populations) : undefined;
+  // Plan-wide deviation stats are meaningless while districts sit at zero
+  // population (top-to-bottom would just be the largest district), so they
+  // stay unresolved until every district is started.
+  const allStarted = populations.length > 0 && populations.every(pop => pop > 0);
+  // Largest minus smallest district population.
+  const topToBottom = allStarted ? Math.max(...populations) - Math.min(...populations) : undefined;
   // The single worst signed deviation from ideal across districts.
-  const maxDeviation = idealPopulation
-    ? populations.reduce(
-        (worst, pop) =>
-          Math.abs(pop - idealPopulation) > Math.abs(worst) ? pop - idealPopulation : worst,
-        0
-      )
-    : undefined;
+  const maxDeviation =
+    allStarted && idealPopulation
+      ? populations.reduce(
+          (worst, pop) =>
+            Math.abs(pop - idealPopulation) > Math.abs(worst) ? pop - idealPopulation : worst,
+          0
+        )
+      : undefined;
+  const pendingStatTitle = allStarted ? undefined : 'Available once every district is started';
   const unassigned = summaryStats?.unassigned;
   const allAssigned = unassigned === 0;
 
@@ -166,27 +212,11 @@ export const DistrictMeters = () => {
     }
   };
 
-  const handleFindUnassigned = () => {
-    // Super Draw's stacked layout has no workflow tabs mounted (their request
-    // would be discarded); open the validity accordion card directly instead.
-    if (superDraw && stackedSidebar) {
-      if (!sidebarPanels.includes('mapValidation')) {
-        setSidebarPanels([...sidebarPanels, 'mapValidation']);
-      }
-      setTimeout(() => {
-        document
-          .querySelector('[data-testid="data-panel-mapValidation"]')
-          ?.scrollIntoView({behavior: 'smooth', block: 'start'});
-      }, 100);
-      return;
-    }
-    requestSidebarTab('stats');
-  };
-
   // Fixed number column sized to the widest district number so every bar
   // starts at the same x.
   const numColWidth = `${String(populationData.length).length + 1}ch`;
   const showRowIcons = superDraw && isEditing;
+  const rowsScroll = visibleData.length > ROW_SCROLL_THRESHOLD;
 
   // The target-deviation band brackets the ideal line; rendered per row (like
   // the tick) so it reads as one continuous band.
@@ -207,8 +237,21 @@ export const DistrictMeters = () => {
       ) : (
         <>
           {/* Header strip: vertical column labels, and the ideal population
-              labeled where its line crosses the bars. */}
-          <Flex gap="2" px="1" pb="1" align="end">
+              labeled where its line crosses the bars. It sits outside the
+              rows' ScrollArea, so it has to reserve the same right-edge width
+              the scrollbar takes or the columns and the ideal line drift out
+              from under their labels. */}
+          <Flex
+            gap="2"
+            px="1"
+            pb="1"
+            align="end"
+            style={
+              rowsScroll
+                ? {paddingRight: `calc(var(--space-1) + ${SCROLL_RESERVED_WIDTH})`}
+                : undefined
+            }
+          >
             {showDistrictNumbers && <Box style={{width: numColWidth, flexShrink: 0}} />}
             {showRowIcons && (
               /* Mirrors the rows' icon cluster exactly — an invisible twin of
@@ -221,7 +264,7 @@ export const DistrictMeters = () => {
                   size="1"
                   aria-hidden
                   tabIndex={-1}
-                  style={{visibility: 'hidden'}}
+                  style={{visibility: 'hidden', marginRight: TWIN_TRAIL}}
                 >
                   <LockOpen2Icon />
                 </IconButton>
@@ -287,24 +330,17 @@ export const DistrictMeters = () => {
               </Text>
             )}
           </Flex>
-          <ConditionalScrollArea
-            shouldUseScrollableRows={visibleData.length > ROW_SCROLL_THRESHOLD}
-            maxHeight="60vh"
-          >
+          <ConditionalScrollArea shouldUseScrollableRows={rowsScroll} maxHeight="60vh">
             <Flex direction="column" gap="0">
               {visibleData.map(d => {
                 const population = d.total_pop_20 ?? 0;
                 const fill = scaleTotal ? population / scaleTotal : 0;
-                // Off the scale: 125% of ideal and beyond. The row goes red
-                // and the bar becomes an arrow — in zero-to-ideal scaling it's
-                // pinned at the track's end, in current-range scaling the
-                // arrow ends wherever the bar does.
+                // Off the scale: 125% of ideal and beyond. The row goes red and
+                // the bar, pinned at the track's end, breaks off in a squiggle.
                 const offScale = !!idealPopulation && population >= idealPopulation / IDEAL_TICK;
-                const barEnd = Math.min(fill, 1);
+                const chevrons = idealPopulation ? chevronCount(population, idealPopulation) : 0;
                 const color = getZoneColor(d.zone);
-                // Population past ideal renders as a darker shade of the
-                // district's own color.
-                const overflowColor = `color-mix(in srgb, ${color} 70%, black)`;
+                const overflowColor = overflowColorFor(color, population, idealPopulation);
                 const locked = lockPaintedAreas.includes(d.zone);
                 const deviation = idealPopulation ? population - idealPopulation : undefined;
                 const overflowsIdeal =
@@ -315,20 +351,12 @@ export const DistrictMeters = () => {
                     align="center"
                     gap="2"
                     px="1"
-                    // Row-as-button keeps keyboard selection reachable (the
-                    // old per-row IconButton was focusable); a real <button>
-                    // can't wrap the nested lock/comment controls.
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`Select district ${d.zone}`}
+                    // Clicking anywhere on the row selects it, but the row
+                    // itself stays a plain div: a role="button" wrapping the
+                    // lock/comment controls is invalid ARIA and hides them
+                    // from assistive tech. The bar carries the real <button>.
                     onClick={() => selectCommunity(d.zone)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        selectCommunity(d.zone);
-                      }
-                    }}
-                    className={`cursor-pointer rounded-md transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-8)] ${
+                    className={`cursor-pointer rounded-md transition-colors duration-150 ${
                       selectedZone === d.zone ? 'bg-[var(--accent-3)]' : 'hover:bg-[var(--gray-2)]'
                     }`}
                     style={{height: ROW_HEIGHT}}
@@ -339,12 +367,7 @@ export const DistrictMeters = () => {
                         size="2"
                         color={offScale ? 'red' : 'gray'}
                         weight={selectedZone === d.zone ? 'bold' : 'regular'}
-                        style={{
-                          width: numColWidth,
-                          flexShrink: 0,
-                          textAlign: 'right',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
+                        style={{...NUM_CELL_STYLE, width: numColWidth}}
                       >
                         {d.zone}
                       </Text>
@@ -382,12 +405,31 @@ export const DistrictMeters = () => {
                         </Tooltip>
                       </Flex>
                     )}
-                    <Box flexGrow="1" style={{height: BAR_HEIGHT, position: 'relative'}}>
+                    {/* The bar is the row's keyboard/AT control — a real
+                        <button>, unlike the row, which has to wrap the
+                        lock/comment buttons. Its clicks (including the one
+                        Enter/Space synthesizes) bubble to the row's handler,
+                        so it needs no onClick of its own. */}
+                    <button
+                      type="button"
+                      aria-label={`Select district ${d.zone}`}
+                      className="rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-8)]"
+                      style={{
+                        flexGrow: 1,
+                        height: BAR_HEIGHT,
+                        position: 'relative',
+                        padding: 0,
+                        border: 'none',
+                        background: 'none',
+                        cursor: 'pointer',
+                        outlineOffset: 2,
+                      }}
+                    >
                       {offScale && tickFraction !== undefined ? (
-                        /* Off the scale: no pill track — the bar itself becomes
-                           an arrow. Rounded cap on the left, darker shaft past
-                           the ideal line, and an oversized head extending past
-                           the bar's height: this district is off the chart. */
+                        /* Off the scale: no pill track — the bar runs to the
+                           track's end and stops flat. Rounded cap on the left,
+                           darker shaft past the ideal line, and chevrons on the
+                           end: this district is off the chart. */
                         <>
                           <Box
                             style={{
@@ -406,21 +448,11 @@ export const DistrictMeters = () => {
                               top: 0,
                               bottom: 0,
                               left: `${tickFraction * 100}%`,
-                              right: `calc(${(1 - barEnd) * 100}% + ${ARROW_HEAD_WIDTH - 1}px)`,
+                              right: 0,
                               background: overflowColor,
                             }}
                           />
-                          <Box
-                            style={{
-                              position: 'absolute',
-                              left: `calc(${barEnd * 100}% - ${ARROW_HEAD_WIDTH}px)`,
-                              top: -ARROW_HEAD_OVERHANG,
-                              bottom: -ARROW_HEAD_OVERHANG,
-                              width: ARROW_HEAD_WIDTH,
-                              background: overflowColor,
-                              clipPath: 'polygon(0 0, 100% 50%, 0 100%)',
-                            }}
-                          />
+                          <OffScaleChevrons count={chevrons} />
                         </>
                       ) : (
                         <Box
@@ -487,18 +519,13 @@ export const DistrictMeters = () => {
                           }}
                         />
                       )}
-                    </Box>
+                    </button>
                     {showPopNumbers && (
                       <Text
                         size="2"
                         weight="medium"
                         color={offScale ? 'red' : undefined}
-                        style={{
-                          width: POP_COL_WIDTH,
-                          flexShrink: 0,
-                          textAlign: 'right',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
+                        style={{...NUM_CELL_STYLE, width: POP_COL_WIDTH}}
                       >
                         {formatNumber(population, NUMBER_FORMATS.STRING)}
                       </Text>
@@ -507,14 +534,11 @@ export const DistrictMeters = () => {
                       <Text
                         size="2"
                         color={offScale ? 'red' : 'gray'}
-                        style={{
-                          width: DEV_COL_WIDTH,
-                          flexShrink: 0,
-                          textAlign: 'right',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
+                        style={{...NUM_CELL_STYLE, width: DEV_COL_WIDTH}}
                       >
-                        {deviation !== undefined ? signedNumber(deviation) : '—'}
+                        {/* An unstarted district's "deviation" is just the
+                            ideal restated as a negative; leave it blank. */}
+                        {population > 0 && deviation !== undefined ? signedNumber(deviation) : '—'}
                       </Text>
                     )}
                   </Flex>
@@ -561,16 +585,6 @@ export const DistrictMeters = () => {
                 {higlightUnassigned ? <EyeOpenIcon /> : <EyeNoneIcon />}
                 Show on map
               </Button>
-              <Button
-                size="1"
-                variant="ghost"
-                onClick={handleFindUnassigned}
-                // Neutralize the ghost variant's optical negative margins so
-                // the two buttons sit on one line at matching heights.
-                style={{fontWeight: 600, margin: 0}}
-              >
-                Find areas →
-              </Button>
             </Flex>
           )}
         </Flex>
@@ -585,7 +599,7 @@ export const DistrictMeters = () => {
               <HelpTip tip="topToBottomDeviation" openDelay={HELP_TIP_FAST_DELAY} />
             </Flex>
           </Flex>
-          <Flex align="baseline" gap="1">
+          <Flex align="baseline" gap="1" title={pendingStatTitle}>
             <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>
               {topToBottom !== undefined ? formatNumber(topToBottom, NUMBER_FORMATS.STRING) : '—'}
             </Text>
@@ -605,7 +619,7 @@ export const DistrictMeters = () => {
               <HelpTip tip="maxDeviation" openDelay={HELP_TIP_FAST_DELAY} />
             </Flex>
           </Flex>
-          <Flex align="baseline" gap="1">
+          <Flex align="baseline" gap="1" title={pendingStatTitle}>
             <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>
               {maxDeviation !== undefined ? signedNumber(maxDeviation) : '—'}
             </Text>

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -509,7 +509,11 @@ export const DistrictMeters = () => {
             <Text color="gray" style={STAT_LABEL_STYLE}>
               Top-to-bottom
             </Text>
-            <HelpTip tip="topToBottomDeviation" openDelay={HELP_TIP_FAST_DELAY} />
+            {/* Counters the trigger icon's built-in baseline nudge (made for
+                body text) so it centers on the small-caps label line. */}
+            <Flex align="center" style={{transform: 'translateY(-1.5px)'}}>
+              <HelpTip tip="topToBottomDeviation" openDelay={HELP_TIP_FAST_DELAY} />
+            </Flex>
           </Flex>
           <Flex align="baseline" gap="1">
             <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>
@@ -527,7 +531,9 @@ export const DistrictMeters = () => {
             <Text color="gray" style={STAT_LABEL_STYLE}>
               Max deviation
             </Text>
-            <HelpTip tip="maxDeviation" openDelay={HELP_TIP_FAST_DELAY} />
+            <Flex align="center" style={{transform: 'translateY(-1.5px)'}}>
+              <HelpTip tip="maxDeviation" openDelay={HELP_TIP_FAST_DELAY} />
+            </Flex>
           </Flex>
           <Flex align="baseline" gap="1">
             <Text size="4" weight="bold" style={{fontVariantNumeric: 'tabular-nums'}}>

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -32,7 +32,7 @@ const DEV_COL_WIDTH = 76;
 const ICONS_WIDTH = 56;
 // ZoneDescriptionPopover's trigger carries mr-2, but its ghost-variant negative
 // margin eats half of it: measured against the rendered rows, its real trailing
-// space is 4px, not 8. The header's invisible twin uses the measured value —
+// space is 6px, not 8. The header's invisible twin uses the measured value —
 // copying the mr-2 class instead puts the lock-all 4px right of the rows'.
 const TWIN_TRAIL = 6;
 // Bars stop growing on wide sidebars; everything (label strip, rows,

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -1,11 +1,11 @@
 'use client';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Box, Button, Flex, IconButton, Text, Tooltip} from '@radix-ui/themes';
 import {EyeNoneIcon, EyeOpenIcon, LockClosedIcon, LockOpen2Icon} from '@radix-ui/react-icons';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {useToolbarStore} from '@store/toolbarStore';
-import {useChartStore} from '@store/chartStore';
+import {DEFAULT_CHART_OPTIONS, useChartStore} from '@store/chartStore';
 import {useZonePopulations} from '@/app/hooks/useDemography';
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {useZoneColorGetter} from '@/app/hooks/useZoneColor';
@@ -98,6 +98,14 @@ export const DistrictMeters = () => {
   const superDraw = useToolbarStore(state => state.superDraw);
   const access = useMapStore(state => state.mapStatus?.access);
   const chartOptions = useChartStore(state => state.chartOptions);
+  const setChartOptions = useChartStore(state => state.setChartOptions);
+
+  // Plain Draw has no chart-settings UI, so leaving Super Draw resets the
+  // options — otherwise hidden columns or alternate scaling would be stranded
+  // with no way to undo them.
+  useEffect(() => {
+    if (!superDraw) setChartOptions(DEFAULT_CHART_OPTIONS);
+  }, [superDraw, setChartOptions]);
   const getZoneColor = useZoneColorGetter();
   const selectCommunity = useSelectCommunity();
 
@@ -241,10 +249,12 @@ export const DistrictMeters = () => {
               {visibleData.map(d => {
                 const population = d.total_pop_20 ?? 0;
                 const fill = scaleTotal ? population / scaleTotal : 0;
-                // Off the scale: the bar is pinned at the track's end (only
-                // possible in zero-to-ideal scaling, at >=125% of ideal). The
-                // row goes red and the bar becomes an arrow off the chart.
-                const offScale = !!scaleTotal && !scaleToCurrent && fill >= 1;
+                // Off the scale: 125% of ideal and beyond. The row goes red
+                // and the bar becomes an arrow — in zero-to-ideal scaling it's
+                // pinned at the track's end, in current-range scaling the
+                // arrow ends wherever the bar does.
+                const offScale = !!idealPopulation && population >= idealPopulation / IDEAL_TICK;
+                const barEnd = Math.min(fill, 1);
                 const color = getZoneColor(d.zone);
                 // Population past ideal renders as a darker shade of the
                 // district's own color.
@@ -338,14 +348,14 @@ export const DistrictMeters = () => {
                               top: 0,
                               bottom: 0,
                               left: `${tickFraction * 100}%`,
-                              right: ARROW_HEAD_WIDTH - 1,
+                              right: `calc(${(1 - barEnd) * 100}% + ${ARROW_HEAD_WIDTH - 1}px)`,
                               background: overflowColor,
                             }}
                           />
                           <Box
                             style={{
                               position: 'absolute',
-                              right: 0,
+                              left: `calc(${barEnd * 100}% - ${ARROW_HEAD_WIDTH}px)`,
                               top: -ARROW_HEAD_OVERHANG,
                               bottom: -ARROW_HEAD_OVERHANG,
                               width: ARROW_HEAD_WIDTH,

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -1,8 +1,7 @@
 import {Flex, Heading, IconButton, Spinner, Text} from '@radix-ui/themes';
 import React, {useMemo, useState} from 'react';
-import {formatDeviationPct, formatNumber} from '@utils/numbers';
 import {ParentSize} from '@visx/responsive'; // Import ParentSize
-import {HelpTip, HELP_TIP_HOVER_DELAY, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
+import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
 import {useChartStore} from '@store/chartStore';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
@@ -18,21 +17,19 @@ import {
   getChartHeight,
 } from './PopulationChart/PopulationChart';
 import {PopulationPanelOptions} from './PopulationPanelOptions';
+import {DistrictMeters} from './DistrictMeters';
 import {LockClosedIcon, LockOpen2Icon, Pencil1Icon} from '@radix-ui/react-icons';
 import {useZonePopulations} from '@/app/hooks/useDemography';
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {ZoneDescriptionPopover} from './ZoneDescriptionPopover';
-import {FALLBACK_NUM_DISTRICTS} from '@/app/constants/map/layerStyle';
 import {ConditionalScrollArea} from '../ConditionalScrollArea';
-import {FALLBACK_NUM_COMMUNITIES} from '@constants/document/limits';
 import {useZoneColorGetter} from '@/app/hooks/useZoneColor';
 import {getCommunityRenderOrderId, getUnusedCommunityColors} from '@/app/utils/communities';
 import {useSelectCommunity} from '@/app/hooks/useSelectCommunity';
 import {EditCommunityDialog} from '@/app/components/Toolbar/EditCommunityDialog';
 import {useColorScheme} from '@/app/hooks/useColorScheme';
-import {MAP_MODES, MAP_MODE_LABELS, MAP_MODE_LABEL_PLURAL} from '@constants/map/mode';
+import {MAP_MODES, MAP_MODE_LABELS} from '@constants/map/mode';
 import {ACCESS_STATES} from '@constants/document/state';
-import {NUMBER_FORMATS} from '@constants/demography/format';
 
 // The "Ideal" label and the axis render in separate fixed strips above/below the
 // (scrollable) rows, so all three rows must use the same fixed left column width to
@@ -46,24 +43,13 @@ const POP_LEFT_COL_TOP_SPACER =
 
 export const PopulationPanel = () => {
   const {populationData, demoIsLoaded} = useZonePopulations();
-  const {summaryStats, zoneStats} = useSummaryStats();
+  const {summaryStats} = useSummaryStats();
   const idealPopulation = summaryStats?.idealpop;
-  const unassigned = summaryStats.unassigned;
   const mapDocument = useMapStore(state => state.mapDocument);
   const mapMode = useMapControlsStore(state => state.mapMode);
-  const numDistricts = useMapStore(
-    state => state.mapDocument?.num_districts ?? FALLBACK_NUM_DISTRICTS
-  );
-  const numCommunities = useMapStore(state => state.numCommunities ?? FALLBACK_NUM_COMMUNITIES);
-  const numZones = mapMode === MAP_MODES.COI ? numCommunities : numDistricts;
   const zoneLabel = MAP_MODE_LABELS[mapMode];
   const isCommunityMode = mapMode === MAP_MODES.COI;
   const effectiveIdealPopulation = isCommunityMode ? undefined : idealPopulation;
-  const zoneLabelPlural = MAP_MODE_LABEL_PLURAL[mapMode];
-  const allPainted =
-    numZones === populationData.length &&
-    zoneStats.minPopulation !== undefined &&
-    zoneStats.minPopulation > 0;
 
   const lockPaintedAreas = useMapControlsStore(state => state.mapOptions.lockPaintedAreas);
   const chartOptions = useChartStore(state => state.chartOptions);
@@ -151,196 +137,175 @@ export const PopulationPanel = () => {
         shouldUseScrollableRows ? {maxHeight: '80vh', overflow: 'hidden'} : {maxHeight: '80vh'}
       }
     >
-      <Flex direction="row" gap={'2'} align="center">
-        <Heading as="h3" size="3">
-          {`Total population by ${zoneLabel}`}
-        </Heading>
-        {superDraw && (
-          <PopulationPanelOptions
-            chartOptions={chartOptions}
-            setChartOptions={setChartOptions}
-            idealPopulation={effectiveIdealPopulation}
-          />
-        )}
-      </Flex>
-      {/* Fixed header: lock-all control + "Ideal" label strip. Never scrolls.
+      {/* The Population tab already names the panel; only COI mode (with its
+          different zone label) keeps a heading. */}
+      {(isCommunityMode || superDraw) && (
+        <Flex direction="row" gap={'2'} align="center">
+          {isCommunityMode && (
+            <Heading as="h3" size="3">
+              {`Total population by ${zoneLabel}`}
+            </Heading>
+          )}
+          {superDraw && (
+            <PopulationPanelOptions
+              chartOptions={chartOptions}
+              setChartOptions={setChartOptions}
+              idealPopulation={effectiveIdealPopulation}
+            />
+          )}
+        </Flex>
+      )}
+      {/* Districts render as population meters; the visx bar chart remains for
+          COI mode, which has no ideal population to meter against. */}
+      {!isCommunityMode ? (
+        <DistrictMeters />
+      ) : (
+        <>
+          {/* Fixed header: lock-all control + "Ideal" label strip. Never scrolls.
           align="center" on this row matters: the default cross-axis "stretch" would
           force the left column to its sibling strip's height (POP_CHART_LABEL_HEIGHT)
           instead of the icon's natural size, centering the lock-all icon at a
           different height than the per-district rows' own lock icons. */}
-      <Flex direction="row" width={'100%'} gap="1" mt="2" align="center">
-        <Flex justify="end" align="center" style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}}>
-          {!isCommunityMode && (
-            <HelpTip tip="districtLock" openDelay={HELP_TIP_HOVER_DELAY}>
-              <IconButton
-                onClick={toggleLockAllAreas}
-                variant="ghost"
-                size="1"
-                disabled={access === ACCESS_STATES.READ}
-                style={{opacity: isEditing ? 1 : 0}}
-                aria-label={allAreLocked ? 'Unlock all districts' : 'Lock all districts'}
-              >
-                {allAreLocked ? <LockClosedIcon /> : <LockOpen2Icon />}
-              </IconButton>
-            </HelpTip>
-          )}
-        </Flex>
-        <ParentSize style={{height: `${POP_CHART_LABEL_HEIGHT}px`, width: '100%'}}>
-          {({width}) => (
-            <PopulationChartIdealLabel
-              width={width}
-              data={populationData}
-              idealPopulation={effectiveIdealPopulation}
-            />
-          )}
-        </ParentSize>
-      </Flex>
-      <div style={{position: 'relative'}}>
-        <ConditionalScrollArea
-          shouldUseScrollableRows={shouldUseScrollableRows}
-          // Show 10.6 rows so the half-visible row signals more content below;
-          // 60vh keeps the panel usable on short viewports.
-          maxHeight={`min(60vh, ${POP_CHART_MARGINS.top + Math.round(10.6 * POP_ROW_HEIGHT)}px)`}
-        >
-          <Flex direction="row" width={'100%'} gap="1">
-            <Flex
-              direction={'column'}
-              className={'flex-grow-0 p-0'}
-              style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}}
-            >
-              <Flex style={{height: POP_LEFT_COL_TOP_SPACER}} />
-              {/* @ts-ignore */}
-              {populationData.map(d => (
-                <Flex
-                  key={d.zone}
-                  direction={'row'}
-                  gapX="1"
-                  align={'center'}
-                  className="p-0 m-0"
-                  justify={'between'}
-                  style={{height: POP_ROW_HEIGHT}}
-                >
-                  {!!showDistrictNumbers && (
-                    <IconButton
-                      variant={'outline'}
-                      onClick={() => selectCommunity(d.zone)}
-                      size="1"
-                      className={`${selectedZone === d.zone ? 'bg-gray-100' : '!shadow-none'} max-w-12 flex-grow`}
-                    >
-                      <Text weight={selectedZone === d.zone ? 'bold' : 'regular'}>
-                        {mapMode === MAP_MODES.COI
-                          ? (getCommunityRenderOrderId(communities, d.zone) ?? d.zone)
-                          : d.zone}
-                      </Text>
-                    </IconButton>
-                  )}
-                  <Flex gap="0" align="center">
-                    <ZoneDescriptionPopover zone={d.zone} color={getZoneColor(d.zone)} />
-                    {!!isEditing && (
-                      <>
-                        {isCommunityMode ? (
-                          <IconButton
-                            onClick={() => handleEditCommunity(d.zone)}
-                            variant="ghost"
-                            size="1"
-                            disabled={access === ACCESS_STATES.READ}
-                            aria-label={`Edit community ${d.zone}`}
-                          >
-                            <Pencil1Icon />
-                          </IconButton>
-                        ) : (
-                          <HelpTip tip="districtLock" openDelay={HELP_TIP_HOVER_DELAY}>
-                            <IconButton
-                              onClick={() => handleLockChange(d.zone)}
-                              variant="ghost"
-                              size="1"
-                              disabled={access === ACCESS_STATES.READ}
-                              aria-label={
-                                lockPaintedAreas.includes(d.zone)
-                                  ? `Unlock district ${d.zone}`
-                                  : `Lock district ${d.zone}`
-                              }
-                            >
-                              {lockPaintedAreas.includes(d.zone) ? (
-                                <LockClosedIcon />
-                              ) : (
-                                <LockOpen2Icon />
-                              )}
-                            </IconButton>
-                          </HelpTip>
-                        )}
-                      </>
-                    )}
-                  </Flex>
-                </Flex>
-              ))}
+          <Flex direction="row" width={'100%'} gap="1" mt="2" align="center">
+            <Flex justify="end" align="center" style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}}>
+              {!isCommunityMode && (
+                <HelpTip tip="districtLock" openDelay={HELP_TIP_HOVER_DELAY}>
+                  <IconButton
+                    onClick={toggleLockAllAreas}
+                    variant="ghost"
+                    size="1"
+                    disabled={access === ACCESS_STATES.READ}
+                    style={{opacity: isEditing ? 1 : 0}}
+                    aria-label={allAreLocked ? 'Unlock all districts' : 'Lock all districts'}
+                  >
+                    {allAreLocked ? <LockClosedIcon /> : <LockOpen2Icon />}
+                  </IconButton>
+                </HelpTip>
+              )}
             </Flex>
-            <ParentSize
-              style={{
-                height: `${getChartHeight(populationData.length, POP_ROW_HEIGHT)}px`,
-                width: '100%',
-              }}
-            >
+            <ParentSize style={{height: `${POP_CHART_LABEL_HEIGHT}px`, width: '100%'}}>
               {({width}) => (
-                <PopulationChart
+                <PopulationChartIdealLabel
                   width={width}
-                  rowHeight={POP_ROW_HEIGHT}
                   data={populationData}
                   idealPopulation={effectiveIdealPopulation}
-                  onBarSelect={selectCommunity}
                 />
               )}
             </ParentSize>
           </Flex>
-        </ConditionalScrollArea>
-      </div>
-      {/* Fixed axis strip below the scrollable rows. Never scrolls. */}
-      <Flex direction="row" width={'100%'} gap="1">
-        <Flex style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}} />
-        <ParentSize style={{height: `${POP_CHART_AXIS_HEIGHT}px`, width: '100%'}}>
-          {({width}) => (
-            <PopulationChartAxis
-              width={width}
-              data={populationData}
-              idealPopulation={effectiveIdealPopulation}
-            />
-          )}
-        </ParentSize>
-      </Flex>
-      {!!idealPopulation && !isCommunityMode && (
-        <Flex direction={'row'} justify={'between'} align={'start'} wrap="wrap">
-          <Flex direction="column" gapX="2" minWidth={'10rem'}>
-            <Text size="2">
-              Ideal population <HelpTip tip="idealPopulation" openDelay={HELP_TIP_FAST_DELAY} />
-            </Text>
-            <Text weight={'bold'} className="mb-2">
-              {formatNumber(idealPopulation, NUMBER_FORMATS.STRING)}
-            </Text>
-            {unassigned !== undefined && (
-              <>
-                <Text size="2">Unassigned</Text>
-                <Text weight={'bold'}>{formatNumber(unassigned, NUMBER_FORMATS.STRING)}</Text>
-              </>
-            )}
+          <div style={{position: 'relative'}}>
+            <ConditionalScrollArea
+              shouldUseScrollableRows={shouldUseScrollableRows}
+              // Show 10.6 rows so the half-visible row signals more content below;
+              // 60vh keeps the panel usable on short viewports.
+              maxHeight={`min(60vh, ${POP_CHART_MARGINS.top + Math.round(10.6 * POP_ROW_HEIGHT)}px)`}
+            >
+              <Flex direction="row" width={'100%'} gap="1">
+                <Flex
+                  direction={'column'}
+                  className={'flex-grow-0 p-0'}
+                  style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}}
+                >
+                  <Flex style={{height: POP_LEFT_COL_TOP_SPACER}} />
+                  {/* @ts-ignore */}
+                  {populationData.map(d => (
+                    <Flex
+                      key={d.zone}
+                      direction={'row'}
+                      gapX="1"
+                      align={'center'}
+                      className="p-0 m-0"
+                      justify={'between'}
+                      style={{height: POP_ROW_HEIGHT}}
+                    >
+                      {!!showDistrictNumbers && (
+                        <IconButton
+                          variant={'outline'}
+                          onClick={() => selectCommunity(d.zone)}
+                          size="1"
+                          className={`${selectedZone === d.zone ? 'bg-gray-100' : '!shadow-none'} max-w-12 flex-grow`}
+                        >
+                          <Text weight={selectedZone === d.zone ? 'bold' : 'regular'}>
+                            {mapMode === MAP_MODES.COI
+                              ? (getCommunityRenderOrderId(communities, d.zone) ?? d.zone)
+                              : d.zone}
+                          </Text>
+                        </IconButton>
+                      )}
+                      <Flex gap="0" align="center">
+                        <ZoneDescriptionPopover zone={d.zone} color={getZoneColor(d.zone)} />
+                        {!!isEditing && (
+                          <>
+                            {isCommunityMode ? (
+                              <IconButton
+                                onClick={() => handleEditCommunity(d.zone)}
+                                variant="ghost"
+                                size="1"
+                                disabled={access === ACCESS_STATES.READ}
+                                aria-label={`Edit community ${d.zone}`}
+                              >
+                                <Pencil1Icon />
+                              </IconButton>
+                            ) : (
+                              <HelpTip tip="districtLock" openDelay={HELP_TIP_HOVER_DELAY}>
+                                <IconButton
+                                  onClick={() => handleLockChange(d.zone)}
+                                  variant="ghost"
+                                  size="1"
+                                  disabled={access === ACCESS_STATES.READ}
+                                  aria-label={
+                                    lockPaintedAreas.includes(d.zone)
+                                      ? `Unlock district ${d.zone}`
+                                      : `Lock district ${d.zone}`
+                                  }
+                                >
+                                  {lockPaintedAreas.includes(d.zone) ? (
+                                    <LockClosedIcon />
+                                  ) : (
+                                    <LockOpen2Icon />
+                                  )}
+                                </IconButton>
+                              </HelpTip>
+                            )}
+                          </>
+                        )}
+                      </Flex>
+                    </Flex>
+                  ))}
+                </Flex>
+                <ParentSize
+                  style={{
+                    height: `${getChartHeight(populationData.length, POP_ROW_HEIGHT)}px`,
+                    width: '100%',
+                  }}
+                >
+                  {({width}) => (
+                    <PopulationChart
+                      width={width}
+                      rowHeight={POP_ROW_HEIGHT}
+                      data={populationData}
+                      idealPopulation={effectiveIdealPopulation}
+                      onBarSelect={selectCommunity}
+                    />
+                  )}
+                </ParentSize>
+              </Flex>
+            </ConditionalScrollArea>
+          </div>
+          {/* Fixed axis strip below the scrollable rows. Never scrolls. */}
+          <Flex direction="row" width={'100%'} gap="1">
+            <Flex style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}} />
+            <ParentSize style={{height: `${POP_CHART_AXIS_HEIGHT}px`, width: '100%'}}>
+              {({width}) => (
+                <PopulationChartAxis
+                  width={width}
+                  data={populationData}
+                  idealPopulation={effectiveIdealPopulation}
+                />
+              )}
+            </ParentSize>
           </Flex>
-
-          <Text size="2">
-            Top-to-bottom population deviation{' '}
-            <HelpTip tip="topToBottomDeviation" openDelay={HELP_TIP_FAST_DELAY} />
-            <br />
-            {allPainted &&
-            zoneStats?.range !== undefined &&
-            zoneStats?.maxPopulation !== undefined &&
-            zoneStats?.maxPopulation !== 0 ? (
-              <>
-                <b>{formatDeviationPct(zoneStats.range / zoneStats?.maxPopulation)}</b> (
-                {formatNumber(zoneStats.range || 0, NUMBER_FORMATS.STRING)} people)
-              </>
-            ) : (
-              ` will appear when all ${zoneLabelPlural} are started`
-            )}
-          </Text>
-        </Flex>
+        </>
       )}
       {editingCommunity && (
         <EditCommunityDialog

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -1,7 +1,6 @@
 import {Flex, Heading, IconButton, Spinner, Text} from '@radix-ui/themes';
 import React, {useMemo, useState} from 'react';
 import {ParentSize} from '@visx/responsive'; // Import ParentSize
-import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
 import {useChartStore} from '@store/chartStore';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
@@ -18,7 +17,7 @@ import {
 } from './PopulationChart/PopulationChart';
 import {PopulationPanelOptions} from './PopulationPanelOptions';
 import {DistrictMeters} from './DistrictMeters';
-import {LockClosedIcon, LockOpen2Icon, Pencil1Icon} from '@radix-ui/react-icons';
+import {Pencil1Icon} from '@radix-ui/react-icons';
 import {useZonePopulations} from '@/app/hooks/useDemography';
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {ZoneDescriptionPopover} from './ZoneDescriptionPopover';
@@ -51,13 +50,9 @@ export const PopulationPanel = () => {
   const isCommunityMode = mapMode === MAP_MODES.COI;
   const effectiveIdealPopulation = isCommunityMode ? undefined : idealPopulation;
 
-  const lockPaintedAreas = useMapControlsStore(state => state.mapOptions.lockPaintedAreas);
   const chartOptions = useChartStore(state => state.chartOptions);
   const showDistrictNumbers = chartOptions.popShowDistrictNumbers;
   const setChartOptions = useChartStore(state => state.setChartOptions);
-  const setLockedZones = useMapControlsStore(state => state.setLockedZones);
-  const toggleLockAllAreas = useMapControlsStore(state => state.toggleLockAllAreas);
-  const allAreLocked = populationData.every((d: any) => lockPaintedAreas?.includes(d.zone));
   const selectedZone = useMapControlsStore(state => state.selectedZone);
   const access = useMapStore(state => state.mapStatus?.access);
   const communities = useMapStore(state => state.communities);
@@ -79,13 +74,6 @@ export const PopulationPanel = () => {
       new Set([editingCommunity.color, ...getUnusedCommunityColors(communities, colorScheme)])
     );
   }, [communities, colorScheme, editingCommunity]);
-  const handleLockChange = (zone: number) => {
-    if (lockPaintedAreas.includes(zone)) {
-      setLockedZones(lockPaintedAreas.filter(f => f !== zone));
-    } else {
-      setLockedZones([...(lockPaintedAreas || []), zone]);
-    }
-  };
   const handleEditCommunity = (zone: number) => {
     selectCommunity(zone);
     setEditingCommunityId(zone);
@@ -167,22 +155,7 @@ export const PopulationPanel = () => {
           instead of the icon's natural size, centering the lock-all icon at a
           different height than the per-district rows' own lock icons. */}
           <Flex direction="row" width={'100%'} gap="1" mt="2" align="center">
-            <Flex justify="end" align="center" style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}}>
-              {!isCommunityMode && (
-                <HelpTip tip="districtLock" openDelay={HELP_TIP_HOVER_DELAY}>
-                  <IconButton
-                    onClick={toggleLockAllAreas}
-                    variant="ghost"
-                    size="1"
-                    disabled={access === ACCESS_STATES.READ}
-                    style={{opacity: isEditing ? 1 : 0}}
-                    aria-label={allAreLocked ? 'Unlock all districts' : 'Lock all districts'}
-                  >
-                    {allAreLocked ? <LockClosedIcon /> : <LockOpen2Icon />}
-                  </IconButton>
-                </HelpTip>
-              )}
-            </Flex>
+            <Flex justify="end" align="center" style={{width: POP_LEFT_COL_WIDTH, flexShrink: 0}} />
             <ParentSize style={{height: `${POP_CHART_LABEL_HEIGHT}px`, width: '100%'}}>
               {({width}) => (
                 <PopulationChartIdealLabel
@@ -235,39 +208,15 @@ export const PopulationPanel = () => {
                       <Flex gap="0" align="center">
                         <ZoneDescriptionPopover zone={d.zone} color={getZoneColor(d.zone)} />
                         {!!isEditing && (
-                          <>
-                            {isCommunityMode ? (
-                              <IconButton
-                                onClick={() => handleEditCommunity(d.zone)}
-                                variant="ghost"
-                                size="1"
-                                disabled={access === ACCESS_STATES.READ}
-                                aria-label={`Edit community ${d.zone}`}
-                              >
-                                <Pencil1Icon />
-                              </IconButton>
-                            ) : (
-                              <HelpTip tip="districtLock" openDelay={HELP_TIP_HOVER_DELAY}>
-                                <IconButton
-                                  onClick={() => handleLockChange(d.zone)}
-                                  variant="ghost"
-                                  size="1"
-                                  disabled={access === ACCESS_STATES.READ}
-                                  aria-label={
-                                    lockPaintedAreas.includes(d.zone)
-                                      ? `Unlock district ${d.zone}`
-                                      : `Lock district ${d.zone}`
-                                  }
-                                >
-                                  {lockPaintedAreas.includes(d.zone) ? (
-                                    <LockClosedIcon />
-                                  ) : (
-                                    <LockOpen2Icon />
-                                  )}
-                                </IconButton>
-                              </HelpTip>
-                            )}
-                          </>
+                          <IconButton
+                            onClick={() => handleEditCommunity(d.zone)}
+                            variant="ghost"
+                            size="1"
+                            disabled={access === ACCESS_STATES.READ}
+                            aria-label={`Edit community ${d.zone}`}
+                          >
+                            <Pencil1Icon />
+                          </IconButton>
                         )}
                       </Flex>
                     </Flex>

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
@@ -49,7 +49,7 @@ export const PopulationPanelOptions: React.FC<{
     <>
       <Popover.Root>
         <Popover.Trigger>
-          <Button variant="ghost" size="1" aria-label="Open population chart settings">
+          <Button variant="outline" size="1" ml="2" aria-label="Open population chart settings">
             Population chart settings
           </Button>
         </Popover.Trigger>

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
@@ -9,7 +9,6 @@ import {
 } from '@radix-ui/themes';
 import React, {useEffect} from 'react'; // Import ParentSize
 import {Popover} from '@radix-ui/themes';
-import {GearIcon} from '@radix-ui/react-icons';
 import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
 import {ChartStore} from '@store/chartStore';
 import {ColorChangeModal} from '../../Toolbar/ColorChangeModal';
@@ -50,9 +49,9 @@ export const PopulationPanelOptions: React.FC<{
     <>
       <Popover.Root>
         <Popover.Trigger>
-          <IconButton variant="ghost" size="3" aria-label="Open population panel options">
-            <GearIcon />
-          </IconButton>
+          <Button variant="ghost" size="1" aria-label="Open population chart settings">
+            Population chart settings
+          </Button>
         </Popover.Trigger>
         <Popover.Content>
           <CheckboxGroup.Root

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  CheckboxGroup,
-  Flex,
-  IconButton,
-  SegmentedControl,
-  Text,
-  TextField,
-} from '@radix-ui/themes';
+import {Button, CheckboxGroup, Flex, IconButton, Text, TextField} from '@radix-ui/themes';
 import React, {useEffect} from 'react'; // Import ParentSize
 import {Popover} from '@radix-ui/themes';
 import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
@@ -58,7 +50,6 @@ export const PopulationPanelOptions: React.FC<{
             defaultValue={[]}
             name="districts"
             value={[
-              chartOptions.popBarScaleToCurrent ? 'scaleToCurrent' : '',
               chartOptions.popShowDistrictNumbers ? 'numbers' : '',
               chartOptions.popShowPopNumbers ? 'pops' : '',
               chartOptions.popShowTopBottomDeviation ? 'topBottomDeviation' : '',
@@ -107,19 +98,6 @@ export const PopulationPanelOptions: React.FC<{
           )}
           {!isCommunityMode && (
             <Flex direction="column" gap="1" py="2" mt="2">
-              <Text size="2" weight="medium">
-                X-axis bar scaling
-                <HelpTip tip="barScaling" openDelay={HELP_TIP_FAST_DELAY} />
-              </Text>
-              <SegmentedControl.Root
-                size="1"
-                value={chartOptions.popBarScaleToCurrent ? 'current' : 'ideal'}
-                onValueChange={v => setChartOptions({popBarScaleToCurrent: v === 'current'})}
-              >
-                <SegmentedControl.Item value="ideal">Zero to ideal</SegmentedControl.Item>
-                <SegmentedControl.Item value="current">Current range</SegmentedControl.Item>
-              </SegmentedControl.Root>
-
               {!!idealPopulation && (
                 <Flex direction="column" align="start" gapX="2" pt="2">
                   <Text size="2" weight="medium" className="py-2">

--- a/app/src/app/components/sidebar/ShowAllDistrictsButton.tsx
+++ b/app/src/app/components/sidebar/ShowAllDistrictsButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+import React from 'react';
+import {Button} from '@radix-ui/themes';
+
+/** Toggle under district tables that default to started-districts-only.
+ * Renders nothing when every district is already visible. */
+export const ShowAllDistrictsButton: React.FC<{
+  showAll: boolean;
+  onToggle: () => void;
+  total: number;
+  hiddenCount: number;
+}> = ({showAll, onToggle, total, hiddenCount}) =>
+  hiddenCount > 0 ? (
+    <Button
+      variant="ghost"
+      size="1"
+      onClick={onToggle}
+      style={{alignSelf: 'start', fontWeight: 600}}
+      mx="1"
+      my="1"
+    >
+      {showAll ? 'Show only started districts' : `Show all ${total} districts`}
+    </Button>
+  ) : null;

--- a/app/src/app/store/chartStore.ts
+++ b/app/src/app/store/chartStore.ts
@@ -12,15 +12,19 @@ export interface ChartStore {
   setDataUpdateHash: (hash: string) => void;
 }
 
+export const DEFAULT_CHART_OPTIONS: DistrictrChartOptions = {
+  popShowPopNumbers: true,
+  popShowTopBottomDeviation: true,
+  popShowDistrictNumbers: true,
+  popBarScaleToCurrent: false,
+  popTargetPopDeviation: undefined,
+  popTargetPopDeviationPct: undefined,
+};
+
 export const useChartStore = create(
   devwrapper(
     subscribeWithSelector<ChartStore>((set, get) => ({
-      chartOptions: {
-        popShowPopNumbers: true,
-        popShowTopBottomDeviation: true,
-        popShowDistrictNumbers: true,
-        popBarScaleToCurrent: false,
-      },
+      chartOptions: {...DEFAULT_CHART_OPTIONS},
       setChartOptions: options => set({chartOptions: {...get().chartOptions, ...options}}),
       dataUpdateHash: '',
       paintedChanges: {},


### PR DESCRIPTION
Replaces the visx population chart rows with pill-shaped meters for district mode (the chart stays for COI mode). Refinements over the source branch: started-only default with a show-all toggle in both Draw and Super Draw, inline population + signed deviation per row, overflow past ideal in a darker shade of the district color, red text + arrow tip only when a bar pins at 125% of ideal, capped chart width, an always-visible scoreboard (unassigned with actions, top-to-bottom and max deviation with percents), no success-green styling, and thicker bars with larger text.

## Description
- Closes #681 


## Reviewers
- Primary: @fangge518 
- Secondary:

## Checklist
<!--- Complete this checklist before asking for reviews. You can simply click the checkboxes once the markdown is rendered. -->
<!--- If not applicable, simply leave a reason why under the bullet point. -->
- [ ] Added/Updated related documentation (if applicable).
- [ ] Added/Updated related unit tests (if applicable).

## Screenshots (if applicable):

Draw
<img width="598" height="335" alt="Screenshot 2026-07-31 at 2 08 50 PM" src="https://github.com/user-attachments/assets/acf02f09-16ab-43d7-8765-c16c30eb7f61" />

Super draw
<img width="598" height="335" alt="Screenshot 2026-07-31 at 2 08 54 PM" src="https://github.com/user-attachments/assets/ec0c0e88-af9e-42a3-aad6-0eae3a84720c" />

## Review required
<!--- Given agentic engineer efforts, provide a summary of what aspects of the code and UI/UX require human validation. -->
- UX review
- Math/logic review on thresholds and meter displays; however, none of this touches the state outside of the component