### PR TITLE
Add "Disallow Paint-over" brush toggle

### DIFF
--- a/app/src/app/components/HelpTip/helpTipContent.ts
+++ b/app/src/app/components/HelpTip/helpTipContent.ts
@@ -60,6 +60,12 @@ export const helpTipContent = {
     videoFile: 'county_brush.webm',
     guideAnchor: 'drawing-the-districts',
   },
+  // No video for this one yet — text-only, unlike the other brush tips.
+  disallowPaintOver: {
+    title: 'Disallow paint over',
+    text: 'Toggle this to protect every district you\'ve already drawn — the brush will only add unassigned units, leaving painted areas untouched. Erasing still works.',
+    guideAnchor: 'drawing-the-districts',
+  },
   switchDistrict: {
     title: 'Switching districts',
     text: 'Click a color to switch which district you’re painting. For plans with many districts, use the dropdown to find the one you want.',

--- a/app/src/app/components/HelpTip/helpTipContent.ts
+++ b/app/src/app/components/HelpTip/helpTipContent.ts
@@ -63,7 +63,7 @@ export const helpTipContent = {
   // No video for this one yet — text-only, unlike the other brush tips.
   disallowPaintOver: {
     title: 'Disallow paint over',
-    text: 'When toggled on, the brush will only add unassigned units, leaving painted areas untouched.',
+    text: 'When enabled, the brush will only add unassigned units, leaving painted areas untouched.',
     guideAnchor: 'drawing-the-districts',
   },
   switchDistrict: {

--- a/app/src/app/components/HelpTip/helpTipContent.ts
+++ b/app/src/app/components/HelpTip/helpTipContent.ts
@@ -63,7 +63,7 @@ export const helpTipContent = {
   // No video for this one yet — text-only, unlike the other brush tips.
   disallowPaintOver: {
     title: 'Disallow paint over',
-    text: 'Toggle this to protect every district you\'ve already drawn — the brush will only add unassigned units, leaving painted areas untouched. Erasing still works.',
+    text: 'When toggled on, the brush will only add unassigned units, leaving painted areas untouched.',
     guideAnchor: 'drawing-the-districts',
   },
   switchDistrict: {

--- a/app/src/app/components/Toolbar/DisallowPaintOver.tsx
+++ b/app/src/app/components/Toolbar/DisallowPaintOver.tsx
@@ -1,0 +1,48 @@
+import {Card, Text} from '@radix-ui/themes';
+import {useMapStore} from '@/app/store/mapStore';
+import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {ACCESS_STATES} from '@constants/document/state';
+import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
+
+export default function DisallowPaintOver() {
+  const disallowPaintOver = useMapControlsStore(state => state.mapOptions.disallowPaintOver);
+  const setMapOptions = useMapControlsStore(state => state.setMapOptions);
+  const access = useMapStore(state => state.mapStatus?.access);
+  const disabled = access === ACCESS_STATES.READ;
+
+  const handleToggle = () => {
+    if (disabled) return;
+    setMapOptions({
+      disallowPaintOver: !disallowPaintOver,
+    });
+  };
+
+  return (
+    <HelpTip tip="disallowPaintOver" openDelay={HELP_TIP_HOVER_DELAY}>
+      <Card
+        size="1"
+        className={`p-1 w-fit ${disallowPaintOver ? 'bg-indigo-50' : ''}`}
+        style={disabled ? {opacity: 0.5} : undefined}
+      >
+        <Text
+          as="label"
+          size="2"
+          className={disabled ? 'select-none' : 'cursor-pointer select-none'}
+          role="button"
+          tabIndex={disabled ? -1 : 0}
+          aria-pressed={!!disallowPaintOver}
+          aria-disabled={disabled}
+          onClick={handleToggle}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleToggle();
+            }
+          }}
+        >
+          Disallow paint over
+        </Text>
+      </Card>
+    </HelpTip>
+  );
+}

--- a/app/src/app/components/Toolbar/DisallowPaintOver.tsx
+++ b/app/src/app/components/Toolbar/DisallowPaintOver.tsx
@@ -1,4 +1,4 @@
-import {Card, Checkbox, Flex, Text} from '@radix-ui/themes';
+import {Checkbox, Flex, Text} from '@radix-ui/themes';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {ACCESS_STATES} from '@constants/document/state';
@@ -23,14 +23,17 @@ export default function DisallowPaintOver() {
 
   return (
     <HelpTip tip="disallowPaintOver" openDelay={HELP_TIP_HOVER_DELAY}>
-      <Card size="1" className={disallowPaintOver ? 'bg-indigo-50' : ''}>
-        <Text as="label" size="2" className="cursor-pointer select-none">
-          <Flex gap="2" align="center">
-            <Checkbox checked={!!disallowPaintOver} onCheckedChange={handleToggle} disabled={disabled} />
-            Disallow Paint-over
-          </Flex>
-        </Text>
-      </Card>
+      <Text as="label" size="1" className="cursor-pointer select-none">
+        <Flex gap="1" align="center">
+          <Checkbox
+            size="1"
+            checked={!!disallowPaintOver}
+            onCheckedChange={handleToggle}
+            disabled={disabled}
+          />
+          Disallow Paint-over
+        </Flex>
+      </Text>
     </HelpTip>
   );
 }

--- a/app/src/app/components/Toolbar/DisallowPaintOver.tsx
+++ b/app/src/app/components/Toolbar/DisallowPaintOver.tsx
@@ -23,15 +23,15 @@ export default function DisallowPaintOver() {
 
   return (
     <HelpTip tip="disallowPaintOver" openDelay={HELP_TIP_HOVER_DELAY}>
-      <Text as="label" size="1" className="cursor-pointer select-none">
+      <Text as="label" size="2" className="cursor-pointer select-none">
         <Flex gap="1" align="center">
           <Checkbox
-            size="1"
+            size="2"
             checked={!!disallowPaintOver}
             onCheckedChange={handleToggle}
             disabled={disabled}
           />
-          Disallow Paint-over
+          Disallow paint-over
         </Flex>
       </Text>
     </HelpTip>

--- a/app/src/app/components/Toolbar/DisallowPaintOver.tsx
+++ b/app/src/app/components/Toolbar/DisallowPaintOver.tsx
@@ -1,14 +1,18 @@
-import {Card, Text} from '@radix-ui/themes';
+import {Card, Checkbox, Flex, Text} from '@radix-ui/themes';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {ACCESS_STATES} from '@constants/document/state';
+import {MAP_MODES} from '@constants/map/mode';
 import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
 
 export default function DisallowPaintOver() {
   const disallowPaintOver = useMapControlsStore(state => state.mapOptions.disallowPaintOver);
   const setMapOptions = useMapControlsStore(state => state.setMapOptions);
+  const mapMode = useMapControlsStore(state => state.mapMode);
   const access = useMapStore(state => state.mapStatus?.access);
   const disabled = access === ACCESS_STATES.READ;
+
+  if (mapMode === MAP_MODES.COI) return null;
 
   const handleToggle = () => {
     if (disabled) return;
@@ -19,28 +23,12 @@ export default function DisallowPaintOver() {
 
   return (
     <HelpTip tip="disallowPaintOver" openDelay={HELP_TIP_HOVER_DELAY}>
-      <Card
-        size="1"
-        className={`p-1 w-fit ${disallowPaintOver ? 'bg-indigo-50' : ''}`}
-        style={disabled ? {opacity: 0.5} : undefined}
-      >
-        <Text
-          as="label"
-          size="2"
-          className={disabled ? 'select-none' : 'cursor-pointer select-none'}
-          role="button"
-          tabIndex={disabled ? -1 : 0}
-          aria-pressed={!!disallowPaintOver}
-          aria-disabled={disabled}
-          onClick={handleToggle}
-          onKeyDown={e => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              handleToggle();
-            }
-          }}
-        >
-          Disallow paint over
+      <Card size="1" className={disallowPaintOver ? 'bg-indigo-50' : ''}>
+        <Text as="label" size="2" className="cursor-pointer select-none">
+          <Flex gap="2" align="center">
+            <Checkbox checked={!!disallowPaintOver} onCheckedChange={handleToggle} disabled={disabled} />
+            Disallow Paint-over
+          </Flex>
         </Text>
       </Card>
     </HelpTip>

--- a/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
@@ -5,6 +5,7 @@ import {useFeatureFlagStore} from '@store/featureFlagStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
 import {BrushSizeSelector} from '@components/Toolbar/ToolControls/BrushSizeSelector';
 import PaintByCounty from '@components/Toolbar/PaintByCounty';
+import DisallowPaintOver from '@components/Toolbar/DisallowPaintOver';
 import {ZonePicker} from '@components/Toolbar/ZonePicker';
 import {ACTIVE_TOOLS} from '@constants/map/tools';
 import {MAP_MODES} from '@constants/map/mode';
@@ -36,9 +37,14 @@ export const BrushControls = () => {
         )}
       </Flex>
       {showZonePicker ? (
-        <Flex direction="row" flexGrow={'0'} maxWidth={'100%'} p="0" m="0">
-          <ZonePicker />
-        </Flex>
+        <>
+          <Flex direction="row" flexGrow={'0'} maxWidth={'100%'} p="0" m="0">
+            <ZonePicker />
+          </Flex>
+          <Flex direction="row" justify="start">
+            <DisallowPaintOver />
+          </Flex>
+        </>
       ) : null}
 
       {paintConstraint && (

--- a/app/src/app/store/mapControlsStore.tsx
+++ b/app/src/app/store/mapControlsStore.tsx
@@ -92,6 +92,7 @@ export const DEFAULT_MAP_OPTIONS: MapOptions & DistrictrMapOptions = {
   highlightBrokenDistricts: false,
   higlightUnassigned: false,
   lockPaintedAreas: [],
+  disallowPaintOver: false,
   mode: 'default',
   paintByCounty: false,
   prominentCountyNames: true,

--- a/app/src/app/store/types.ts
+++ b/app/src/app/store/types.ts
@@ -11,6 +11,10 @@ export type DistrictrMapOptions = {
   highlightBrokenDistricts?: boolean;
   higlightUnassigned?: boolean;
   lockPaintedAreas: Array<NullableZone>;
+  /** When on, the brush can only paint unassigned areas — no district's area
+   * can be repainted, regardless of which one. Brush-tool and districts-mode
+   * only; the eraser and block-painting inside broken units are unaffected. */
+  disallowPaintOver?: boolean;
   mode: 'default' | 'break';
   showZoneNumbers?: boolean;
   paintByCounty?: boolean;

--- a/app/src/app/store/types.ts
+++ b/app/src/app/store/types.ts
@@ -11,9 +11,6 @@ export type DistrictrMapOptions = {
   highlightBrokenDistricts?: boolean;
   higlightUnassigned?: boolean;
   lockPaintedAreas: Array<NullableZone>;
-  /** When on, the brush can only paint unassigned areas — no district's area
-   * can be repainted, regardless of which one. Brush-tool and districts-mode
-   * only; the eraser and block-painting inside broken units are unaffected. */
   disallowPaintOver?: boolean;
   mode: 'default' | 'break';
   showZoneNumbers?: boolean;

--- a/app/src/app/utils/map/filterFeatures.ts
+++ b/app/src/app/utils/map/filterFeatures.ts
@@ -55,11 +55,6 @@ export const filterFeatures = ({
     filterFunctions.push(f => captiveIds.has(f.id?.toString() || ''));
   }
   if (filterLocked) {
-    // "Disallow paint over": the brush can't repaint anything already
-    // assigned to a district, whichever one — separate from (and composes
-    // with) the per-district lockPaintedAreas list below. Brush-tool and
-    // districts-mode only, so the eraser and break/shatter's block-painting
-    // are untouched.
     if (
       activeTool === ACTIVE_TOOLS.BRUSH &&
       mapMode === MAP_MODES.DISTRICTS &&

--- a/app/src/app/utils/map/filterFeatures.ts
+++ b/app/src/app/utils/map/filterFeatures.ts
@@ -55,6 +55,18 @@ export const filterFeatures = ({
     filterFunctions.push(f => captiveIds.has(f.id?.toString() || ''));
   }
   if (filterLocked) {
+    // "Disallow paint over": the brush can't repaint anything already
+    // assigned to a district, whichever one — separate from (and composes
+    // with) the per-district lockPaintedAreas list below. Brush-tool and
+    // districts-mode only, so the eraser and break/shatter's block-painting
+    // are untouched.
+    if (
+      activeTool === ACTIVE_TOOLS.BRUSH &&
+      mapMode === MAP_MODES.DISTRICTS &&
+      mapOptions.disallowPaintOver
+    ) {
+      filterFunctions.push(f => !zoneAssignments.get(f.id?.toString() || ''));
+    }
     if (activeTool === ACTIVE_TOOLS.BRUSH && mapOptions.lockPaintedAreas.includes(selectedZone)) {
       return [];
     } else if (mapOptions.lockPaintedAreas.length) {


### PR DESCRIPTION
Closes #677. Adds a session-only toggle that, while on, restricts the brush to unassigned areas — no district's already-painted area can be repainted, whichever district it belongs to.

**Fix:** a new `disallowPaintOver` flag on `mapOptions` (default off, no persistence — matches sibling `mapOptions` fields), checked in `filterFeatures.ts` only when the active tool is the brush and the map is in districts mode. It composes with the existing per-district `lockPaintedAreas` filter rather than replacing it — both can be active together. The eraser and block-painting inside broken units go through a different tool value and are untouched.

The toggle itself is a checkbox+label, matching `PaintByCounty`'s pattern except smaller and without a card to emphasize it. Hidden entirely in COI/community mode, and disabled for read-only viewers.
