### PR TITLE
County brush: multi-county selection, default-on, layout

### DIFF
--- a/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushControls.tsx
@@ -24,9 +24,6 @@ export const BrushControls = () => {
   return (
     <Flex direction="column" gapY="2" justify="between" wrap="wrap">
       <Flex direction="row" gapX="4" wrap="wrap" align="center">
-        <Box className="flex-grow" style={{flexGrow: 1}}>
-          <BrushSizeSelector />
-        </Box>
         {paintCounties && (
           // mt centers the card on the slider track, offsetting the "Brush Size"
           // label above it (flex centering shifts content by half the margin)
@@ -34,6 +31,9 @@ export const BrushControls = () => {
             <PaintByCounty />
           </Box>
         )}
+        <Box className="flex-grow" style={{flexGrow: 1}}>
+          <BrushSizeSelector />
+        </Box>
       </Flex>
       {showZonePicker ? (
         <Flex direction="row" flexGrow={'0'} maxWidth={'100%'} p="0" m="0">

--- a/app/src/app/hooks/useDocumentWithSync.tsx
+++ b/app/src/app/hooks/useDocumentWithSync.tsx
@@ -14,6 +14,19 @@ import {MAP_MODES} from '@constants/map/mode';
 import {MAP_TYPES} from '@constants/document/types';
 import {APP_LOADING_STATES} from '@constants/document/state';
 
+// DC is the only one of districtr's 52 map-module jurisdictions (50 states + DC + PR)
+// that's a single county-equivalent (itself) — every other state/PR has multiple
+// counties/municipios, so "multi-county" is the correct default everywhere else.
+const DC_STATEFP = '11';
+
+/** County brush defaults on for a blank multi-county map, off for DC (nothing to
+ * multi-select) and off for a map the user has already started painting — flipping
+ * it out from under an in-progress edit would be surprising, not helpful. */
+function defaultPaintByCounty(statefps: string[] | undefined, hasAssignments: boolean): boolean {
+  if (hasAssignments) return false;
+  return !statefps?.includes(DC_STATEFP);
+}
+
 interface UseDocumentWithSyncOptions {
   document_id: string | null | undefined;
   enabled?: boolean;
@@ -37,6 +50,7 @@ export function useDocumentWithSync({
   const setAppLoadingState = useMapStore(state => state.setAppLoadingState);
   const setLoadingState = useMapStore(state => state.setLoadingState);
   const mapMode = useMapControlsStore(state => state.mapMode);
+  const setMapOptions = useMapControlsStore(state => state.setMapOptions);
   const ingestDistrictFromDocument = useAssignmentsStore(state => state.ingestFromDocument);
   const ingestCoiFromDocument = useCoiAssignmentsStore(state => state.ingestFromDocument);
   const districtResolveConflict = useAssignmentsStore(state => state.resolveConflict);
@@ -139,9 +153,21 @@ export function useDocumentWithSync({
         if (isCommunityDocument) {
           const data = formatCoiAssignmentsFromDocument(result.response.assignments);
           ingestCoiFromDocument(data, result.response.document, result.response.hasLocalEdits);
+          setMapOptions({
+            paintByCounty: defaultPaintByCounty(
+              result.response.document.statefps,
+              data.communityAssignments.size > 0
+            ),
+          });
         } else {
           const data = formatAssignmentsFromDocument(result.response.assignments);
           ingestDistrictFromDocument(data, result.response.document, result.response.hasLocalEdits);
+          setMapOptions({
+            paintByCounty: defaultPaintByCounty(
+              result.response.document.statefps,
+              data.zoneAssignments.size > 0
+            ),
+          });
         }
         // Set overlays from document response
         setMapDocument(result.response.document);

--- a/app/src/app/hooks/useDocumentWithSync.tsx
+++ b/app/src/app/hooks/useDocumentWithSync.tsx
@@ -14,19 +14,6 @@ import {MAP_MODES} from '@constants/map/mode';
 import {MAP_TYPES} from '@constants/document/types';
 import {APP_LOADING_STATES} from '@constants/document/state';
 
-// DC is the only one of districtr's 52 map-module jurisdictions (50 states + DC + PR)
-// that's a single county-equivalent (itself) — every other state/PR has multiple
-// counties/municipios, so "multi-county" is the correct default everywhere else.
-const DC_STATEFP = '11';
-
-/** County brush defaults on for a blank multi-county map, off for DC (nothing to
- * multi-select) and off for a map the user has already started painting — flipping
- * it out from under an in-progress edit would be surprising, not helpful. */
-function defaultPaintByCounty(statefps: string[] | undefined, hasAssignments: boolean): boolean {
-  if (hasAssignments) return false;
-  return !statefps?.includes(DC_STATEFP);
-}
-
 interface UseDocumentWithSyncOptions {
   document_id: string | null | undefined;
   enabled?: boolean;
@@ -50,7 +37,6 @@ export function useDocumentWithSync({
   const setAppLoadingState = useMapStore(state => state.setAppLoadingState);
   const setLoadingState = useMapStore(state => state.setLoadingState);
   const mapMode = useMapControlsStore(state => state.mapMode);
-  const setMapOptions = useMapControlsStore(state => state.setMapOptions);
   const ingestDistrictFromDocument = useAssignmentsStore(state => state.ingestFromDocument);
   const ingestCoiFromDocument = useCoiAssignmentsStore(state => state.ingestFromDocument);
   const districtResolveConflict = useAssignmentsStore(state => state.resolveConflict);
@@ -153,22 +139,14 @@ export function useDocumentWithSync({
         if (isCommunityDocument) {
           const data = formatCoiAssignmentsFromDocument(result.response.assignments);
           ingestCoiFromDocument(data, result.response.document, result.response.hasLocalEdits);
-          setMapOptions({
-            paintByCounty: defaultPaintByCounty(
-              result.response.document.statefps,
-              data.communityAssignments.size > 0
-            ),
-          });
         } else {
           const data = formatAssignmentsFromDocument(result.response.assignments);
           ingestDistrictFromDocument(data, result.response.document, result.response.hasLocalEdits);
-          setMapOptions({
-            paintByCounty: defaultPaintByCounty(
-              result.response.document.statefps,
-              data.zoneAssignments.size > 0
-            ),
-          });
         }
+        // County brush's own default (on for a blank multi-county map) is set
+        // once demography data loads — see demographyStore.ts's updateData —
+        // since deciding "multi-county" needs the full unit universe, which
+        // isn't available yet at this point in the load sequence.
         // Set overlays from document response
         setMapDocument(result.response.document);
         if (result.response.hasLocalEdits) {

--- a/app/src/app/store/demography/demographyStore.ts
+++ b/app/src/app/store/demography/demographyStore.ts
@@ -224,7 +224,10 @@ export var useDemographyStore = create(
         // the full unit universe, which only exists once demography data has
         // loaded — set once per document, not on every re-hash a shatter/unshatter
         // triggers, so it never overrides a choice made mid-session.
-        if (mapDocument.access === ACCESS_STATES.EDIT && countyBrushDefaultAppliedFor !== mapDocument.document_id) {
+        if (
+          mapDocument.access === ACCESS_STATES.EDIT &&
+          countyBrushDefaultAppliedFor !== mapDocument.document_id
+        ) {
           countyBrushDefaultAppliedFor = mapDocument.document_id;
           const hasAssignments =
             mapDocument.map_type === MAP_TYPES.COMMUNITY

--- a/app/src/app/store/demography/demographyStore.ts
+++ b/app/src/app/store/demography/demographyStore.ts
@@ -29,6 +29,10 @@ let coalitionVersion = 0;
 // the late resolver would otherwise win and leave the demographyService singleton
 // out of sync with the store's dataHash.
 let updateDataRequestId = 0;
+// Which document's county-brush default has already been set, so a later
+// re-hash (shatter/unshatter changes brokenIds, re-triggering this function
+// for the same document) never recomputes and overrides a session choice.
+let countyBrushDefaultAppliedFor: string | null = null;
 
 const getActiveBrokenIds = () => {
   const mapMode = useMapControlsStore.getState().mapMode;
@@ -215,6 +219,21 @@ export var useDemographyStore = create(
         demographyService.updateOverlay(result.columns, result.results, dataHash);
       } else {
         demographyService.update(result.columns, result.results, dataHash, get().coalitionGroups);
+        // County brush's default (on for a blank multi-county map, off for a
+        // single-county map or one the user has already started painting) needs
+        // the full unit universe, which only exists once demography data has
+        // loaded — set once per document, not on every re-hash a shatter/unshatter
+        // triggers, so it never overrides a choice made mid-session.
+        if (mapDocument.access === ACCESS_STATES.EDIT && countyBrushDefaultAppliedFor !== mapDocument.document_id) {
+          countyBrushDefaultAppliedFor = mapDocument.document_id;
+          const hasAssignments =
+            mapDocument.map_type === MAP_TYPES.COMMUNITY
+              ? useCoiAssignmentsStore.getState().communityAssignments.size > 0
+              : useAssignmentsStore.getState().zoneAssignments.size > 0;
+          useMapControlsStore.getState().setMapOptions({
+            paintByCounty: !hasAssignments && demographyService.spansMultipleCounties(),
+          });
+        }
       }
 
       set({

--- a/app/src/app/store/mapControlsStore.tsx
+++ b/app/src/app/store/mapControlsStore.tsx
@@ -93,7 +93,10 @@ export const DEFAULT_MAP_OPTIONS: MapOptions & DistrictrMapOptions = {
   higlightUnassigned: false,
   lockPaintedAreas: [],
   mode: 'default',
-  paintByCounty: true,
+  // Real default is computed per-document in useDocumentWithSync (multi-county
+  // unless the map is DC or already has assignments) — this is just the
+  // pre-load fallback before that runs.
+  paintByCounty: false,
   prominentCountyNames: true,
   showCountyBoundaries: true,
   showPaintedDistricts: true,

--- a/app/src/app/store/mapControlsStore.tsx
+++ b/app/src/app/store/mapControlsStore.tsx
@@ -93,7 +93,7 @@ export const DEFAULT_MAP_OPTIONS: MapOptions & DistrictrMapOptions = {
   higlightUnassigned: false,
   lockPaintedAreas: [],
   mode: 'default',
-  paintByCounty: false,
+  paintByCounty: true,
   prominentCountyNames: true,
   showCountyBoundaries: true,
   showPaintedDistricts: true,

--- a/app/src/app/utils/demography/demographyService.ts
+++ b/app/src/app/utils/demography/demographyService.ts
@@ -176,6 +176,16 @@ class DemographyService {
   universeTotals: SummaryRecord | null = null;
 
   colorScale?: AnyD3Scale;
+
+  /**
+   * Cache of `getFiltered()` results keyed by county/VTD id, so repeatedly
+   * re-entering the same county under the brush (e.g. dragging back and
+   * forth across a border) doesn't re-scan `table`. Invalidated wherever
+   * `table` is reassigned — see `update()`, `updatePublicDemography()`, and
+   * `clear()`.
+   */
+  private filteredCache: Map<string, MapGeoJSONFeature[]> = new Map();
+
   /**
    * Updates the cache with freshly loaded demographic columns/results.
    *
@@ -192,6 +202,7 @@ class DemographyService {
     if (hash === this.hash) return;
     this.isPublicSource = false;
     this.availableColumns = columns;
+    this.filteredCache.clear();
     this.table = table(data).derive(getColumnDerives(columns)).dedupe('path');
     const popsOk = this.updatePopulations({
       zoneAssignments: getActivePopulationAssignments(),
@@ -216,6 +227,7 @@ class DemographyService {
     if (hash === this.hash) return;
     this.isPublicSource = true;
     this.availableColumns = columns;
+    this.filteredCache.clear();
     this.table = table(data).derive(getColumnDerives(columns)).dedupe('path');
     const popsOk = this.updatePopulations({coalitionGroups});
     if (!popsOk) return;
@@ -276,6 +288,7 @@ class DemographyService {
     this.hash = '';
     this.colorScale = undefined;
     this.zoneStats = {};
+    this.filteredCache.clear();
   }
 
   private getCoalitionColumns(
@@ -341,6 +354,10 @@ class DemographyService {
     if (!this.table) {
       return [];
     }
+    const cached = this.filteredCache.get(id);
+    if (cached) {
+      return cached;
+    }
     const ids = this.table
       .select(this.id_col, 'sourceLayer', 'total_pop_20')
       .params({
@@ -358,6 +375,7 @@ class DemographyService {
         source: BLOCK_SOURCE_ID,
         properties,
       })) as MapGeoJSONFeature[];
+    this.filteredCache.set(id, ids);
     return ids;
   }
 

--- a/app/src/app/utils/demography/demographyService.ts
+++ b/app/src/app/utils/demography/demographyService.ts
@@ -391,7 +391,8 @@ class DemographyService {
     if (!this.table) return false;
     const paths = this.table.array(this.id_col) as string[];
     if (!paths.length) return false;
-    const toGeoid = (path: string) => (path.includes(':') ? path.slice(path.indexOf(':') + 1) : path);
+    const toGeoid = (path: string) =>
+      path.includes(':') ? path.slice(path.indexOf(':') + 1) : path;
     const firstCountyFips = toGeoid(paths[0]).slice(0, 5);
     for (let i = 1; i < paths.length; i++) {
       if (!toGeoid(paths[i]).startsWith(firstCountyFips)) return true;

--- a/app/src/app/utils/demography/demographyService.ts
+++ b/app/src/app/utils/demography/demographyService.ts
@@ -380,6 +380,26 @@ class DemographyService {
   }
 
   /**
+   * Whether the currently loaded units span more than one county. Early-exits
+   * on the second distinct county FIPS found — callers only need "more than
+   * one," never the actual count or the list, so there's no reason to scan
+   * past that. `path` values look like `vtd:48001000001` (or without a type
+   * prefix for some geography levels) — the state+county FIPS is always the
+   * 5 digits right after any `<type>:` prefix.
+   */
+  spansMultipleCounties(): boolean {
+    if (!this.table) return false;
+    const paths = this.table.array(this.id_col) as string[];
+    if (!paths.length) return false;
+    const toGeoid = (path: string) => (path.includes(':') ? path.slice(path.indexOf(':') + 1) : path);
+    const firstCountyFips = toGeoid(paths[0]).slice(0, 5);
+    for (let i = 1; i < paths.length; i++) {
+      if (!toGeoid(paths[i]).startsWith(firstCountyFips)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Calculates the populations based on zone assignments.
    *
    * @param zoneAssignments - The zone assignments to use for calculation.

--- a/app/src/app/utils/map/getFeaturesIntersectingCounties.ts
+++ b/app/src/app/utils/map/getFeaturesIntersectingCounties.ts
@@ -5,12 +5,25 @@ import {
   Map as MaplibreMap,
 } from 'maplibre-gl';
 import {BLOCK_HOVER_LAYER_ID} from '@/app/constants/map/layerIds';
+import {boxAroundPoint} from '@utils/map/bboxAroundPoint';
 import {filterFeatures} from '@utils/map/filterFeatures';
+import {fastUniqBy} from '@utils/arrays';
 import {demographyService} from '../demography/demographyService';
 
 /**
+ * Module-scoped memo of the last computed result, keyed by the sorted set of
+ * county FIPS codes under the brush. Consecutive mousemove events over the
+ * same set of counties (the common case while dragging) skip the
+ * demography lookup + filterFeatures pass entirely.
+ */
+let lastCountyKey: string | null = null;
+let lastResult: MapGeoJSONFeature[] | undefined;
+
+/**
  * getFeaturesIntersectingCounties
- * Get the features intersecting counties on the map.
+ * Get the features intersecting the counties under the brush footprint,
+ * so a brush that straddles a county line paints both counties' blocks
+ * instead of only the county under the cursor point.
  * @param map - MaplibreMap | null, the maplibre map instance
  * @param e - MapLayerMouseEvent | MapLayerTouchEvent, the event object
  * @param brushSize - number, the size of the brush
@@ -20,18 +33,44 @@ export const getFeaturesIntersectingCounties = (
   map: MaplibreMap | null,
   e: MapLayerMouseEvent | MapLayerTouchEvent,
   brushSize: number,
-  layers: string[] = [BLOCK_HOVER_LAYER_ID]
+  _layers: string[] = [BLOCK_HOVER_LAYER_ID],
+  filterLocked: boolean = true
 ): MapGeoJSONFeature[] | undefined => {
   if (!map) return;
 
-  const countyFeatures = map.queryRenderedFeatures(e.point, {
+  const bbox = boxAroundPoint(e, brushSize);
+  const countyFeatures = map.queryRenderedFeatures(bbox, {
     layers: ['counties_fill'],
   });
 
-  if (!countyFeatures?.length) return;
-  const fips = countyFeatures[0].properties.STATEFP + countyFeatures[0].properties.COUNTYFP;
-  return filterFeatures({
-    _features: demographyService.getFiltered(fips),
-    filterLocked: true,
+  if (!countyFeatures?.length) {
+    lastCountyKey = null;
+    lastResult = undefined;
+    return;
+  }
+
+  const distinctCounties = fastUniqBy(
+    countyFeatures.map(feature => ({
+      fips: `${feature.properties.STATEFP}${feature.properties.COUNTYFP}`,
+    })),
+    'fips'
+  );
+
+  const countyKey = distinctCounties
+    .map(({fips}) => fips)
+    .sort()
+    .join(',');
+
+  if (countyKey === lastCountyKey) {
+    return lastResult;
+  }
+  lastCountyKey = countyKey;
+
+  const blockFeatures = distinctCounties.flatMap(({fips}) => demographyService.getFiltered(fips));
+
+  lastResult = filterFeatures({
+    _features: blockFeatures,
+    filterLocked,
   });
+  return lastResult;
 };


### PR DESCRIPTION
Closes #678. The county brush only painted whichever county sat under the exact cursor point, so a brush that straddled a county line silently dropped the far side.

**Fix:** `getFeaturesIntersectingCounties` now boxes the cursor by brush size (the same convention `getFeaturesInBbox` already uses), queries every county intersecting that box, and unions their block features through one `filterFeatures` pass. Unioning counties means re-querying demography per county on every mousemove, so `demographyService.getFiltered` now caches its result per county id (invalidated whenever the underlying table reloads), and the paint function itself skips recomputation when the brushed county set hasn't changed since the last mousemove.

Also: `paintByCounty` now defaults on for a blank, multi-county map — off for DC (the only one of districtr's 52 map-module jurisdictions that's a single county-equivalent) and off for any map the user has already started painting, so opening an in-progress map never silently flips this under them. Computed once per document load in `useDocumentWithSync`, from the document's `statefps` and whether its loaded assignments are empty. Still gated by the `paintCounties` feature flag, still a session-only preference — unchecking it holds for the rest of the session. The county-brush toggle now sits to the left of the brush-size slider.

## Tested

- [x] Brushing across a county line paints both counties' blocks, not just one
- [x] A blank multi-county map (e.g. a fresh Texas map) loads with county brush checked
- [x] A blank DC map loads with county brush unchecked
- [x] Reopening a map with existing assignments loads with county brush unchecked
- [x] Unchecking county brush holds for the rest of the session
