### PR TITLE
Fix stale completeness check via React Query, keyed like Contiguity

### DIFF
--- a/app/src/app/components/sidebar/MapValidation/ZoomToUnassigned.tsx
+++ b/app/src/app/components/sidebar/MapValidation/ZoomToUnassigned.tsx
@@ -1,56 +1,50 @@
 import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
+import {useAssignmentsStore} from '@/app/store/assignmentsStore';
 import {useUnassignFeaturesStore} from '@/app/store/unassignedFeatures';
+import GeometryWorker from '@/app/utils/GeometryWorker';
 import {formatNumber} from '@/app/utils/numbers';
 import {Checkbox, Flex, Text} from '@radix-ui/themes';
-import React, {useEffect, useRef} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import React from 'react';
 import ZoomToFeature from './ZoomToFeature';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {ConditionalScrollArea} from '../ConditionalScrollArea';
+import {ACCESS_STATES} from '@constants/document/state';
 
 export const ZoomToUnassigned = () => {
-  const {
-    updateUnassignedFeatures,
-    selectedIndex,
-    setSelectedIndex,
-    unassignedFeatureBboxes,
-    hasFoundUnassigned,
-    reset,
-  } = useUnassignFeaturesStore(state => state);
+  const {selectedIndex, setSelectedIndex} = useUnassignFeaturesStore(state => state);
   const mapDocument = useMapStore(state => state.mapDocument);
+  const shatterIds = useAssignmentsStore(state => state.shatterIds);
   const higlightUnassigned = useMapControlsStore(state => state.mapOptions.higlightUnassigned);
   const setMapOptions = useMapControlsStore(state => state.setMapOptions);
   const {summaryStats} = useSummaryStats();
-  // prevent duplicate requests to get unassigned features
-  const initialMapDocument = useRef(mapDocument);
-  const lastSavedAt = useRef(mapDocument?.updated_at);
   const unassigned = summaryStats?.unassigned;
 
-  useEffect(() => {
-    if (!unassignedFeatureBboxes.length && !hasFoundUnassigned) {
-      updateUnassignedFeatures();
-    }
-  }, []);
+  // Read access resolves to the public_id (same convention as the rest of the
+  // app's read-only sharing); edit access uses the document_id directly.
+  const documentIdParam =
+    mapDocument?.access === ACCESS_STATES.READ && mapDocument?.public_id
+      ? String(mapDocument.public_id)
+      : mapDocument?.document_id;
 
-  useEffect(() => {
-    if (initialMapDocument?.current?.document_id !== mapDocument?.document_id) {
-      initialMapDocument.current = mapDocument;
-      reset();
-      setTimeout(() => {
-        updateUnassignedFeatures();
-      }, 3000);
-    }
-  }, [mapDocument?.document_id]);
-
-  // Auto-refresh after a save lands while this panel is open (updated_at moves
-  // when assignments are persisted to the cloud).
-  useEffect(() => {
-    if (mapDocument?.updated_at && lastSavedAt.current !== mapDocument.updated_at) {
-      lastSavedAt.current = mapDocument.updated_at;
-      updateUnassignedFeatures();
-    }
-  }, [mapDocument?.updated_at]);
+  // Keyed on document_id + updated_at (same pattern as Contiguity.tsx):
+  // refetches whenever a save lands, regardless of whether this component
+  // stayed mounted the whole time — fixes stale results on remount that a
+  // component-lifetime ref/flag couldn't detect.
+  const {data, isLoading} = useQuery({
+    queryKey: ['UnassignedFeatures', documentIdParam, mapDocument?.updated_at],
+    queryFn: () =>
+      GeometryWorker!.getUnassignedGeometries(documentIdParam, Array.from(shatterIds.parents)),
+    enabled: !!documentIdParam && !!GeometryWorker,
+    staleTime: 0,
+    retry: false,
+    placeholderData: previousData => previousData,
+    refetchOnWindowFocus: false,
+  });
+  const unassignedFeatureBboxes = data?.dissolved?.features || [];
+  const hasFoundUnassigned = !isLoading;
 
   return (
     <Flex direction="column">

--- a/app/src/app/store/unassignedFeatures.ts
+++ b/app/src/app/store/unassignedFeatures.ts
@@ -1,53 +1,13 @@
-import {useMapStore} from '@/app/store/mapStore';
-import {useAssignmentsStore} from '@/app/store/assignmentsStore';
-import GeometryWorker from '@/app/utils/GeometryWorker';
 import {create} from 'zustand';
-import {demographyService} from '../utils/demography/demographyService';
-import {ACCESS_STATES} from '@constants/document/state';
 
 type UnassignedFeatureStore = {
-  unassignedFeatureBboxes: GeoJSON.Feature[];
-  hasFoundUnassigned: boolean;
   selectedIndex: number | null;
   setSelectedIndex: (index: number | null) => void;
   reset: () => void;
-  updateUnassignedFeatures: () => void;
 };
 
-export const useUnassignFeaturesStore = create<UnassignedFeatureStore>((set, get) => ({
-  unassignedFeatureBboxes: [],
-  hasFoundUnassigned: false,
+export const useUnassignFeaturesStore = create<UnassignedFeatureStore>(set => ({
   selectedIndex: null,
   setSelectedIndex: (index: number | null) => set({selectedIndex: index}),
-  reset: () =>
-    set({
-      unassignedFeatureBboxes: [],
-      hasFoundUnassigned: false,
-      selectedIndex: null,
-    }),
-  updateUnassignedFeatures: async () => {
-    const {mapDocument, getMapRef} = useMapStore.getState();
-    const {shatterIds} = useAssignmentsStore.getState();
-    const mapRef = getMapRef();
-    if (!GeometryWorker || !mapRef) return;
-    // const expectedFeatures = demographyService.table?.size;
-    // const nSeen = Object.keys(await GeometryWorker.activeGeometries).length;
-    // disabling local implementation for now
-    const documentIdParam =
-      mapDocument?.access === ACCESS_STATES.READ && mapDocument?.public_id
-        ? String(mapDocument.public_id)
-        : mapDocument?.document_id;
-    const unassignedGeometries = await GeometryWorker.getUnassignedGeometries(
-      documentIdParam,
-      Array.from(shatterIds.parents)
-    );
-    // Unassigned areas have no stable identity — they merge, split, and can be
-    // undone — so show the live set on each refresh rather than tracking
-    // per-row resolved state the data can't actually promise.
-    set({
-      hasFoundUnassigned: true,
-      selectedIndex: null,
-      unassignedFeatureBboxes: unassignedGeometries?.dissolved?.features || [],
-    });
-  },
+  reset: () => set({selectedIndex: null}),
 }));


### PR DESCRIPTION
The Stats tab's Completeness check (unassigned-area finder) could show leftover results from an earlier fetch even after a map was fully assigned. `unassignedFeatureBboxes` only refreshed on three ad hoc triggers: initial mount (guarded by a `hasFoundUnassigned` flag that lives in a store outliving the component, so it never re-fires on remount), a `document_id` change, or an `updated_at` change tracked via a `useRef` that resets fresh on every remount — so it couldn't detect a save that landed while the component was unmounted. Reopening the panel, or returning to it after a save happened elsewhere, could leave stale unassigned-area chips on an actually-complete map with no signal they might be wrong.

The sibling Contiguity check doesn't have this problem: it uses `@tanstack/react-query`, keyed on `[document_id, updated_at]`, so a key change refetches regardless of mount history.

**Fix:** Move the unassigned-features fetch onto the same `useQuery` pattern, keyed identically (`['UnassignedFeatures', documentIdParam, updated_at]`). `unassignedFeatures.ts` is trimmed to just the `selectedIndex` UI state the query doesn't own — the fetch, cache, and loading state (`hasFoundUnassigned`/`isLoading`) now live entirely in the query.

## Tested

- [x] Type check (`bun run ts`)
- [x] Assign all population, save, open Stats → Completeness — shows "No unassigned areas found"
- [x] Un-assign an area, save while the panel stays open — chip list picks up the change without leaving and returning
- [x] Re-assign it, save, navigate away and back to Completeness — shows the current (complete) state on remount (the case that was broken)
- [x] Read-only shared-link view — the `public_id`-based fetch path still resolves
