### PR TITLE
Fix Community mode's key-option toggles getting clipped

### DIFF
--- a/app/src/app/components/Toolbar/CoiRadioGroup.tsx
+++ b/app/src/app/components/Toolbar/CoiRadioGroup.tsx
@@ -105,7 +105,7 @@ const CoiRadioRow: React.FC<{
             </Text>
           )}
         </Box>
-        <Box className="overflow-hidden" flexGrow="1">
+        <Box className="overflow-hidden min-w-0" flexGrow="1">
           <Tooltip content={community.description}>
             <Text size="2" color="gray" truncate>
               {community.description}

--- a/app/src/app/components/Toolbar/ToolControls/ToolControlsScaffold.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/ToolControlsScaffold.tsx
@@ -21,7 +21,7 @@ import {MAP_MODES} from '@constants/map/mode';
 // two-column is worth it — sharing one breakpoint meant Community mode's rows
 // got squeezed unreadable at widths where Districts mode looked fine.
 const TWO_COLUMN_BREAKPOINT = 400;
-const COI_TWO_COLUMN_BREAKPOINT = 640;
+const COI_TWO_COLUMN_BREAKPOINT = 550;
 
 const makeTwoColumnGrid = (breakpoint: number) =>
   styled('div', {

--- a/app/src/app/components/Toolbar/ToolControls/ToolControlsScaffold.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/ToolControlsScaffold.tsx
@@ -13,26 +13,37 @@ import {ACTIVE_TOOLS} from '@constants/map/tools';
 import {MAP_MODES} from '@constants/map/mode';
 
 // Sidebar container width (it defaults to 35vw and is user-resizable) at which
-// the left/right columns stop stacking.
+// the left/right columns stop stacking. The breakpoint is a fixed pixel value
+// (container queries can't measure a column's own content), so it has to be
+// picked per how wide the left column's content actually runs: Districts'
+// zone picker is a compact grid of color swatches; Community's CoiZonePicker
+// rows (name, description, three icon buttons) need much more room before
+// two-column is worth it — sharing one breakpoint meant Community mode's rows
+// got squeezed unreadable at widths where Districts mode looked fine.
 const TWO_COLUMN_BREAKPOINT = 400;
+const COI_TWO_COLUMN_BREAKPOINT = 640;
 
-const TwoColumnGrid = styled('div', {
-  display: 'grid',
-  gridTemplateColumns: '1fr',
-  gap: 'var(--space-4)',
-  width: '100%',
-  [`@container (min-width: ${TWO_COLUMN_BREAKPOINT}px)`]: {
-    // max-content, not a fraction: the right column's toggle labels must
-    // never wrap, regardless of container width or font metrics. The left
-    // column (zone picker) absorbs whatever space is left. minmax(0, 1fr),
-    // not a bare 1fr (which is minmax(auto, 1fr) by spec): a bare 1fr can't
-    // shrink below its content's min-content width, so a wide left column
-    // (e.g. CoiZonePicker's name/description/icon rows) pushes the whole
-    // grid past the sidebar's edge instead of letting its own text-truncate
-    // kick in — clipping both columns rather than wrapping or eliding.
-    gridTemplateColumns: 'minmax(0, 1fr) max-content',
-  },
-});
+const makeTwoColumnGrid = (breakpoint: number) =>
+  styled('div', {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: 'var(--space-4)',
+    width: '100%',
+    [`@container (min-width: ${breakpoint}px)`]: {
+      // max-content, not a fraction: the right column's toggle labels must
+      // never wrap, regardless of container width or font metrics. The left
+      // column (zone picker) absorbs whatever space is left. minmax(0, 1fr),
+      // not a bare 1fr (which is minmax(auto, 1fr) by spec): a bare 1fr can't
+      // shrink below its content's min-content width, so a wide left column
+      // pushes the whole grid past the sidebar's edge instead of letting its
+      // own text-truncate kick in — clipping both columns rather than
+      // wrapping or eliding.
+      gridTemplateColumns: 'minmax(0, 1fr) max-content',
+    },
+  });
+
+const TwoColumnGrid = makeTwoColumnGrid(TWO_COLUMN_BREAKPOINT);
+const CoiTwoColumnGrid = makeTwoColumnGrid(COI_TWO_COLUMN_BREAKPOINT);
 
 const disabledSectionStyle = (disabled: boolean): React.CSSProperties =>
   disabled ? {opacity: 0.5, pointerEvents: 'none'} : {};
@@ -58,6 +69,7 @@ export const ToolControlsScaffold = () => {
     activeTool === ACTIVE_TOOLS.PAN ||
     breakBeforeBlockView ||
     (activeTool === ACTIVE_TOOLS.ERASER && mapMode === MAP_MODES.DISTRICTS);
+  const Grid = mapMode === MAP_MODES.COI ? CoiTwoColumnGrid : TwoColumnGrid;
 
   return (
     <Flex direction="column" gapY="4" width="100%">
@@ -76,12 +88,12 @@ export const ToolControlsScaffold = () => {
         </Box>
       </Flex>
 
-      <TwoColumnGrid>
+      <Grid>
         <Box style={disabledSectionStyle(zonePickerDisabled)}>
           <ZonePicker disabled={zonePickerDisabled} />
         </Box>
         <KeyOptionToggles />
-      </TwoColumnGrid>
+      </Grid>
     </Flex>
   );
 };

--- a/app/src/app/components/Toolbar/ToolControls/ToolControlsScaffold.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/ToolControlsScaffold.tsx
@@ -24,8 +24,13 @@ const TwoColumnGrid = styled('div', {
   [`@container (min-width: ${TWO_COLUMN_BREAKPOINT}px)`]: {
     // max-content, not a fraction: the right column's toggle labels must
     // never wrap, regardless of container width or font metrics. The left
-    // column (zone picker) absorbs whatever space is left.
-    gridTemplateColumns: '1fr max-content',
+    // column (zone picker) absorbs whatever space is left. minmax(0, 1fr),
+    // not a bare 1fr (which is minmax(auto, 1fr) by spec): a bare 1fr can't
+    // shrink below its content's min-content width, so a wide left column
+    // (e.g. CoiZonePicker's name/description/icon rows) pushes the whole
+    // grid past the sidebar's edge instead of letting its own text-truncate
+    // kick in — clipping both columns rather than wrapping or eliding.
+    gridTemplateColumns: 'minmax(0, 1fr) max-content',
   },
 });
 


### PR DESCRIPTION
The tool controls panel's two-column layout (district/community picker beside "Show district numbers"/"Show population on hover"/etc.) clipped or squeezed both columns in Community mode — the community rows (name, description, three icon buttons) are wider than what fits comfortably at the same widths where Districts mode's compact color-swatch grid looks fine.

**Cause, part one:** the grid's left column was a bare `1fr`, which per the CSS Grid spec can't shrink below its content's min-content width, so it pushed the whole row past the sidebar's edge instead of shrinking. The community description text already had truncation wired up, but its containing box was a flex item with the browser's default `min-width: auto`, so it couldn't shrink below its own content either — the truncation code was already there and just never got the chance to run.

**Cause, part two:** the two-column layout switches on at a fixed sidebar width (a container query, which can't measure a column's own content) — one breakpoint shared between Districts and Community mode. Fixing the shrink behavior above stopped the clipping, but at that same shared breakpoint Community's wider rows were still squeezed down to near-unreadable before the fix, and cramped-but-legible after.

**Fix:** the grid's left column is `minmax(0, 1fr)` now (lets it actually shrink), the description box gets `min-w-0` (lets its existing truncate-with-tooltip logic run), and Community mode gets its own, wider two-column breakpoint (550px vs. Districts' 400px, tuned against a live render) — so at ordinary sidebar widths it stays in the same single-column stack Districts mode already falls back to when narrow, instead of switching to a cramped two-column layout too early.
