### PR TITLE
Feat/final launch feedback

### DIFF
--- a/app/src/app/(static)/guide/page.tsx
+++ b/app/src/app/(static)/guide/page.tsx
@@ -113,7 +113,7 @@ export default function GuidePage() {
               videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/brush_size.webm`}
             />
             <Text size="3">
-              To paint whole counties at once, toggle the “County Brush” box next to the slider.
+              To paint whole counties at once, toggle the “Paint by county” box next to the slider.
             </Text>
             <LoopVideoPlayer
               videoUrl={`${process.env.NEXT_PUBLIC_S3_BUCKET_URL}/videos/guide-2026/county_brush.webm`}

--- a/app/src/app/(static)/rules/page.tsx
+++ b/app/src/app/(static)/rules/page.tsx
@@ -76,7 +76,7 @@ export default function RulesPage() {
           />
           <RuleSection
             title="Contiguity"
-            description="Each district should be one connected piece"
+            description="Each district should be one connected component"
             image="/nesting - contiguity.png"
             imageAlt="Contiguity"
           />

--- a/app/src/app/components/HelpTip/helpTipContent.ts
+++ b/app/src/app/components/HelpTip/helpTipContent.ts
@@ -184,13 +184,13 @@ export const helpTipContent = {
   },
   mapActions: {
     title: 'Map actions',
-    text: 'Click "Map actions" above to share a link to your map, or export it as a CSV of unit assignments, a GeoJSON or Shapefile of district boundaries, or a JSON of evaluation metrics.',
+    text: 'Share a link to your map, or export it as a CSV, GeoJSON, Shapefile, or JSON.',
     videoFiles: ['share_map.webm', 'export.webm'],
     guideAnchor: 'saving-sharing-importing-and-exporting',
   },
   modeSwitcher: {
     title: 'Switching modes',
-    text: 'Click the mode switcher above to move between Draw (build your plan), View (a clean read-only display), and Evaluate (a dashboard of stats about it).',
+    text: 'Switch between Draw, View, and Evaluate modes.',
     videoFiles: ['view_mode.webm', 'evaluation_mode.webm'],
     guideAnchor: 'map-modes',
   },

--- a/app/src/app/components/HelpTip/helpTipContent.ts
+++ b/app/src/app/components/HelpTip/helpTipContent.ts
@@ -52,7 +52,7 @@ export const helpTipContent = {
   // (the video modal's description still does).
   drawToolsCombination: {
     title: 'Draw tools',
-    text: 'Use county brush to paint the basic outline, and use smaller brushes/erasers to refine the edges:',
+    text: 'Use Paint by county to paint the basic outline, and use smaller brushes/erasers to refine the edges:',
     videoFile: 'draw_tools_combination.webm',
     guideAnchor: 'drawing-the-districts',
     linkSuffix: 'on how to combine tools efficiently',

--- a/app/src/app/components/Map/BlockModePill.tsx
+++ b/app/src/app/components/Map/BlockModePill.tsx
@@ -18,12 +18,8 @@ export const BlockModePill = () => {
   const setActiveTool = useMapControlsStore(state => state.setActiveTool);
   const bounds = useMapControlsStore(state => state.mapOptions.bounds);
   const captiveIds = useMapStore(state => state.captiveIds);
-  // Name the map's paintable unit ("precinct" for VTD maps, "block group" for
-  // block-group maps) in the break prompt; fall back to "precinct" when the
-  // document hasn't loaded yet.
   const parentGeoUnitType = useMapStore(state => state.mapDocument?.parent_geo_unit_type);
-  const unitName =
-    (parentGeoUnitType && GEO_UNIT_SINGULAR_NAMES[parentGeoUnitType]) || 'precinct';
+  const unitName = (parentGeoUnitType && GEO_UNIT_SINGULAR_NAMES[parentGeoUnitType]) || 'precinct';
   const exitBlockView = useMapStore(state => state.exitBlockView);
   const getMapRef = useMapStore(state => state.getMapRef);
   const inBlockView = captiveIds.size > 0;

--- a/app/src/app/components/Map/BlockModePill.tsx
+++ b/app/src/app/components/Map/BlockModePill.tsx
@@ -4,6 +4,7 @@ import {InfoCircledIcon} from '@radix-ui/react-icons';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {ACTIVE_TOOLS} from '@constants/map/tools';
+import {GEO_UNIT_SINGULAR_NAMES} from '@constants/document/geoUnits';
 import {MapPill} from './MapPill';
 
 /**
@@ -17,6 +18,12 @@ export const BlockModePill = () => {
   const setActiveTool = useMapControlsStore(state => state.setActiveTool);
   const bounds = useMapControlsStore(state => state.mapOptions.bounds);
   const captiveIds = useMapStore(state => state.captiveIds);
+  // Name the map's paintable unit ("precinct" for VTD maps, "block group" for
+  // block-group maps) in the break prompt; fall back to "precinct" when the
+  // document hasn't loaded yet.
+  const parentGeoUnitType = useMapStore(state => state.mapDocument?.parent_geo_unit_type);
+  const unitName =
+    (parentGeoUnitType && GEO_UNIT_SINGULAR_NAMES[parentGeoUnitType]) || 'precinct';
   const exitBlockView = useMapStore(state => state.exitBlockView);
   const getMapRef = useMapStore(state => state.getMapRef);
   const inBlockView = captiveIds.size > 0;
@@ -77,7 +84,7 @@ export const BlockModePill = () => {
         }
         onEscape={() => setActiveTool(ACTIVE_TOOLS.BRUSH)}
       >
-        <b>Choose a unit</b> to break into blocks
+        <b>Choose a {unitName}</b> to break down into blocks
       </MapPill>
     );
   }

--- a/app/src/app/components/MapPage/MapPage.tsx
+++ b/app/src/app/components/MapPage/MapPage.tsx
@@ -6,6 +6,7 @@ import {PublicMap} from '@components/Map/PublicMap';
 import {DemographicMap} from '@components/Map/DemographicMap';
 import {PublicDemographicMap} from '@components/Map/PublicDemographicMap';
 import SidebarComponent from '@components/sidebar/Sidebar';
+import {DraftStatusHelper} from '@components/sidebar/DraftStatusHelper';
 import {EvalPanel} from '@components/EvalPanel/EvalPanel';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {queryClient} from '@utils/api/queryClient';
@@ -141,9 +142,18 @@ function ChildMapPage({isEditing, isEval, mapId}: MapPageProps) {
         ) : (
           <Topbar />
         )}
-        <Flex direction="row" className="flex-1 min-h-0">
+        <Flex direction="row" className="flex-1 min-h-0 relative">
           {isPublicPage ? <PublicMap /> : <MainMap />}
           {showDemographicMap && (isPublicPage ? <PublicDemographicMap /> : <DemographicMap />)}
+          {/* Draft-status helper overlays the map's top-right (the geocode bar
+              holds top-left, zoom bottom-right). Hidden below lg, where the
+              MobileToolbar's "View map guide" modal serves it instead; scrolls
+              within itself rather than outgrowing the map. No fixed width
+              here: the card sizes itself (360px expanded, shrink-to-fit
+              collapsed) and the right anchor keeps it hugging the corner. */}
+          <div className="absolute top-3 right-3 z-10 hidden lg:flex justify-end max-w-[calc(100%-24px)] max-h-[calc(100%-24px)] overflow-y-auto rounded-[10px]">
+            <DraftStatusHelper />
+          </div>
         </Flex>
         <MobileToolbar />
         <MapTooltip />

--- a/app/src/app/components/MapPage/MapPage.tsx
+++ b/app/src/app/components/MapPage/MapPage.tsx
@@ -145,12 +145,9 @@ function ChildMapPage({isEditing, isEval, mapId}: MapPageProps) {
         <Flex direction="row" className="flex-1 min-h-0 relative">
           {isPublicPage ? <PublicMap /> : <MainMap />}
           {showDemographicMap && (isPublicPage ? <PublicDemographicMap /> : <DemographicMap />)}
-          {/* Draft-status helper overlays the map's top-right (the geocode bar
-              holds top-left, zoom bottom-right). Hidden below lg, where the
-              MobileToolbar's "View map guide" modal serves it instead; scrolls
-              within itself rather than outgrowing the map. No fixed width
-              here: the card sizes itself (360px expanded, shrink-to-fit
-              collapsed) and the right anchor keeps it hugging the corner. */}
+          {/* Draft-status helper, top-right of the map. Hidden below lg (the
+              mobile "View map guide" modal serves it); the card sizes itself
+              so the right anchor keeps the collapsed header in the corner. */}
           <div className="absolute top-3 right-3 z-10 hidden lg:flex justify-end max-w-[calc(100%-24px)] max-h-[calc(100%-24px)] overflow-y-auto rounded-[10px]">
             <DraftStatusHelper />
           </div>

--- a/app/src/app/components/Toolbar/MobileToolbar.tsx
+++ b/app/src/app/components/Toolbar/MobileToolbar.tsx
@@ -42,7 +42,7 @@ export const MobileToolbar: React.FC = () => {
         )}
       </div>
       <Dialog.Root open={guideOpen} onOpenChange={setGuideOpen}>
-        <Dialog.Content size="1" maxWidth="400px">
+        <Dialog.Content size="1" maxWidth="400px" aria-describedby={undefined}>
           <Dialog.Title className="sr-only">Map guide</Dialog.Title>
           <DraftStatusHelper onNavigate={() => setGuideOpen(false)} collapsible={false} />
         </Dialog.Content>

--- a/app/src/app/components/Toolbar/PaintByCounty.tsx
+++ b/app/src/app/components/Toolbar/PaintByCounty.tsx
@@ -52,8 +52,7 @@ export default function PaintByCounty() {
   const disabledForGeography = isConnecticut || isSingleCounty;
   const disabled =
     access === ACCESS_STATES.READ || lockedForBreak || disabledForPan || disabledForGeography;
-  // Guided step (see uiHintStore.guideTargets): the helper's "paint by
-  // counties" hint pulses this control until the user flips it themselves.
+  // Guide target for the "paint by counties" hint (see uiHintStore).
   const guiding = useUiHintStore(state => state.guideTargets[0] === 'county-brush');
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
 

--- a/app/src/app/components/Toolbar/PaintByCounty.tsx
+++ b/app/src/app/components/Toolbar/PaintByCounty.tsx
@@ -52,10 +52,13 @@ export default function PaintByCounty() {
   const disabledForGeography = isConnecticut || isSingleCounty;
   const disabled =
     access === ACCESS_STATES.READ || lockedForBreak || disabledForPan || disabledForGeography;
-  // The helper's "paint by counties" hint pulses this control.
-  const flashing = useUiHintStore(state => state.flashTarget === 'county-brush');
+  // Guided step (see uiHintStore.guideTargets): the helper's "paint by
+  // counties" hint pulses this control until the user flips it themselves.
+  const guiding = useUiHintStore(state => state.guideTargets[0] === 'county-brush');
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
 
   const handleToggle = () => {
+    advanceGuide('county-brush');
     if (!mapRef) return;
     setMapOptions({
       paintByCounty: !paintByCounty,
@@ -84,7 +87,7 @@ export default function PaintByCounty() {
     >
       <Card
         size="1"
-        className={`${paintByCounty ? 'bg-indigo-50' : ''} ${flashing ? 'ui-flash' : ''}`}
+        className={`${paintByCounty ? 'bg-indigo-50' : ''} ${guiding ? 'ui-guide' : ''}`}
         style={
           lockedForBreak || disabledForPan || disabledForGeography ? {opacity: 0.5} : undefined
         }
@@ -92,7 +95,7 @@ export default function PaintByCounty() {
         <Text as="label" size="2" className="cursor-pointer select-none">
           <Flex gap="2" align="center">
             <Checkbox checked={paintByCounty} onCheckedChange={handleToggle} disabled={disabled} />
-            County Brush
+            Paint by county
           </Flex>
         </Text>
       </Card>

--- a/app/src/app/components/Toolbar/PaintByCounty.tsx
+++ b/app/src/app/components/Toolbar/PaintByCounty.tsx
@@ -1,9 +1,11 @@
+import {useEffect} from 'react';
 import {Card, Checkbox, Flex, Text} from '@radix-ui/themes';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
 import {useToolbarStore} from '@/app/store/toolbarStore';
 import {useUiHintStore} from '@/app/store/uiHintStore';
+import {useFeatureFlagStore} from '@/app/store/featureFlagStore';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
 import {demographyService} from '@/app/utils/demography/demographyService';
 import {getFeaturesInBbox} from '@utils/map/getFeaturesInBbox';
@@ -20,13 +22,29 @@ import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
 // which has no way to see this mismatch.
 const CONNECTICUT_STATE_FIPS = '09';
 
+/** Whether county painting can work on this map at all: the feature flag is
+ * off for LOCAL maps (the control isn't even rendered then), Connecticut's
+ * county layer can't match districtr's block geoids (see above), and a
+ * single-county map has no second county to paint by. Exported for
+ * DraftStatusHelper, whose rough-draw hint must not guide the user to a
+ * disabled — or missing — control. */
+export const useCountyPaintAvailable = (): boolean => {
+  const paintCounties = useFeatureFlagStore(state => state.paintCounties);
+  const statefps = useMapStore(state => state.mapDocument?.statefps);
+  // Re-render when demography data (re)loads, so this always reflects the
+  // currently loaded unit universe rather than a stale render.
+  const dataHash = useDemographyStore(state => state.dataHash);
+  const isConnecticut = statefps?.length === 1 && statefps[0] === CONNECTICUT_STATE_FIPS;
+  const isSingleCounty = !isConnecticut && !!dataHash && !demographyService.spansMultipleCounties();
+  return paintCounties && !isConnecticut && !isSingleCounty;
+};
+
 export default function PaintByCounty() {
   const mapRef = useMapStore(state => state.getMapRef());
   const setPaintFunction = useMapControlsStore(state => state.setPaintFunction);
   const paintByCounty = useMapControlsStore(state => state.mapOptions.paintByCounty);
   const setMapOptions = useMapControlsStore(state => state.setMapOptions);
   const access = useMapStore(state => state.mapStatus?.access);
-  const statefps = useMapStore(state => state.mapDocument?.statefps);
   const clearPaintConstraint = useOverlayStore(state => state.clearPaintConstraint);
   const activeTool = useMapControlsStore(state => state.activeTool);
   const inBlockView = useMapStore(state => state.captiveIds.size > 0);
@@ -42,19 +60,25 @@ export default function PaintByCounty() {
   // Pan doesn't paint at all — same as the brush-size slider and zone picker,
   // just visually/functionally inert, no explanatory tooltip needed.
   const disabledForPan = activeTool === ACTIVE_TOOLS.PAN;
-  // Re-render when demography data (re)loads, so this always reflects the
-  // currently loaded unit universe rather than a stale render.
-  const dataHash = useDemographyStore(state => state.dataHash);
-  const isConnecticut = statefps?.length === 1 && statefps[0] === CONNECTICUT_STATE_FIPS;
-  const isSingleCounty = !isConnecticut && !!dataHash && !demographyService.spansMultipleCounties();
-  // A single-county map or local map has no second county to paint by; toggling
-  // wouldn't do anything, so the control itself is disabled, not just unchecked.
-  const disabledForGeography = isConnecticut || isSingleCounty;
+  // A single-county map (or Connecticut, or a LOCAL map) has no county pair
+  // to paint by; toggling wouldn't do anything, so the control itself is
+  // disabled, not just unchecked. See useCountyPaintAvailable above.
+  const disabledForGeography = !useCountyPaintAvailable();
   const disabled =
     access === ACCESS_STATES.READ || lockedForBreak || disabledForPan || disabledForGeography;
-  // Guide target for the "paint by counties" hint (see uiHintStore).
+  // Guide target for the "paint by counties" hint (see uiHintStore). Already
+  // on means nothing to click — skip ahead with a confirmation pulse instead
+  // of inviting a click that would turn it off.
   const guiding = useUiHintStore(state => state.guideTargets[0] === 'county-brush');
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const flash = useUiHintStore(state => state.flash);
+  const flashing = useUiHintStore(state => state.flashTarget === 'county-brush');
+  useEffect(() => {
+    if (guiding && paintByCounty) {
+      advanceGuide('county-brush');
+      flash('county-brush');
+    }
+  }, [guiding, paintByCounty, advanceGuide, flash]);
 
   const handleToggle = () => {
     advanceGuide('county-brush');
@@ -86,7 +110,9 @@ export default function PaintByCounty() {
     >
       <Card
         size="1"
-        className={`${paintByCounty ? 'bg-indigo-50' : ''} ${guiding ? 'ui-guide' : ''}`}
+        className={`${paintByCounty ? 'bg-indigo-50' : ''} ${
+          guiding ? 'ui-guide' : flashing ? 'ui-flash' : ''
+        }`}
         style={
           lockedForBreak || disabledForPan || disabledForGeography ? {opacity: 0.5} : undefined
         }

--- a/app/src/app/components/Toolbar/PaintByCounty.tsx
+++ b/app/src/app/components/Toolbar/PaintByCounty.tsx
@@ -1,10 +1,9 @@
-import {useEffect} from 'react';
 import {Card, Checkbox, Flex, Text} from '@radix-ui/themes';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {useOverlayStore} from '@/app/store/overlayStore';
 import {useToolbarStore} from '@/app/store/toolbarStore';
-import {useUiHintStore} from '@/app/store/uiHintStore';
+import {useUiHintStore, useGuideTarget} from '@/app/store/uiHintStore';
 import {useFeatureFlagStore} from '@/app/store/featureFlagStore';
 import {useDemographyStore} from '@/app/store/demography/demographyStore';
 import {demographyService} from '@/app/utils/demography/demographyService';
@@ -22,17 +21,13 @@ import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
 // which has no way to see this mismatch.
 const CONNECTICUT_STATE_FIPS = '09';
 
-/** Whether county painting can work on this map at all: the feature flag is
- * off for LOCAL maps (the control isn't even rendered then), Connecticut's
- * county layer can't match districtr's block geoids (see above), and a
- * single-county map has no second county to paint by. Exported for
- * DraftStatusHelper, whose rough-draw hint must not guide the user to a
- * disabled — or missing — control. */
+/** Whether county painting can work on this map at all: LOCAL maps (flag
+ * off), Connecticut (see above), and single-county maps can't. Exported for
+ * DraftStatusHelper's rough-draw hint. */
 export const useCountyPaintAvailable = (): boolean => {
   const paintCounties = useFeatureFlagStore(state => state.paintCounties);
   const statefps = useMapStore(state => state.mapDocument?.statefps);
-  // Re-render when demography data (re)loads, so this always reflects the
-  // currently loaded unit universe rather than a stale render.
+  // Re-render when demography data (re)loads.
   const dataHash = useDemographyStore(state => state.dataHash);
   const isConnecticut = statefps?.length === 1 && statefps[0] === CONNECTICUT_STATE_FIPS;
   const isSingleCounty = !isConnecticut && !!dataHash && !demographyService.spansMultipleCounties();
@@ -60,25 +55,12 @@ export default function PaintByCounty() {
   // Pan doesn't paint at all — same as the brush-size slider and zone picker,
   // just visually/functionally inert, no explanatory tooltip needed.
   const disabledForPan = activeTool === ACTIVE_TOOLS.PAN;
-  // A single-county map (or Connecticut, or a LOCAL map) has no county pair
-  // to paint by; toggling wouldn't do anything, so the control itself is
-  // disabled, not just unchecked. See useCountyPaintAvailable above.
   const disabledForGeography = !useCountyPaintAvailable();
   const disabled =
     access === ACCESS_STATES.READ || lockedForBreak || disabledForPan || disabledForGeography;
-  // Guide target for the "paint by counties" hint (see uiHintStore). Already
-  // on means nothing to click — skip ahead with a confirmation pulse instead
-  // of inviting a click that would turn it off.
-  const guiding = useUiHintStore(state => state.guideTargets[0] === 'county-brush');
+  // Already on counts as satisfied — a click would turn it off.
+  const {guiding, flashing} = useGuideTarget('county-brush', paintByCounty);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
-  const flash = useUiHintStore(state => state.flash);
-  const flashing = useUiHintStore(state => state.flashTarget === 'county-brush');
-  useEffect(() => {
-    if (guiding && paintByCounty) {
-      advanceGuide('county-brush');
-      flash('county-brush');
-    }
-  }, [guiding, paintByCounty, advanceGuide, flash]);
 
   const handleToggle = () => {
     advanceGuide('county-brush');

--- a/app/src/app/components/Toolbar/ToolButtons.tsx
+++ b/app/src/app/components/Toolbar/ToolButtons.tsx
@@ -22,23 +22,17 @@ const HISTORY_GROW_FACTOR = 0.2;
 
 const HISTORY_TOOLS: ActiveTool[] = [ACTIVE_TOOLS.UNDO, ACTIVE_TOOLS.REDO];
 
-// Chorded labels ('⌘ + Shift + Z') are too wide for a corner badge; condense
-// them to symbol form ('⌘⇧Z' / 'Ctrl⇧Z'). Single-letter labels pass through.
+// '⌘ + Shift + Z' → '⌘⇧Z': chorded labels are too wide for a corner badge.
 const compactHotkeyLabel = (label: string) => label.replace(/Shift/g, '⇧').replace(/\s*\+\s*/g, '');
 
 export const ToolButtons: React.FC = () => {
   const activeTool = useMapControlsStore(state => state.activeTool);
   const setActiveTool = useMapControlsStore(state => state.setActiveTool);
-  // Shortcut previews (the corner hotkey badge) appear only while Alt/Option
-  // is held — the buttons are too cramped for always-on badges. This component
-  // only mounts in draw mode, so the Alt listener doesn't outlive it; mobile
-  // has no Alt key, so the held state is effectively desktop-only. The hotkeys
-  // themselves always work without the badges.
+  // Hotkey badges show only while Alt/Option is held; the hotkeys themselves
+  // always work.
   const showHotkeyHints = useAltHeld();
   const activeTools = useActiveTools();
-  // Guided step (see uiHintStore.guideTargets): the draft helper points at a
-  // tool button (`tool:<mode>`) and pulses it until the user arms that tool
-  // themselves; a guide pointing at the already-active tool skips ahead.
+  // Guide target `tool:<mode>` (see uiHintStore); skips if already armed.
   const guideTarget = useUiHintStore(state => state.guideTargets[0]);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
   useEffect(() => {
@@ -49,8 +43,6 @@ export const ToolButtons: React.FC = () => {
   const renderTool = (tool: ActiveToolConfig, buttonStyle: React.CSSProperties) => {
     const IconComponent = tool.icon;
     const isActive = activeTool === tool.mode;
-    // History tools' chorded shortcuts get a compact badge (⌘⇧Z) — the full
-    // '⌘ + Shift + Z' form is too wide for their narrow buttons.
     const isHistoryTool = HISTORY_TOOLS.includes(tool.mode);
     const button = (
       <IconButton
@@ -84,7 +76,6 @@ export const ToolButtons: React.FC = () => {
         color={isActive ? undefined : 'gray'}
         disabled={tool.disabled}
       >
-        {/* Shortcuts float in the button's top-right corner while Alt is held. */}
         {showHotkeyHints && (
           <Kbd
             size="1"
@@ -119,8 +110,7 @@ export const ToolButtons: React.FC = () => {
     // ToolUtils' combinationHelpKey / 'superdrawToolsCombination'), so its
     // hover card would describe every tool in the group rather than just
     // this button — text="" suppresses that description, leaving only the
-    // demonstration link. Shortcuts no longer ride along in the hover card;
-    // they're revealed by holding Alt/Option instead (corner badges above).
+    // demonstration link.
     return tool.helpKey ? (
       <HelpTip key={tool.mode} tip={tool.helpKey} openDelay={HELP_TIP_HOVER_DELAY} text="">
         {button}

--- a/app/src/app/components/Toolbar/ToolButtons.tsx
+++ b/app/src/app/components/Toolbar/ToolButtons.tsx
@@ -1,12 +1,13 @@
 'use client';
 import {Flex, IconButton, Kbd, Text} from '@radix-ui/themes';
 import {useMapControlsStore} from '@store/mapControlsStore';
-import {useToolbarStore} from '@store/toolbarStore';
-import React from 'react';
+import {useUiHintStore} from '@store/uiHintStore';
+import React, {useEffect} from 'react';
 import {ACTIVE_TOOLS, type ActiveTool} from '@constants/map/tools';
 import {useActiveTools} from '@/app/components/Toolbar/ToolUtils';
 import type {ActiveToolConfig} from '@/app/components/Toolbar/ToolUtils';
 import {HelpTip, HELP_TIP_HOVER_DELAY} from '@/app/components/HelpTip/HelpTip';
+import {useAltHeld} from '@/app/hooks/useAltHeld';
 
 // Fixed button size; the old user-configurable size picker was removed.
 const TOOLBAR_SIZE = 40;
@@ -21,44 +22,44 @@ const HISTORY_GROW_FACTOR = 0.2;
 
 const HISTORY_TOOLS: ActiveTool[] = [ACTIVE_TOOLS.UNDO, ACTIVE_TOOLS.REDO];
 
+// Chorded labels ('⌘ + Shift + Z') are too wide for a corner badge; condense
+// them to symbol form ('⌘⇧Z' / 'Ctrl⇧Z'). Single-letter labels pass through.
+const compactHotkeyLabel = (label: string) => label.replace(/Shift/g, '⇧').replace(/\s*\+\s*/g, '');
+
 export const ToolButtons: React.FC = () => {
   const activeTool = useMapControlsStore(state => state.activeTool);
   const setActiveTool = useMapControlsStore(state => state.setActiveTool);
-  // Shortcut previews (the corner hotkey badge) are Super Draw only; the
-  // hotkeys themselves still work in plain Draw.
-  const showHotkeyHints = useToolbarStore(state => state.superDraw);
+  // Shortcut previews (the corner hotkey badge) appear only while Alt/Option
+  // is held — the buttons are too cramped for always-on badges. This component
+  // only mounts in draw mode, so the Alt listener doesn't outlive it; mobile
+  // has no Alt key, so the held state is effectively desktop-only. The hotkeys
+  // themselves always work without the badges.
+  const showHotkeyHints = useAltHeld();
   const activeTools = useActiveTools();
+  // Guided step (see uiHintStore.guideTargets): the draft helper points at a
+  // tool button (`tool:<mode>`) and pulses it until the user arms that tool
+  // themselves; a guide pointing at the already-active tool skips ahead.
+  const guideTarget = useUiHintStore(state => state.guideTargets[0]);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  useEffect(() => {
+    if (guideTarget === `tool:${activeTool}`) advanceGuide(guideTarget);
+  }, [guideTarget, activeTool, advanceGuide]);
   const mainTools = activeTools.filter(tool => !HISTORY_TOOLS.includes(tool.mode));
   const historyTools = activeTools.filter(tool => HISTORY_TOOLS.includes(tool.mode));
-  // Undo/Redo share one HelpTip entry and have no room for a corner hotkey
-  // badge (their shortcuts are chorded, too wide) — so in Super Draw, their
-  // shortcuts ride along in the hover card's own text instead of a second,
-  // Alt-revealed tooltip (this override hides the demonstration link for that
-  // mode — no room for both, and the shortcuts matter more there). Outside
-  // Super Draw, '' suppresses the dictionary entry's own text the same way
-  // the tool-group combos do, leaving just the demonstration link. Composed
-  // from each tool's own hotKeyLabel (already OS-aware: ⌘ vs Ctrl), not
-  // hardcoded into the static copy.
-  const undoTool = historyTools.find(tool => tool.mode === ACTIVE_TOOLS.UNDO);
-  const redoTool = historyTools.find(tool => tool.mode === ACTIVE_TOOLS.REDO);
-  const historyHelpText =
-    showHotkeyHints && undoTool && redoTool
-      ? `Undo shortcut: ${undoTool.hotKeyLabel}.\nRedo shortcut: ${redoTool.hotKeyLabel}.`
-      : '';
-
   const renderTool = (tool: ActiveToolConfig, buttonStyle: React.CSSProperties) => {
     const IconComponent = tool.icon;
     const isActive = activeTool === tool.mode;
-    // Main tools get a corner hotkey badge; history tools (chorded ⌘Z/⌘⇧Z
-    // shortcuts, too wide for a corner) have their shortcut folded into the
-    // HelpTip text below instead — one hover mechanism for every tool.
+    // History tools' chorded shortcuts get a compact badge (⌘⇧Z) — the full
+    // '⌘ + Shift + Z' form is too wide for their narrow buttons.
     const isHistoryTool = HISTORY_TOOLS.includes(tool.mode);
     const button = (
       <IconButton
         key={tool.mode}
         data-testid={`${tool.mode}-tool`}
         aria-label={tool.label}
-        className="cursor-pointer tool-button"
+        className={`cursor-pointer tool-button ${
+          guideTarget === `tool:${tool.mode}` ? 'ui-guide' : ''
+        }`}
         onClick={() => {
           if (tool.onClick) {
             tool.onClick();
@@ -83,8 +84,8 @@ export const ToolButtons: React.FC = () => {
         color={isActive ? undefined : 'gray'}
         disabled={tool.disabled}
       >
-        {/* Main-tool shortcuts float in the button's top-right corner. */}
-        {!isHistoryTool && showHotkeyHints && (
+        {/* Shortcuts float in the button's top-right corner while Alt is held. */}
+        {showHotkeyHints && (
           <Kbd
             size="1"
             style={{
@@ -95,9 +96,11 @@ export const ToolButtons: React.FC = () => {
               boxShadow: 'none',
               color: 'inherit',
               opacity: 0.7,
+              whiteSpace: 'nowrap',
+              ...(isHistoryTool ? {fontSize: 9, letterSpacing: 0} : {}),
             }}
           >
-            {tool.hotKeyLabel}
+            {isHistoryTool ? compactHotkeyLabel(tool.hotKeyLabel) : tool.hotKeyLabel}
           </Kbd>
         )}
         <Flex direction="column" align="center" gap="1">
@@ -116,15 +119,10 @@ export const ToolButtons: React.FC = () => {
     // ToolUtils' combinationHelpKey / 'superdrawToolsCombination'), so its
     // hover card would describe every tool in the group rather than just
     // this button — text="" suppresses that description, leaving only the
-    // demonstration link. History tools (undo/redo) get their own,
-    // pair-specific text/link instead.
+    // demonstration link. Shortcuts no longer ride along in the hover card;
+    // they're revealed by holding Alt/Option instead (corner badges above).
     return tool.helpKey ? (
-      <HelpTip
-        key={tool.mode}
-        tip={tool.helpKey}
-        openDelay={HELP_TIP_HOVER_DELAY}
-        text={isHistoryTool ? historyHelpText : ''}
-      >
+      <HelpTip key={tool.mode} tip={tool.helpKey} openDelay={HELP_TIP_HOVER_DELAY} text="">
         {button}
       </HelpTip>
     ) : (

--- a/app/src/app/components/Toolbar/ToolControls/BrushSizeSelector.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushSizeSelector.tsx
@@ -76,10 +76,6 @@ export function BrushSizeSelector() {
               {'--gray-a3': 'var(--gray-a6)', '--gray-a5': 'var(--gray-a8)'} as React.CSSProperties
             }
           />
-          {/* Fixed width so the slider doesn't resize as digits change. */}
-          <Text size="1" color="gray" align="right" style={{width: '2.2em', flexShrink: 0}}>
-            {brushSize}
-          </Text>
         </Flex>
       </Flex>
     </Flex>

--- a/app/src/app/components/Toolbar/ToolControls/BrushSizeSelector.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushSizeSelector.tsx
@@ -77,8 +77,8 @@ export function BrushSizeSelector() {
             }
           />
           {/* Fixed width so the slider doesn't resize as digits change. */}
-          <Text size="1" color="gray" align="right" style={{width: '3.2em', flexShrink: 0}}>
-            {brushSize} px
+          <Text size="1" color="gray" align="right" style={{width: '2.2em', flexShrink: 0}}>
+            {brushSize}
           </Text>
         </Flex>
       </Flex>

--- a/app/src/app/components/Toolbar/ToolControls/BrushSizeSelector.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/BrushSizeSelector.tsx
@@ -76,6 +76,10 @@ export function BrushSizeSelector() {
               {'--gray-a3': 'var(--gray-a6)', '--gray-a5': 'var(--gray-a8)'} as React.CSSProperties
             }
           />
+          {/* Fixed width so the slider doesn't resize as digits change. */}
+          <Text size="1" color="gray" align="right" style={{width: '3.2em', flexShrink: 0}}>
+            {brushSize} px
+          </Text>
         </Flex>
       </Flex>
     </Flex>

--- a/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
@@ -23,9 +23,7 @@ export const KeyOptionToggles: React.FC = () => {
   // numbers stays enabled; that display doesn't depend on the active tool).
   const populationTooltipDisabled =
     access === ACCESS_STATES.READ || activeTool === ACTIVE_TOOLS.PAN;
-  // Guided step (see uiHintStore.guideTargets): DraftStatusHelper's "Show
-  // population tooltips as you paint" hint pulses this row until the user
-  // flips the checkbox themselves — the hint points, it never toggles.
+  // Guide target for the population-tooltip hint (see uiHintStore).
   const guiding = useUiHintStore(state => state.guideTargets[0] === 'population-tooltip');
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
 

--- a/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
@@ -23,9 +23,11 @@ export const KeyOptionToggles: React.FC = () => {
   // numbers stays enabled; that display doesn't depend on the active tool).
   const populationTooltipDisabled =
     access === ACCESS_STATES.READ || activeTool === ACTIVE_TOOLS.PAN;
-  // DraftStatusHelper's "Show population tooltips as you paint" hint pulses
-  // this row directly — it lives here, not inside any jump-able sidebar tab.
-  const flashing = useUiHintStore(state => state.flashTarget === 'population-tooltip');
+  // Guided step (see uiHintStore.guideTargets): DraftStatusHelper's "Show
+  // population tooltips as you paint" hint pulses this row until the user
+  // flips the checkbox themselves — the hint points, it never toggles.
+  const guiding = useUiHintStore(state => state.guideTargets[0] === 'population-tooltip');
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
 
   return (
     <Flex direction="column" gap="2">
@@ -40,7 +42,7 @@ export const KeyOptionToggles: React.FC = () => {
                 }
                 disabled={disallowPaintOverDisabled}
               />
-              Only paint unassigned areas
+              Forbid paint-over
             </Flex>
           </Text>
         </HelpTip>
@@ -57,15 +59,16 @@ export const KeyOptionToggles: React.FC = () => {
       <Text
         as="label"
         size="2"
-        className={`${populationTooltipDisabled ? 'select-none' : 'cursor-pointer select-none'} ${flashing ? 'ui-flash' : ''}`}
+        className={`${populationTooltipDisabled ? 'select-none' : 'cursor-pointer select-none'} ${guiding ? 'ui-guide' : ''}`}
         style={populationTooltipDisabled ? {opacity: 0.5} : undefined}
       >
         <Flex gap="2" align="center">
           <Checkbox
             checked={mapOptions.showPopulationTooltip === true}
-            onCheckedChange={() =>
-              setMapOptions({showPopulationTooltip: !mapOptions.showPopulationTooltip})
-            }
+            onCheckedChange={() => {
+              advanceGuide('population-tooltip');
+              setMapOptions({showPopulationTooltip: !mapOptions.showPopulationTooltip});
+            }}
             disabled={populationTooltipDisabled}
           />
           Show population on hover

--- a/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Checkbox, Flex, Text} from '@radix-ui/themes';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {useMapStore} from '@store/mapStore';
@@ -23,9 +23,20 @@ export const KeyOptionToggles: React.FC = () => {
   // numbers stays enabled; that display doesn't depend on the active tool).
   const populationTooltipDisabled =
     access === ACCESS_STATES.READ || activeTool === ACTIVE_TOOLS.PAN;
-  // Guide target for the population-tooltip hint (see uiHintStore).
+  // Guide target for the population-tooltip hint (see uiHintStore). Already
+  // on means nothing to click — skip ahead with a confirmation pulse instead
+  // of inviting a click that would turn it off.
   const guiding = useUiHintStore(state => state.guideTargets[0] === 'population-tooltip');
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const flash = useUiHintStore(state => state.flash);
+  const flashing = useUiHintStore(state => state.flashTarget === 'population-tooltip');
+  const showPopulationTooltip = mapOptions.showPopulationTooltip === true;
+  useEffect(() => {
+    if (guiding && showPopulationTooltip) {
+      advanceGuide('population-tooltip');
+      flash('population-tooltip');
+    }
+  }, [guiding, showPopulationTooltip, advanceGuide, flash]);
 
   return (
     <Flex direction="column" gap="2">
@@ -57,7 +68,9 @@ export const KeyOptionToggles: React.FC = () => {
       <Text
         as="label"
         size="2"
-        className={`${populationTooltipDisabled ? 'select-none' : 'cursor-pointer select-none'} ${guiding ? 'ui-guide' : ''}`}
+        className={`${populationTooltipDisabled ? 'select-none' : 'cursor-pointer select-none'} ${
+          guiding ? 'ui-guide' : flashing ? 'ui-flash' : ''
+        }`}
         style={populationTooltipDisabled ? {opacity: 0.5} : undefined}
       >
         <Flex gap="2" align="center">

--- a/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
+++ b/app/src/app/components/Toolbar/ToolControls/KeyOptionToggles.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {Checkbox, Flex, Text} from '@radix-ui/themes';
 import {useMapControlsStore} from '@store/mapControlsStore';
 import {useMapStore} from '@store/mapStore';
-import {useUiHintStore} from '@store/uiHintStore';
+import {useUiHintStore, useGuideTarget} from '@store/uiHintStore';
 import {ACCESS_STATES} from '@constants/document/state';
 import {ACTIVE_TOOLS} from '@constants/map/tools';
 import {MAP_MODES} from '@constants/map/mode';
@@ -23,20 +23,10 @@ export const KeyOptionToggles: React.FC = () => {
   // numbers stays enabled; that display doesn't depend on the active tool).
   const populationTooltipDisabled =
     access === ACCESS_STATES.READ || activeTool === ACTIVE_TOOLS.PAN;
-  // Guide target for the population-tooltip hint (see uiHintStore). Already
-  // on means nothing to click — skip ahead with a confirmation pulse instead
-  // of inviting a click that would turn it off.
-  const guiding = useUiHintStore(state => state.guideTargets[0] === 'population-tooltip');
-  const advanceGuide = useUiHintStore(state => state.advanceGuide);
-  const flash = useUiHintStore(state => state.flash);
-  const flashing = useUiHintStore(state => state.flashTarget === 'population-tooltip');
   const showPopulationTooltip = mapOptions.showPopulationTooltip === true;
-  useEffect(() => {
-    if (guiding && showPopulationTooltip) {
-      advanceGuide('population-tooltip');
-      flash('population-tooltip');
-    }
-  }, [guiding, showPopulationTooltip, advanceGuide, flash]);
+  // Already on counts as satisfied — a click would turn it off.
+  const {guiding, flashing} = useGuideTarget('population-tooltip', showPopulationTooltip);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
 
   return (
     <Flex direction="column" gap="2">

--- a/app/src/app/components/Topbar/MapActionsDropdown.tsx
+++ b/app/src/app/components/Topbar/MapActionsDropdown.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {Button, DropdownMenu, Text} from '@radix-ui/themes';
 import {CaretDownIcon, MixIcon} from '@radix-ui/react-icons';
 import {useMapStore} from '@store/mapStore';
@@ -8,6 +8,7 @@ import {ANONYMOUS_DOCUMENT_ID} from '@/app/constants/document/limits';
 import {ACCESS_STATES} from '@constants/document/state';
 import {DocumentMetadata} from '@utils/api/apiHandlers/types';
 import {SaveShareModal} from '../Toolbar/SaveShareModal/SaveShareModal';
+import {useDraftStatusHelperDismissal} from '@components/sidebar/DraftStatusHelper';
 import {fetchWithSession} from '@utils/api/session';
 import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
 import {useMapSaveStatus} from '@/app/hooks/useMapSaveStatus';
@@ -37,16 +38,23 @@ export const MapActionsDropdown: React.FC<{
   // stuck on the body when a dialog opens from onSelect.
   const openModal = (which: 'share') => setTimeout(() => setModal(which), 0);
 
-  // The draft-status helper's "Share your map" pointer opens the modal from
-  // outside this dropdown.
-  const shareModalRequest = useUiHintStore(state => state.requests.shareModal);
-  const clearRequest = useUiHintStore(state => state.clear);
-  useEffect(() => {
-    if (shareModalRequest) {
-      clearRequest('shareModal');
-      setModal('share');
+  // The draft-status helper's "Share your map" pointer guides rather than
+  // clicks: it pulses this trigger until the user opens the menu themselves,
+  // then pulses the Share item until they select it (see uiHintStore).
+  const guideTarget = useUiHintStore(state => state.guideTargets[0]);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const cancelGuide = useUiHintStore(state => state.cancelGuide);
+  // Way back from the guide's dismiss: only offered while it's hidden.
+  const {dismissed: guideDismissed, restore: restoreGuide} = useDraftStatusHelperDismissal();
+  const handleMenuOpenChange = (open: boolean) => {
+    if (open) {
+      advanceGuide('map-actions');
+    } else if (guideTarget === 'map-actions-share') {
+      // Closed without picking the guided item — the highlight would linger
+      // invisibly inside an unmounted menu, so end the guide instead.
+      cancelGuide();
     }
-  }, [shareModalRequest, clearRequest]);
+  };
 
   // Export works for view-only users too: the backend resolves a public_id the same
   // as a document UUID, so fall back to the public_id when the loaded doc is the
@@ -95,7 +103,7 @@ export const MapActionsDropdown: React.FC<{
 
   return (
     <>
-      <DropdownMenu.Root>
+      <DropdownMenu.Root onOpenChange={handleMenuOpenChange}>
         {/* HelpTip wraps DropdownMenu.Trigger (not the reverse) — see ModeSwitcher.tsx
             for why the order matters (chained asChild forwarding). */}
         <HelpTip tip="mapActions" openDelay={HELP_TIP_HOVER_DELAY}>
@@ -104,7 +112,9 @@ export const MapActionsDropdown: React.FC<{
               variant="surface"
               color="gray"
               size="2"
-              className="cursor-pointer relative transition-shadow hover:shadow-md"
+              className={`cursor-pointer relative transition-shadow hover:shadow-md ${
+                guideTarget === 'map-actions' ? 'ui-guide' : ''
+              }`}
               data-testid="map-actions-trigger"
             >
               <MixIcon />
@@ -119,10 +129,13 @@ export const MapActionsDropdown: React.FC<{
           className="min-w-[var(--radix-dropdown-menu-trigger-width)]"
         >
           <DropdownMenu.Item
-            className="cursor-pointer"
+            className={`cursor-pointer ${guideTarget === 'map-actions-share' ? 'ui-guide' : ''}`}
             disabled={!mapDocument?.document_id}
             data-testid="share-button"
-            onSelect={() => openModal('share')}
+            onSelect={() => {
+              advanceGuide('map-actions-share');
+              openModal('share');
+            }}
           >
             Share map
           </DropdownMenu.Item>
@@ -157,6 +170,15 @@ export const MapActionsDropdown: React.FC<{
               </DropdownMenu.Item>
             </DropdownMenu.SubContent>
           </DropdownMenu.Sub>
+          {guideDismissed && (
+            <DropdownMenu.Item
+              className="cursor-pointer"
+              onSelect={restoreGuide}
+              data-testid="show-map-guide"
+            >
+              Show map guide
+            </DropdownMenu.Item>
+          )}
           <DropdownMenu.Separator />
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger

--- a/app/src/app/components/Topbar/MapActionsDropdown.tsx
+++ b/app/src/app/components/Topbar/MapActionsDropdown.tsx
@@ -38,20 +38,16 @@ export const MapActionsDropdown: React.FC<{
   // stuck on the body when a dialog opens from onSelect.
   const openModal = (which: 'share') => setTimeout(() => setModal(which), 0);
 
-  // The draft-status helper's "Share your map" pointer guides rather than
-  // clicks: it pulses this trigger until the user opens the menu themselves,
-  // then pulses the Share item until they select it (see uiHintStore).
+  // "Share your map" guide: pulses this trigger, then the Share item.
   const guideTarget = useUiHintStore(state => state.guideTargets[0]);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
   const cancelGuide = useUiHintStore(state => state.cancelGuide);
-  // Way back from the guide's dismiss: only offered while it's hidden.
   const {dismissed: guideDismissed, restore: restoreGuide} = useDraftStatusHelperDismissal();
   const handleMenuOpenChange = (open: boolean) => {
     if (open) {
       advanceGuide('map-actions');
     } else if (guideTarget === 'map-actions-share') {
-      // Closed without picking the guided item — the highlight would linger
-      // invisibly inside an unmounted menu, so end the guide instead.
+      // Closed without selecting: end the guide rather than pulse an unmounted item.
       cancelGuide();
     }
   };

--- a/app/src/app/components/Topbar/ModeSwitcher.tsx
+++ b/app/src/app/components/Topbar/ModeSwitcher.tsx
@@ -56,8 +56,7 @@ const ModeSwitcherItem: React.FC<{
 }> = ({mode, isCurrent, disabled, disabledReason, locked, onSelect}) => {
   const meta = MODE_META[mode];
   const Icon = locked ? LockClosedIcon : meta.Icon;
-  // Guided-step target for the helper's mode pointers: keeps pulsing until
-  // the user picks the mode themselves.
+  // Guide target for the helper's mode pointers (see uiHintStore).
   const guiding = useUiHintStore(state => state.guideTargets[0] === `mode-${mode}`);
   const row = (
     <Flex
@@ -132,9 +131,7 @@ export const ModeSwitcher: React.FC = () => {
     if (pwParam || passwordRequired) setPasswordUnlockable(true);
   }, [pwParam, passwordRequired, publicIdForLookup, setPasswordUnlockable]);
 
-  // The draft-status helper's Super Draw / Evaluate pointers guide rather
-  // than click: they pulse this trigger until the user opens the menu
-  // themselves, then pulse the mode they meant (see uiHintStore).
+  // Mode-pointer guide: pulses this trigger, then the meant mode item.
   const [menuOpen, setMenuOpen] = React.useState(false);
   const guideTarget = useUiHintStore(state => state.guideTargets[0]);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
@@ -144,8 +141,7 @@ export const ModeSwitcher: React.FC = () => {
     if (open) {
       advanceGuide('mode-switcher');
     } else if (guideTarget?.startsWith('mode-') && guideTarget !== 'mode-switcher') {
-      // Closed without picking the guided mode — the highlight would linger
-      // invisibly inside an unmounted menu, so end the guide instead.
+      // Closed without selecting: end the guide rather than pulse an unmounted item.
       cancelGuide();
     }
   };
@@ -280,9 +276,8 @@ export const ModeSwitcher: React.FC = () => {
   const CurrentIcon = MODE_META[currentMode].Icon;
 
   return (
-    // Non-modal so a click on another helper pointer while the menu is open
-    // reaches that pointer (starting a fresh guided sequence) instead of
-    // being swallowed by the modal dismiss layer.
+    // Non-modal so clicks on other helper pointers aren't swallowed by the
+    // modal dismiss layer.
     <DropdownMenu.Root open={menuOpen} onOpenChange={handleMenuOpenChange} modal={false}>
       {/* HelpTip wraps DropdownMenu.Trigger (not the reverse): HelpTip's own
           HoverCard.Trigger and DropdownMenu.Trigger both need asChild to reach the

--- a/app/src/app/components/Topbar/ModeSwitcher.tsx
+++ b/app/src/app/components/Topbar/ModeSwitcher.tsx
@@ -56,8 +56,9 @@ const ModeSwitcherItem: React.FC<{
 }> = ({mode, isCurrent, disabled, disabledReason, locked, onSelect}) => {
   const meta = MODE_META[mode];
   const Icon = locked ? LockClosedIcon : meta.Icon;
-  // Pulse target for the helper's mode pointers.
-  const flashing = useUiHintStore(state => state.flashTarget === `mode-${mode}`);
+  // Guided-step target for the helper's mode pointers: keeps pulsing until
+  // the user picks the mode themselves.
+  const guiding = useUiHintStore(state => state.guideTargets[0] === `mode-${mode}`);
   const row = (
     <Flex
       align="center"
@@ -65,7 +66,7 @@ const ModeSwitcherItem: React.FC<{
       gap="4"
       width="100%"
       py="1"
-      className={flashing ? 'ui-flash' : ''}
+      className={guiding ? 'ui-guide' : ''}
     >
       <Flex align="center" gap="3">
         <Icon className="size-4 shrink-0" />
@@ -131,19 +132,23 @@ export const ModeSwitcher: React.FC = () => {
     if (pwParam || passwordRequired) setPasswordUnlockable(true);
   }, [pwParam, passwordRequired, publicIdForLookup, setPasswordUnlockable]);
 
-  // The draft-status helper's Super Draw / Evaluate pointers open this menu
-  // and pulse the mode they meant — they don't switch modes themselves.
+  // The draft-status helper's Super Draw / Evaluate pointers guide rather
+  // than click: they pulse this trigger until the user opens the menu
+  // themselves, then pulse the mode they meant (see uiHintStore).
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const modeMenuRequest = useUiHintStore(state => state.requests.modeMenu);
-  const clearRequest = useUiHintStore(state => state.clear);
-  const flash = useUiHintStore(state => state.flash);
-  React.useEffect(() => {
-    if (modeMenuRequest) {
-      clearRequest('modeMenu');
-      setMenuOpen(true);
-      flash(`mode-${modeMenuRequest}`);
+  const guideTarget = useUiHintStore(state => state.guideTargets[0]);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const cancelGuide = useUiHintStore(state => state.cancelGuide);
+  const handleMenuOpenChange = (open: boolean) => {
+    setMenuOpen(open);
+    if (open) {
+      advanceGuide('mode-switcher');
+    } else if (guideTarget?.startsWith('mode-') && guideTarget !== 'mode-switcher') {
+      // Closed without picking the guided mode — the highlight would linger
+      // invisibly inside an unmounted menu, so end the guide instead.
+      cancelGuide();
     }
-  }, [modeMenuRequest, clearRequest, flash]);
+  };
 
   // No map loaded yet (e.g. the empty "start here" landing) — nothing to switch.
   if (!mapDocument) return null;
@@ -276,9 +281,9 @@ export const ModeSwitcher: React.FC = () => {
 
   return (
     // Non-modal so a click on another helper pointer while the menu is open
-    // reaches that pointer (re-requesting the menu with a new flash) instead
-    // of being swallowed by the modal dismiss layer.
-    <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+    // reaches that pointer (starting a fresh guided sequence) instead of
+    // being swallowed by the modal dismiss layer.
+    <DropdownMenu.Root open={menuOpen} onOpenChange={handleMenuOpenChange} modal={false}>
       {/* HelpTip wraps DropdownMenu.Trigger (not the reverse): HelpTip's own
           HoverCard.Trigger and DropdownMenu.Trigger both need asChild to reach the
           real Button underneath — chained asChild forwarding handles that (each
@@ -291,7 +296,9 @@ export const ModeSwitcher: React.FC = () => {
             variant="surface"
             color="gray"
             size="2"
-            className="cursor-pointer transition-shadow hover:shadow-md"
+            className={`cursor-pointer transition-shadow hover:shadow-md ${
+              guideTarget === 'mode-switcher' ? 'ui-guide' : ''
+            }`}
             disabled={isMinting}
             aria-label="Switch view"
           >
@@ -314,7 +321,10 @@ export const ModeSwitcher: React.FC = () => {
             disabled={isDisabled(mode)}
             disabledReason={disabledReasonFor(mode)}
             locked={isDrawMode(mode) && editLocked}
-            onSelect={() => handleSelect(mode)}
+            onSelect={() => {
+              advanceGuide(`mode-${mode}`);
+              handleSelect(mode);
+            }}
           />
         ))}
       </DropdownMenu.Content>

--- a/app/src/app/components/Topbar/ModeSwitcher.tsx
+++ b/app/src/app/components/Topbar/ModeSwitcher.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {Button, DropdownMenu, Flex, Spinner, Text} from '@radix-ui/themes';
 import {
   BarChartIcon,
@@ -121,18 +121,18 @@ export const ModeSwitcher: React.FC = () => {
   const setLoadingState = useMapStore(state => state.setLoadingState);
   const publicIdForLookup = useMapStore(state => state.mapDocument?.public_id ?? null);
   const pwParam = useSearchParams().get('pw');
-  const [isMinting, setIsMinting] = React.useState(false);
+  const [isMinting, setIsMinting] = useState(false);
 
   // A map is unlockable if the share link carries `?pw=true` or the document itself
   // reports an edit password (so a viewer who landed on the bare public URL still gets
   // the affordance). Remember it so it survives dismissing the prompt or switching views.
   const passwordRequired = mapDocument?.password_required;
-  React.useEffect(() => {
+  useEffect(() => {
     if (pwParam || passwordRequired) setPasswordUnlockable(true);
   }, [pwParam, passwordRequired, publicIdForLookup, setPasswordUnlockable]);
 
   // Mode-pointer guide: pulses this trigger, then the meant mode item.
-  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const guideTarget = useUiHintStore(state => state.guideTargets[0]);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
   const cancelGuide = useUiHintStore(state => state.cancelGuide);

--- a/app/src/app/components/Topbar/SaveButton.tsx
+++ b/app/src/app/components/Topbar/SaveButton.tsx
@@ -1,10 +1,11 @@
 'use client';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Flex, IconButton, Spinner, Text} from '@radix-ui/themes';
 import {CloudNotSavedIcon, CloudSavedIcon} from './Icons';
 import {useMapSaveStatus} from '@/app/hooks/useMapSaveStatus';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
+import {useUiHintStore} from '@store/uiHintStore';
 import {ACCESS_STATES} from '@constants/document/state';
 import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
 
@@ -36,6 +37,14 @@ export const SaveButton: React.FC = () => {
   const access = useMapStore(state => state.mapStatus?.access);
   const isEditing = useMapControlsStore(state => state.isEditing);
   const [saving, setSaving] = useState(false);
+  // Guided step (see uiHintStore.guideTargets): the draft helper's "Save now"
+  // hint pulses this button until the user clicks it themselves. Nothing to
+  // save means nothing to point at, so the guide skips ahead then.
+  const guiding = useUiHintStore(state => state.guideTargets[0] === 'save-button');
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  useEffect(() => {
+    if (guiding && !isOutdated) advanceGuide('save-button');
+  }, [guiding, isOutdated, advanceGuide]);
 
   if (!mapDocument || !isEditing || access !== ACCESS_STATES.EDIT) return null;
 
@@ -43,6 +52,7 @@ export const SaveButton: React.FC = () => {
   // same bottom-center notice rather than the full-screen lock overlay and
   // saved toast — only the wording differs.
   const handleSave = async () => {
+    advanceGuide('save-button');
     if (!isOutdated || saving) return;
     setSaving(true);
     try {
@@ -72,7 +82,7 @@ export const SaveButton: React.FC = () => {
           variant="surface"
           color="gray"
           onClick={handleSave}
-          className={isOutdated ? 'cursor-pointer' : ''}
+          className={`${isOutdated ? 'cursor-pointer' : ''} ${guiding ? 'ui-guide' : ''}`}
           aria-label={isOutdated ? 'Save changes' : 'All changes saved'}
           data-testid="save-button"
         >

--- a/app/src/app/components/Topbar/SaveButton.tsx
+++ b/app/src/app/components/Topbar/SaveButton.tsx
@@ -37,9 +37,7 @@ export const SaveButton: React.FC = () => {
   const access = useMapStore(state => state.mapStatus?.access);
   const isEditing = useMapControlsStore(state => state.isEditing);
   const [saving, setSaving] = useState(false);
-  // Guided step (see uiHintStore.guideTargets): the draft helper's "Save now"
-  // hint pulses this button until the user clicks it themselves. Nothing to
-  // save means nothing to point at, so the guide skips ahead then.
+  // Guide target for the "Save now" hint; skips when there's nothing to save.
   const guiding = useUiHintStore(state => state.guideTargets[0] === 'save-button');
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
   useEffect(() => {

--- a/app/src/app/components/Topbar/SaveButton.tsx
+++ b/app/src/app/components/Topbar/SaveButton.tsx
@@ -5,7 +5,7 @@ import {CloudNotSavedIcon, CloudSavedIcon} from './Icons';
 import {useMapSaveStatus} from '@/app/hooks/useMapSaveStatus';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
-import {useUiHintStore} from '@store/uiHintStore';
+import {useUiHintStore, useGuideTarget} from '@store/uiHintStore';
 import {ACCESS_STATES} from '@constants/document/state';
 import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
 
@@ -38,11 +38,8 @@ export const SaveButton: React.FC = () => {
   const isEditing = useMapControlsStore(state => state.isEditing);
   const [saving, setSaving] = useState(false);
   // Guide target for the "Save now" hint; skips when there's nothing to save.
-  const guiding = useUiHintStore(state => state.guideTargets[0] === 'save-button');
+  const {guiding} = useGuideTarget('save-button', !isOutdated);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
-  useEffect(() => {
-    if (guiding && !isOutdated) advanceGuide('save-button');
-  }, [guiding, isOutdated, advanceGuide]);
 
   if (!mapDocument || !isEditing || access !== ACCESS_STATES.EDIT) return null;
 

--- a/app/src/app/components/Topbar/Topbar.tsx
+++ b/app/src/app/components/Topbar/Topbar.tsx
@@ -27,6 +27,15 @@ export const Topbar: React.FC = () => {
   const isEval = useMapControlsStore(state => state.isEval);
   const handleMetadataChange = useMetadataChange();
 
+  // The statically rendered title on edit links is the password warning (for
+  // link unfurls); once the map loads in the editor, show the real title.
+  React.useEffect(() => {
+    if (!mapDocument?.document_id) return;
+    document.title = [mapDocument.map_metadata?.name || 'Districtr Map', mapDocument.map_module]
+      .filter(Boolean)
+      .join(' | ');
+  }, [mapDocument]);
+
   return (
     <>
       <Flex direction="column" className="h-auto">

--- a/app/src/app/components/Topbar/Topbar.tsx
+++ b/app/src/app/components/Topbar/Topbar.tsx
@@ -27,8 +27,8 @@ export const Topbar: React.FC = () => {
   const isEval = useMapControlsStore(state => state.isEval);
   const handleMetadataChange = useMetadataChange();
 
-  // The statically rendered title on edit links is the password warning (for
-  // link unfurls); once the map loads in the editor, show the real title.
+  // The static title on edit links is the password warning; swap in the real
+  // title once the map loads.
   React.useEffect(() => {
     if (!mapDocument?.document_id) return;
     document.title = [mapDocument.map_metadata?.name || 'Districtr Map', mapDocument.map_module]

--- a/app/src/app/components/Topbar/Topbar.tsx
+++ b/app/src/app/components/Topbar/Topbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import {Text, DropdownMenu, Flex, Heading, IconButton, Tabs} from '@radix-ui/themes';
-import React, {useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {useRouter} from 'next/navigation';
 import {useMapStore} from '@store/mapStore';
 import {ArrowLeftIcon, HamburgerMenuIcon} from '@radix-ui/react-icons';
@@ -22,14 +22,14 @@ import {useAutoSave} from '@/app/hooks/useAutoSave';
 export const Topbar: React.FC = () => {
   const router = useRouter();
   const {isAutoSaving} = useAutoSave();
-  const [modalOpen, setModalOpen] = React.useState<'upload' | null>(null);
+  const [modalOpen, setModalOpen] = useState<'upload' | null>(null);
   const mapDocument = useMapStore(state => state.mapDocument);
   const isEval = useMapControlsStore(state => state.isEval);
   const handleMetadataChange = useMetadataChange();
 
   // The static title on edit links is the password warning; swap in the real
   // title once the map loads.
-  React.useEffect(() => {
+  useEffect(() => {
     if (!mapDocument?.document_id) return;
     document.title = [mapDocument.map_metadata?.name || 'Districtr Map', mapDocument.map_module]
       .filter(Boolean)
@@ -130,20 +130,20 @@ const mobileTabPanels: Array<{
 ];
 
 export const MobileDataTabs: React.FC = () => {
-  const [activeTab, setActiveTab] = React.useState(mobileTabPanels[0].title);
+  const [activeTab, setActiveTab] = useState(mobileTabPanels[0].title);
   const mapMode = useMapControlsStore(state => state.mapMode);
   // Snap back to the Map tab when the viewport grows past lg — otherwise a
   // panel opened at mobile width lingers over the map on desktop, where the
   // tab strip that could dismiss it is hidden.
   const isDesktop = useIsDesktop();
-  React.useEffect(() => {
+  useEffect(() => {
     if (isDesktop) setActiveTab('map');
   }, [isDesktop]);
   // Helper-box jumps: below lg the sidebar sections don't exist, so hints
   // open the matching full-screen panel here instead (see uiHintStore).
   const mobileTabRequest = useUiHintStore(state => state.requests.mobileTab);
   const clearRequest = useUiHintStore(state => state.clear);
-  React.useEffect(() => {
+  useEffect(() => {
     if (!mobileTabRequest) return;
     clearRequest('mobileTab');
     if (!isDesktop) setActiveTab(mobileTabRequest);

--- a/app/src/app/components/sidebar/AnimatedCollapse.tsx
+++ b/app/src/app/components/sidebar/AnimatedCollapse.tsx
@@ -48,8 +48,20 @@ export const Expander: React.FC<{
   onToggle?: () => void;
   /** Extra classes for the header button (e.g. h-auto for multi-line labels). */
   buttonClassName?: string;
+  /** Extra classes for the outer container. Pulse-highlight classes go here:
+   * the header's !bg-transparent and the container's overflow-hidden defeat
+   * the animation on the button itself. */
+  className?: string;
   children: React.ReactNode;
-}> = ({label, defaultOpen = false, open, onToggle, buttonClassName = '', children}) => {
+}> = ({
+  label,
+  defaultOpen = false,
+  open,
+  onToggle,
+  buttonClassName = '',
+  className = '',
+  children,
+}) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
   const isOpen = open ?? uncontrolledOpen;
   const toggle = onToggle ?? (() => setUncontrolledOpen(o => !o));
@@ -57,7 +69,10 @@ export const Expander: React.FC<{
   // unit; the header is a flat soft bar (its own surface border would double
   // up inside the outline).
   return (
-    <Flex direction="column" className="rounded-md border border-[var(--gray-6)] overflow-hidden">
+    <Flex
+      direction="column"
+      className={`rounded-md border border-[var(--gray-6)] overflow-hidden ${className}`}
+    >
       <Button
         variant="soft"
         color="gray"

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -160,8 +160,8 @@ export const useDraftStatusHelperDismissal = () => {
  * it themselves — nothing toggles, saves, or opens on the user's behalf.
  *
  * Collapsible and dismissible. Super Draw starts collapsed — experts asked
- * for the map, not the tutorial — and reaching the final stage auto-collapses
- * it. Dismissal persistence is mode-dependent (see useHelperDismissal).
+ * for the map, not the tutorial. Dismissal persistence is mode-dependent
+ * (see useHelperDismissal).
  *
  * `onNavigate` fires after any hint that points somewhere else in the app —
  * the mobile modal closes itself so the hint's target isn't buried under it.
@@ -226,16 +226,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
     const stored = localStorage.getItem(COLLAPSE_KEY);
     setStoredCollapsed(stored === null ? null : stored === '1');
   }, []);
-  // Final stage auto-collapses — unless the plan has regressed, so the
-  // step-back bubble stays visible instead of hiding behind the collapse.
-  const [autoCollapsed, setAutoCollapsed] = useState(false);
-  const atFinalStage = statusStage === 2;
-  useEffect(() => {
-    if (atFinalStage) setAutoCollapsed(!regressed);
-  }, [atFinalStage, regressed]);
-  const collapsed = collapsible && (autoCollapsed || (storedCollapsed ?? superDraw));
+  const collapsed = collapsible && (storedCollapsed ?? superDraw);
   const toggleCollapsed = () => {
-    setAutoCollapsed(false);
     localStorage.setItem(COLLAPSE_KEY, collapsed ? '0' : '1');
     setStoredCollapsed(!collapsed);
   };

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -1,27 +1,30 @@
 'use client';
 import React, {useEffect, useState} from 'react';
-import {Button, Flex, Text} from '@radix-ui/themes';
-import {CheckIcon, ChevronDownIcon, MinusIcon} from '@radix-ui/react-icons';
+import {create} from 'zustand';
+import {AlertDialog, Button, Flex, IconButton, Text} from '@radix-ui/themes';
+import {CheckIcon, ChevronDownIcon, Cross2Icon, MinusIcon} from '@radix-ui/react-icons';
 import {useMapStore} from '@/app/store/mapStore';
 import {useMapControlsStore, type MapControlsStore} from '@/app/store/mapControlsStore';
 import {useIsDesktop} from '@/app/hooks/useIsDesktop';
 import {useToolbarStore} from '@/app/store/toolbarStore';
-import {useOverlayStore} from '@/app/store/overlayStore';
-import {useUiHintStore} from '@/app/store/uiHintStore';
+import {useUiHintStore, type ValidationTab} from '@/app/store/uiHintStore';
 import {useDraftStatusCriteria, BALANCE_DEVIATION} from '@/app/hooks/useDraftStatusCriteria';
 import {useMetadataChange} from '@/app/hooks/useMetadataChange';
-import {useMapSaveStatus} from '@/app/hooks/useMapSaveStatus';
 import {statusIcons} from '@components/Topbar/MapStatus';
-import {getFeaturesIntersectingCounties} from '@utils/map/getFeaturesIntersectingCounties';
-import {activateOverlayGroup} from '@utils/demography/overlayMemory';
 import {formatNumber} from '@utils/numbers';
 import {NUMBER_FORMATS} from '@constants/demography/format';
-import {SUMMARY_TYPES, toOverlayGroup} from '@constants/demography/summary';
-import {DRAFT_STATUSES, DRAFT_STATUS_TEXT, type DraftStatus} from '@constants/document/draftStatus';
+import {
+  DRAFT_STATUSES,
+  DRAFT_STATUS_TEXT,
+  DRAFT_STATUS_ORDER,
+  DRAFT_STATUS_COLORS,
+  type DraftStatus,
+} from '@constants/document/draftStatus';
 import {MAP_MODES} from '@constants/map/mode';
 import {ACTIVE_TOOLS} from '@constants/map/tools';
 
 const COLLAPSE_KEY = 'districtr-draft-helper-collapsed';
+const DISMISS_KEY = 'districtr-draft-helper-dismissed';
 // Above this share of unassigned population, suggest the county brush for
 // rough drawing; below it, point at the unassigned-areas finder.
 const ROUGH_DRAW_UNASSIGNED_RATIO = 0.25;
@@ -32,6 +35,38 @@ const MOBILE_TAB_FOR_SECTION: Record<string, MapControlsStore['sidebarPanels'][n
   'stats-demographics': 'demography',
   'stats-elections': 'election',
 };
+
+/** Dismissal is mode-dependent by design: dismissing in Super Draw sticks
+ * across sessions (localStorage — an expert opted out for good), while
+ * dismissing in plain Draw lasts only this session; the box returns on the
+ * next visit. One store so every instance (map overlay, mobile guide button)
+ * sees the same answer. */
+const useHelperDismissal = create<{
+  sessionDismissed: boolean;
+  superDrawDismissed: boolean;
+  hydrate: () => void;
+  dismiss: (persist: boolean) => void;
+  restore: () => void;
+}>(set => ({
+  sessionDismissed: false,
+  superDrawDismissed: false,
+  // localStorage is client-only; callers hydrate from an effect.
+  hydrate: () => set({superDrawDismissed: localStorage.getItem(DISMISS_KEY) === '1'}),
+  dismiss: persist => {
+    if (persist) {
+      localStorage.setItem(DISMISS_KEY, '1');
+      set({superDrawDismissed: true});
+    } else {
+      set({sessionDismissed: true});
+    }
+  },
+  // Restore clears both variants: the user asked for the guide back, so no
+  // stale dismissal from the other draw mode should keep it hidden.
+  restore: () => {
+    localStorage.removeItem(DISMISS_KEY);
+    set({sessionDismissed: false, superDrawDismissed: false});
+  },
+}));
 
 type Hint = {label: string; onClick: () => void};
 type ChecklistItem = {
@@ -48,40 +83,29 @@ type ChecklistItem = {
 };
 
 /** Link-styled action that flows inline with the checklist text instead of
- * occupying its own row. `back` renders the quiet gray variant — step-backs
- * shouldn't compete with the forward hints. */
+ * occupying its own row. */
 const InlineHintButton: React.FC<{
   onClick: () => void;
-  back?: boolean;
   children: React.ReactNode;
-}> = ({onClick, back, children}) => (
+}> = ({onClick, children}) => (
   <button
     type="button"
     onClick={onClick}
     // Wraps with the sentence it sits in. It used to be nowrap so a link
     // couldn't break across lines, but these labels are long enough
     // ("Paint by counties to roughly draw districts") that nowrap pushed the
-    // card wider than the sidebar instead.
-    className={`inline cursor-pointer text-left hover:underline underline-offset-2 ${
-      back ? 'text-gray-500 hover:text-gray-700' : 'font-semibold text-districtrBlue'
-    }`}
+    // card wider than the box instead.
+    className="inline cursor-pointer text-left hover:underline underline-offset-2 font-semibold text-districtrBlue"
   >
     {children}
   </button>
 );
 
-/** The topbar's own status glyph, wherever a control names a status to move to.
+/** The topbar's own status glyph, wherever a control names a draft status.
  * Those icons hardcode a 24px size and their own indicator fill, so both are
  * overridden here to inherit from whatever the glyph sits in. */
-const StatusGlyph: React.FC<{status: DraftStatus; inline?: boolean}> = ({status, inline}) => (
-  <span
-    // One size for every status move, forward or back. The inline (link) glyph
-    // spaces itself; inside a Button, Radix's own gap already does.
-    className={`inline-flex align-middle [&_svg]:size-[18px] [&_svg]:!fill-current ${
-      inline ? 'mr-1' : ''
-    }`}
-    aria-hidden
-  >
+const StatusGlyph: React.FC<{status: DraftStatus}> = ({status}) => (
+  <span className="inline-flex align-middle [&_svg]:size-[18px] [&_svg]:!fill-current" aria-hidden>
     {React.createElement(statusIcons[status])}
   </span>
 );
@@ -102,23 +126,55 @@ export const useDraftStatusHelperVisible = () => {
   const mapMode = useMapControlsStore(state => state.mapMode);
   const superDraw = useToolbarStore(state => state.superDraw);
   const documentId = useMapStore(state => state.mapDocument?.document_id);
-  return !superDraw && isEditing && mapMode === MAP_MODES.DISTRICTS && !!documentId;
+  const sessionDismissed = useHelperDismissal(state => state.sessionDismissed);
+  const superDrawDismissed = useHelperDismissal(state => state.superDrawDismissed);
+  const hydrate = useHelperDismissal(state => state.hydrate);
+  useEffect(() => hydrate(), [hydrate]);
+  const dismissed = superDraw ? superDrawDismissed : sessionDismissed;
+  return !dismissed && isEditing && mapMode === MAP_MODES.DISTRICTS && !!documentId;
+};
+
+/** Dismissal state + restore, for controls living outside the box itself
+ * (the Map actions menu's "Show map guide" item). `dismissed` reflects the
+ * current draw mode's variant; `restore` clears both, so the guide comes back
+ * no matter which mode hid it. */
+export const useDraftStatusHelperDismissal = () => {
+  const superDraw = useToolbarStore(state => state.superDraw);
+  const sessionDismissed = useHelperDismissal(state => state.sessionDismissed);
+  const superDrawDismissed = useHelperDismissal(state => state.superDrawDismissed);
+  const restore = useHelperDismissal(state => state.restore);
+  const hydrate = useHelperDismissal(state => state.hydrate);
+  useEffect(() => hydrate(), [hydrate]);
+  return {dismissed: superDraw ? superDrawDismissed : sessionDismissed, restore};
 };
 
 /**
- * Helper card at the top of the sidebar: Get started (scratch) → Refine and
- * validate (in progress) → Advanced plan evaluation (ready to share). The stage follows the
- * draft status, except a regressed plan falls back to the earliest failing
- * checklist (see displayStage). The advance button is the app's one earned
- * move — it appears only when the stage's criteria are met — while the status
- * controls (and the box's own step-back links) stay free choice. Collapsible,
- * not dismissible.
+ * Helper card overlaying the map's top-right: Get started (scratch) → Refine
+ * and validate (in progress) → Advanced plan evaluation (ready to share). The
+ * header names the stage of the user-chosen draft status, and the body shows
+ * that one stage's question checklist — the stage follows the status alone
+ * and never moves on its own when the stats change. Across the bottom, the
+ * three draft statuses lay out as a stepper row — the current one lit in its
+ * status color, the others muted — and clicking a segment sets that status
+ * (free choice, as everywhere else). The stats only ever suggest: earned
+ * criteria raise a dismissible bubble over the next status, and a plan that
+ * no longer meets its status's checks raises one over the status to step
+ * back to.
+ *
+ * Hints guide, they don't click: every hint starts a guided sequence
+ * (uiHintStore.guideTargets) that pulses each control until the user clicks
+ * it themselves — nothing toggles, saves, or opens on the user's behalf.
+ *
+ * Collapsible and dismissible. Super Draw starts collapsed — experts asked
+ * for the map, not the tutorial — and reaching the final stage auto-collapses
+ * it. Dismissal persistence is mode-dependent (see useHelperDismissal).
  *
  * `onNavigate` fires after any hint that points somewhere else in the app —
  * the mobile modal closes itself so the hint's target isn't buried under it.
  * The modal instance sets `collapsible` false: its dialog already opens and
- * closes, so an inner collapse (persisted from the sidebar) would just show
- * a bare header.
+ * closes, so an inner collapse (persisted from the overlay) would just show
+ * a bare header — and it hides the dismiss control too, since the dialog's
+ * own close covers it.
  */
 export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?: boolean}> = ({
   onNavigate,
@@ -126,18 +182,15 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
 }) => {
   const isDesktop = useIsDesktop();
   const visible = useDraftStatusHelperVisible();
-  // The county brush is invalid while broken into blocks (PaintByCounty
-  // disables itself there); the hint must not force it on.
+  const superDraw = useToolbarStore(state => state.superDraw);
+  // The county brush is unavailable while broken into blocks (PaintByCounty
+  // disables itself there); the hint must not point at a dead end.
   const inBlockView = useMapStore(state => state.captiveIds.size > 0);
-  const setActiveTool = useMapControlsStore(state => state.setActiveTool);
-  const setMapOptions = useMapControlsStore(state => state.setMapOptions);
-  const setPaintFunction = useMapControlsStore(state => state.setPaintFunction);
-  const clearPaintConstraint = useOverlayStore(state => state.clearPaintConstraint);
-  const openTabSection = useMapControlsStore(state => state.openTabSection);
   const request = useUiHintStore(state => state.request);
+  const startGuide = useUiHintStore(state => state.startGuide);
   const flash = useUiHintStore(state => state.flash);
+  const dismiss = useHelperDismissal(state => state.dismiss);
   const handleMetadataChange = useMetadataChange();
-  const {save} = useMapSaveStatus();
   // Status changes land silently in the topbar otherwise; the pulse both
   // confirms the change and teaches that the title icon is the status.
   const changeStatus = (status: DraftStatus) =>
@@ -151,15 +204,70 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
     counts,
   } = useDraftStatusCriteria();
 
-  const [storedCollapsed, setStoredCollapsed] = useState(false);
+  // The shown stage follows the user-chosen status alone — it never regresses
+  // on its own when the stats fall below the bar. A plan whose criteria sit
+  // below its status (e.g. population unassigned while marked In Progress)
+  // keeps its stage; the only response is the dismissible step-back bubble
+  // over the status row.
+  const statusStage =
+    currentStatus === DRAFT_STATUSES.SCRATCH
+      ? 0
+      : currentStatus === DRAFT_STATUSES.IN_PROGRESS
+        ? 1
+        : 2;
+  const criteriaStage = !scratchDone ? 0 : !inProgressDone ? 1 : 2;
+  const regressed = criteriaStage < statusStage;
+
+  // Collapse: an explicit toggle persists; without one, Super Draw defaults
+  // collapsed (plain Draw expanded).
+  const [storedCollapsed, setStoredCollapsed] = useState<boolean | null>(null);
   useEffect(() => {
-    setStoredCollapsed(localStorage.getItem(COLLAPSE_KEY) === '1');
+    const stored = localStorage.getItem(COLLAPSE_KEY);
+    setStoredCollapsed(stored === null ? null : stored === '1');
   }, []);
-  const collapsed = collapsible && storedCollapsed;
+  // Reaching the final stage auto-collapses the box — the plan is done and the
+  // checklists no longer need map real estate; re-expanding is one click and
+  // sticks until the next mount at that stage.
+  const [autoCollapsed, setAutoCollapsed] = useState(false);
+  const atFinalStage = statusStage === 2;
+  useEffect(() => {
+    if (atFinalStage) setAutoCollapsed(true);
+  }, [atFinalStage]);
+  const collapsed = collapsible && (autoCollapsed || (storedCollapsed ?? superDraw));
   const toggleCollapsed = () => {
+    setAutoCollapsed(false);
     localStorage.setItem(COLLAPSE_KEY, collapsed ? '0' : '1');
     setStoredCollapsed(!collapsed);
   };
+
+  const previousStatus: DraftStatus =
+    statusStage === 2 ? DRAFT_STATUSES.IN_PROGRESS : DRAFT_STATUSES.SCRATCH;
+  // A move forward is earned: only with the current stage's items done, not
+  // while its earlier criteria have regressed (the back-suggestion wins), and
+  // not while a stale contiguity result awaits the next save.
+  const nextStatus: DraftStatus | null =
+    statusStage === 0
+      ? DRAFT_STATUSES.IN_PROGRESS
+      : statusStage === 1
+        ? DRAFT_STATUSES.READY_TO_SHARE
+        : null;
+  const stageDone = statusStage === 0 ? scratchDone : statusStage === 1 ? inProgressDone : false;
+  const canAdvance =
+    !regressed && !!nextStatus && stageDone && !(statusStage === 1 && contiguityStale);
+
+  // What the stats say about the status row: earned criteria suggest the next
+  // status forward; a regressed plan suggests stepping back. The bubble is
+  // dismissible per suggestion — keyed on target and direction, so dismissing
+  // "mark it In Progress" doesn't also swallow a later "mark it Ready".
+  const suggestion: {status: DraftStatus; direction: 'forward' | 'back'} | null =
+    canAdvance && nextStatus
+      ? {status: nextStatus, direction: 'forward'}
+      : regressed
+        ? {status: previousStatus, direction: 'back'}
+        : null;
+  const suggestionKey = suggestion ? `${suggestion.direction}:${suggestion.status}` : null;
+  const [dismissedSuggestion, setDismissedSuggestion] = useState<string | null>(null);
+  const showSuggestion = !!suggestionKey && dismissedSuggestion !== suggestionKey;
 
   if (!visible) return null;
 
@@ -170,62 +278,51 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       ? unassigned / (idealPopulation * numDistricts)
       : undefined;
 
-  /** Jump to a sidebar section: switch tab, expand and flash the section, and
-   * scroll it into view. The scroll waits out the tab switch and the section
-   * expand animation (which shifts layout under a too-early scroll), retrying
-   * briefly until the section has mounted. */
-  const scrollSectionIntoView = (sectionId: string, attempt = 0) => {
-    const el = document.querySelector(`[data-section-id="${sectionId}"]`);
-    if (!el && attempt < 5) {
-      setTimeout(() => scrollSectionIntoView(sectionId, attempt + 1), 120);
-      return;
-    }
-    el?.scrollIntoView({behavior: 'smooth', block: 'start'});
-  };
-  const jumpToSection = (tab: 'stats' | 'mapLayers', sectionId: string) => {
+  /** Guide the user to a sidebar section: pulse the destination tab until
+   * they click it, then the section header (skipped automatically when
+   * already active/open — see the guide consumers in WorkflowTabs). Below lg
+   * the sidebar is hidden, so open the matching full-screen mobile panel
+   * instead; sections without one skip the jump — the hint's store change
+   * (tooltip on, overlay active) already took effect on the visible map. */
+  const guideToSection = (tab: 'stats' | 'mapLayers', sectionId: string) => {
     if (!isDesktop) {
-      // Below lg the sidebar (and its sections) is hidden; open the matching
-      // full-screen mobile panel instead. Sections without one (map options,
-      // the demographic map layer) skip the jump — the hint's store change
-      // (tooltip on, overlay active) already took effect on the visible map.
       const mobileTab = MOBILE_TAB_FOR_SECTION[sectionId];
       if (mobileTab) request('mobileTab', mobileTab);
       return;
     }
-    openTabSection(sectionId);
-    // Sequence the jump so the instant cut reads as a path: pulse the
-    // destination tab label long enough to register, then switch and pulse
-    // the section itself.
-    flash(`tab:${tab}`);
-    setTimeout(() => {
-      request('sidebarTab', tab);
-      flash(`section:${sectionId}`);
-      setTimeout(() => scrollSectionIntoView(sectionId), 300);
-    }, 1000);
+    startGuide([`tab:${tab}`, `section:${sectionId}`]);
   };
 
-  const openValidation = (tab: 'Contiguity' | 'Completeness') => {
-    request('validationTab', tab);
-    jumpToSection('stats', 'stats-validity');
+  /** Guide to a validation panel: tab → Validity section → the panel itself,
+   * each step waiting on the user's own click. The mobile panel holds the
+   * validation checks directly, so only the last step applies there. */
+  const guideToValidation = (tab: ValidationTab) => {
+    if (!isDesktop) {
+      request('mobileTab', 'mapValidation');
+      startGuide([`validation:${tab}`]);
+      return;
+    }
+    startGuide(['tab:stats', 'section:stats-validity', `validation:${tab}`]);
   };
 
-  const handleCountyBrushHint = () => {
-    // Same wiring as the PaintByCounty toggle: county paint replaces the
-    // brush's feature selector and clears any overlay paint constraint.
-    setActiveTool(ACTIVE_TOOLS.BRUSH);
-    clearPaintConstraint();
-    setMapOptions({paintByCounty: true});
-    setPaintFunction(getFeaturesIntersectingCounties);
-    flash('county-brush');
+  /** Guide to a checkbox in the paint scaffold's tool controls (the county
+   * brush, the population tooltip). Those checkboxes disable themselves while
+   * no painting tool is armed (Pan, pre-break Shatter), so the guide starts
+   * one step earlier — at the brush button — unless a paint-capable tool is
+   * already active. */
+  const guideToBrushControl = (target: string) => {
+    const {activeTool} = useMapControlsStore.getState();
+    const paintCapable = activeTool === ACTIVE_TOOLS.BRUSH || activeTool === ACTIVE_TOOLS.ERASER;
+    startGuide(paintCapable ? [target] : [`tool:${ACTIVE_TOOLS.BRUSH}`, target]);
   };
 
   const scratchItems: ChecklistItem[] = [
     {
-      label: `Start drawing all districts (${paintedZones}/${numDistricts})`,
+      label: `Are all districts started? (${paintedZones}/${numDistricts})`,
       done: paintedZones >= numDistricts,
     },
     {
-      label: `Assign all population${
+      label: `Has all population been assigned to a district?${
         unassigned !== undefined && unassigned > 0
           ? ` (${formatNumber(unassigned, NUMBER_FORMATS.STRING)} remaining)`
           : ''
@@ -239,9 +336,12 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
               unassignedRatio > ROUGH_DRAW_UNASSIGNED_RATIO
                 ? {
                     label: 'Paint by counties to roughly draw districts',
-                    onClick: handleCountyBrushHint,
+                    onClick: () => guideToBrushControl('county-brush'),
                   }
-                : {label: 'Find unassigned areas', onClick: () => openValidation('Completeness')},
+                : {
+                    label: 'Find unassigned areas',
+                    onClick: () => guideToValidation('Completeness'),
+                  },
             ]
           : undefined,
     },
@@ -250,33 +350,26 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const balanced = maxDeviation !== undefined && maxDeviation <= BALANCE_DEVIATION;
   const refineItems: ChecklistItem[] = [
     {
-      label: `Balance district populations within ${formatNumber(
+      label: `Are districts roughly balanced? (within ${formatNumber(
         BALANCE_DEVIATION,
         NUMBER_FORMATS.PERCENT
       )} of ideal${
         maxDeviation !== undefined
-          ? ` (largest deviation ${formatNumber(maxDeviation, NUMBER_FORMATS.PERCENT)})`
+          ? `; largest deviation ${formatNumber(maxDeviation, NUMBER_FORMATS.PERCENT)}`
           : ''
-      }`,
+      })`,
       done: balanced,
       hints: !balanced
         ? [
             {
+              // The toggle lives in ToolControlsScaffold's right column, not
+              // inside any sidebar tab — the guide points there directly.
               label: 'Show population tooltips as you paint',
-              onClick: () => {
-                // The toggle lives in ToolControlsScaffold's right column, not
-                // inside any sidebar tab — pulse it directly instead of
-                // jumping to a tab section.
-                setMapOptions({showPopulationTooltip: true});
-                flash('population-tooltip');
-              },
+              onClick: () => guideToBrushControl('population-tooltip'),
             },
             {
               label: 'Show the demographic map',
-              onClick: () => {
-                activateOverlayGroup(toOverlayGroup(SUMMARY_TYPES.TOTPOP));
-                jumpToSection('mapLayers', 'layers-demographics');
-              },
+              onClick: () => guideToSection('mapLayers', 'layers-demographics'),
             },
           ]
         : undefined,
@@ -285,31 +378,32 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       // Uncheckable/stale contiguity passes the gate (see the criteria hook)
       // but must not display as a confirmed pass.
       label: contiguityUnavailable
-        ? 'Keep districts contiguous (not checked for this map)'
+        ? 'Are districts contiguous? (not checked for this map)'
         : contiguityStale
           ? // No "— updates on save" here: the Save now hint below says it, and
             // says it as something to click.
-            `Keep districts contiguous (?/${numDistricts})`
-          : `Keep districts contiguous (${contiguousZones}/${numDistricts})`,
+            `Are districts contiguous? (?/${numDistricts})`
+          : `Are districts contiguous? (${contiguousZones}/${numDistricts})`,
       done: contiguityUnavailable || contiguousZones >= numDistricts,
       muted: contiguityUnavailable || contiguityStale,
-      // A stale result is waiting on a save, and the advance button stays
-      // blocked until it lands — so offer the save right here rather than
-      // leaving "updates on save" as the only clue. The save alone settles
-      // nothing visible, so it's phrased as the first of two steps.
+      // A stale result is waiting on a save, and the forward suggestion stays
+      // withheld until it lands — so point at the save button right here
+      // rather than leaving "updates on save" as the only clue. The save
+      // alone settles nothing visible, so it's phrased as the first of two
+      // steps.
       hints: contiguityStale
         ? [
-            {label: 'Save now', onClick: () => save(false, {silent: true})},
+            {label: 'Save now', onClick: () => startGuide(['save-button'])},
             {
               label: 'find disconnected fragments',
-              onClick: () => openValidation('Contiguity'),
+              onClick: () => guideToValidation('Contiguity'),
             },
           ]
         : !contiguityUnavailable && contiguousZones < numDistricts
           ? [
               {
                 label: 'Find disconnected fragments',
-                onClick: () => openValidation('Contiguity'),
+                onClick: () => guideToValidation('Contiguity'),
               },
             ]
           : undefined,
@@ -318,55 +412,36 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   ];
 
   const advancedPointers: Hint[] = [
-    {label: 'Share your map', onClick: () => request('shareModal', true)},
+    // Guides only: pulse the real control (topbar dropdowns) and let the user
+    // do the clicking — nothing opens on their behalf.
+    {label: 'Share your map', onClick: () => startGuide(['map-actions', 'map-actions-share'])},
     {
       label: 'Explore demographics',
-      onClick: () => jumpToSection('stats', 'stats-demographics'),
+      onClick: () => guideToSection('stats', 'stats-demographics'),
     },
     {
       label: 'Review election results',
-      onClick: () => jumpToSection('stats', 'stats-elections'),
+      onClick: () => guideToSection('stats', 'stats-elections'),
     },
-    // These two point at the mode switcher rather than switching modes — the
-    // user stays where they are; the opened menu pulses the meant mode.
-    {label: 'Fine-tune in Super Draw', onClick: () => request('modeMenu', 'superdraw')},
-    {label: 'Evaluate your plan', onClick: () => request('modeMenu', 'evaluate')},
+    // Pointless to suggest Super Draw to someone already in it.
+    ...(superDraw
+      ? []
+      : [
+          {
+            label: 'Fine-tune in Super Draw',
+            onClick: () => startGuide(['mode-switcher', 'mode-superdraw']),
+          },
+        ]),
+    {label: 'Evaluate your plan', onClick: () => startGuide(['mode-switcher', 'mode-evaluate'])},
   ];
 
-  // The stage shown is the earliest one whose criteria aren't met, capped at
-  // the current status's stage — a regressed plan (e.g. population unassigned
-  // while marked In Progress) jumps back to the checklist that needs fixing,
-  // with a note offering the voluntary status step-back. Completing that
-  // checklist returns the box to the current status's stage automatically.
-  const statusStage =
-    currentStatus === DRAFT_STATUSES.SCRATCH
-      ? 0
-      : currentStatus === DRAFT_STATUSES.IN_PROGRESS
-        ? 1
-        : 2;
-  const criteriaStage = !scratchDone ? 0 : !inProgressDone ? 1 : 2;
-  const displayStage = Math.min(statusStage, criteriaStage);
-  const regressed = displayStage < statusStage;
-  const previousStatus: DraftStatus =
-    statusStage === 2 ? DRAFT_STATUSES.IN_PROGRESS : DRAFT_STATUSES.SCRATCH;
-
-  const title = ['Get started', 'Refine and validate', 'Advanced plan evaluation'][displayStage];
-  const items = displayStage === 0 ? scratchItems : displayStage === 1 ? refineItems : [];
-  const showPointers = displayStage === 2;
-  const doneCount = items.filter(s => s.done).length;
-  // The box's advance button is the one earned move in the app (the status
-  // controls are free choice): only from the un-regressed flow, only with the
-  // shown stage's items done, and not while a stale contiguity result awaits
-  // the next save. Un-regressed at stage 1 implies the scratch criteria hold.
-  const nextStatus: DraftStatus | null =
-    statusStage === 0
-      ? DRAFT_STATUSES.IN_PROGRESS
-      : statusStage === 1
-        ? DRAFT_STATUSES.READY_TO_SHARE
-        : null;
-  const stageDone = displayStage === 0 ? scratchDone : displayStage === 1 ? inProgressDone : false;
-  const canAdvance =
-    !regressed && !!nextStatus && stageDone && !(statusStage === 1 && contiguityStale);
+  const stages: Array<{title: string; items: ChecklistItem[]}> = [
+    {title: 'Get started', items: scratchItems},
+    {title: 'Refine and validate', items: refineItems},
+    {title: 'Advanced plan evaluation', items: []},
+  ];
+  const currentItems = stages[statusStage].items;
+  const doneCount = currentItems.filter(s => s.done).length;
 
   return (
     <Flex
@@ -374,9 +449,12 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       gap="2"
       p="3"
       flexShrink="0"
-      className="max-w-full"
-      // Accent-tinted chrome so the helper reads as its own layer, distinct
-      // from the white data panels below it.
+      // Fixed width only while expanded; collapsed the card shrinks to its
+      // header so the right-anchored overlay hugs the map's top-right corner
+      // instead of holding a 360px slab open.
+      className={`max-w-full ${collapsed ? '' : 'w-[360px]'}`}
+      // Accent-tinted chrome so the helper reads as its own layer over the
+      // map, distinct from the map pills and the white panels around it.
       //
       // minWidth 0 lets the card shrink inside its flex parent instead of
       // being held open by its widest line; overflowWrap is inherited, so
@@ -391,56 +469,91 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       }}
       data-testid="draft-status-helper"
     >
-      <button
-        type="button"
-        onClick={collapsible ? toggleCollapsed : undefined}
-        aria-expanded={!collapsed}
-        className={`w-full text-left ${collapsible ? 'cursor-pointer' : 'cursor-default'}`}
-      >
-        <Flex align="center" justify="between" gap="2">
-          <Text size="3" weight="bold" style={{minWidth: 0}}>
-            {title}
-          </Text>
-          {/* The count and chevron keep their width; the title wraps. */}
-          <Flex align="center" gap="2" flexShrink="0">
-            {!showPointers && !collapsed && (
-              <Text size="1" color="gray">
-                {doneCount} of {items.length} done
-              </Text>
-            )}
-            {collapsible && (
+      <Flex align="center" justify="between" gap="2">
+        <button
+          type="button"
+          onClick={collapsible ? toggleCollapsed : undefined}
+          aria-expanded={!collapsed}
+          className={`flex-1 text-left ${collapsible ? 'cursor-pointer' : 'cursor-default'}`}
+          style={{minWidth: 0}}
+        >
+          <Flex align="center" gap="2">
+            {/* The header names the current stage — the box shows one stage
+                at a time, so the title is the place the user reads where
+                they are. */}
+            <Text size="3" weight="bold" style={{minWidth: 0}}>
+              {stages[statusStage].title}
+            </Text>
+          </Flex>
+        </button>
+        <Flex align="center" gap="2" flexShrink="0">
+          {currentItems.length > 0 && (
+            <Text size="1" color="gray">
+              {doneCount} of {currentItems.length} done
+            </Text>
+          )}
+          {collapsible && (
+            <IconButton
+              variant="ghost"
+              color="gray"
+              size="1"
+              onClick={toggleCollapsed}
+              aria-label={collapsed ? 'Expand map guide' : 'Collapse map guide'}
+              className="cursor-pointer"
+            >
               <ChevronDownIcon
                 style={{
                   transform: collapsed ? 'rotate(-90deg)' : undefined,
                   transition: 'transform 0.15s',
                 }}
               />
-            )}
-          </Flex>
+            </IconButton>
+          )}
+          {collapsible && (
+            // Confirmation first: dismissal can be persistent (Super Draw),
+            // so the dialog names the way back before anything disappears.
+            <AlertDialog.Root>
+              <AlertDialog.Trigger>
+                <IconButton
+                  variant="ghost"
+                  color="gray"
+                  size="1"
+                  aria-label="Dismiss map guide"
+                  data-testid="dismiss-draft-status"
+                  className="cursor-pointer"
+                >
+                  <Cross2Icon />
+                </IconButton>
+              </AlertDialog.Trigger>
+              <AlertDialog.Content maxWidth="450px">
+                <AlertDialog.Title>Hide the map guide?</AlertDialog.Title>
+                <AlertDialog.Description size="2">
+                  You can restore the map guide anytime from the Map actions menu in the top bar.
+                </AlertDialog.Description>
+                <Flex gap="3" mt="4" justify="end">
+                  <AlertDialog.Cancel>
+                    <Button variant="soft" color="gray">
+                      Cancel
+                    </Button>
+                  </AlertDialog.Cancel>
+                  <AlertDialog.Action>
+                    <Button
+                      variant="solid"
+                      // Persistent in Super Draw, per-session in plain Draw
+                      // (see useHelperDismissal).
+                      onClick={() => dismiss(superDraw)}
+                      data-testid="confirm-dismiss-draft-status"
+                    >
+                      Hide guide
+                    </Button>
+                  </AlertDialog.Action>
+                </Flex>
+              </AlertDialog.Content>
+            </AlertDialog.Root>
+          )}
         </Flex>
-      </button>
-      {!collapsed && regressed && (
-        <Flex
-          direction="column"
-          gap="1"
-          p="2"
-          className="max-w-full"
-          style={{
-            background: 'var(--amber-2)',
-            border: '1px solid var(--amber-6)',
-            borderRadius: 6,
-          }}
-        >
-          <Text size="2" className="max-w-full">
-            Your plan no longer meets the checks for its current status.{' '}
-            <InlineHintButton back onClick={() => changeStatus(previousStatus)}>
-              <StatusGlyph status={previousStatus} inline />
-              Move back to {DRAFT_STATUS_TEXT[previousStatus]}
-            </InlineHintButton>
-          </Text>
-        </Flex>
-      )}
-      {!collapsed && showPointers && (
+      </Flex>
+      {!collapsed && statusStage === 2 && (
         <>
           <Text size="2" color="gray">
             Your plan is ready to share. Keep going:
@@ -462,7 +575,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
         </>
       )}
       {!collapsed &&
-        items.map(step => (
+        currentItems.map(step => (
           <Flex key={step.label} align="start" gap="2" minWidth="0">
             <span className="pt-[3px] shrink-0">
               <ItemMarker done={step.done && !step.muted} />
@@ -501,45 +614,130 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             </Text>
           </Flex>
         ))}
-      {/* Backward moves are always free; the regressed note above carries its
-          own step-back, so skip the duplicate there. */}
-      {!collapsed && (canAdvance || (statusStage > 0 && !regressed)) && (
-        // Wraps: "Mark your plan as “Ready to Share”" outruns a narrow
-        // sidebar, and the step-back link beside it is nowrap.
-        <Flex align="center" gap="3" wrap="wrap">
-          {statusStage > 0 && !regressed && (
-            // size 2 to match the advance Button's own text beside it.
-            <Text size="2">
-              <InlineHintButton back onClick={() => changeStatus(previousStatus)}>
-                <StatusGlyph status={previousStatus} inline />
-                Move back to {DRAFT_STATUS_TEXT[previousStatus]}
-              </InlineHintButton>
-            </Text>
-          )}
-          {canAdvance && nextStatus && (
-            <Button
-              variant="solid"
-              size="2"
-              onClick={() => changeStatus(nextStatus)}
-              className="max-w-full"
-              // The label wraps rather than running off a narrow sidebar, so
-              // the button grows instead of holding its fixed size-2 height.
-              style={{
-                fontWeight: 600,
-                whiteSpace: 'normal',
-                textAlign: 'left',
-                height: 'auto',
-                minHeight: 'var(--base-button-height)',
-                paddingBlock: 'var(--space-1)',
-              }}
-              data-testid="advance-draft-status"
-            >
-              {/* The status it's moving to, shown as the same glyph the topbar
-                  will then display. */}
-              <StatusGlyph status={nextStatus} />
-              Mark your plan as “{DRAFT_STATUS_TEXT[nextStatus]}”
-            </Button>
-          )}
+      {/* The status stepper: all three draft statuses across the bottom, the
+          current one lit in its own status color. Every segment is a free
+          choice — clicking sets that status — and the stats-earned nudge
+          (forward when the stage's criteria pass, backward when the plan has
+          regressed) arrives as a dismissible bubble anchored over the segment
+          it recommends. */}
+      {!collapsed && (
+        <Flex
+          className="w-full"
+          role="group"
+          aria-label="Draft status"
+          style={{
+            border: '1px solid var(--accent-6)',
+            borderRadius: 8,
+            background: 'var(--color-surface)',
+          }}
+          data-testid="draft-status-row"
+        >
+          {DRAFT_STATUS_ORDER.map((status, idx) => {
+            const isCurrentStatus = status === currentStatus;
+            const color = DRAFT_STATUS_COLORS[status];
+            const suggested = showSuggestion && suggestion?.status === status;
+            return (
+              // relative so the suggestion bubble can anchor over the exact
+              // segment it recommends. No overflow-hidden on the row (it
+              // would clip the bubble), so the end segments round themselves.
+              <div key={status} className="relative flex-1 min-w-0">
+                {suggested && suggestion && (
+                  <>
+                    <Flex
+                      role="status"
+                      align="start"
+                      gap="1"
+                      p="2"
+                      // Edge segments anchor the bubble to the card's own edge
+                      // instead of centering it, so it can't spill past the
+                      // card and hand the overlay a horizontal scrollbar.
+                      className={`absolute bottom-full mb-2 w-max max-w-[200px] z-10 ${
+                        idx === 0
+                          ? 'left-0'
+                          : idx === DRAFT_STATUS_ORDER.length - 1
+                            ? 'right-0'
+                            : 'left-1/2 -translate-x-1/2'
+                      }`}
+                      style={{
+                        background:
+                          suggestion.direction === 'forward' ? 'var(--accent-3)' : 'var(--amber-3)',
+                        border: `1px solid ${
+                          suggestion.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
+                        }`,
+                        borderRadius: 6,
+                        boxShadow: 'var(--shadow-3)',
+                      }}
+                      data-testid="draft-status-suggestion"
+                    >
+                      <Text size="1">
+                        {suggestion.direction === 'forward'
+                          ? `Your plan looks ready — mark it “${DRAFT_STATUS_TEXT[status]}”.`
+                          : `Your plan no longer meets the checks for “${DRAFT_STATUS_TEXT[currentStatus]}” — consider moving back.`}
+                      </Text>
+                      <IconButton
+                        variant="ghost"
+                        color="gray"
+                        size="1"
+                        onClick={() => setDismissedSuggestion(suggestionKey)}
+                        aria-label="Dismiss suggestion"
+                        className="cursor-pointer shrink-0"
+                      >
+                        <Cross2Icon width={12} height={12} />
+                      </IconButton>
+                    </Flex>
+                    {/* Caret pointing down at the recommended segment — a
+                        sibling of the bubble (not a child), so it stays
+                        centered on the segment even when the bubble is
+                        edge-anchored. Border only on the two lower edges;
+                        the upper half hides under the bubble's body. */}
+                    <span
+                      aria-hidden
+                      className="absolute bottom-full left-1/2 -translate-x-1/2 mb-[3px] size-[10px] rotate-45 z-[11]"
+                      style={{
+                        background:
+                          suggestion.direction === 'forward' ? 'var(--accent-3)' : 'var(--amber-3)',
+                        borderRight: `1px solid ${
+                          suggestion.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
+                        }`,
+                        borderBottom: `1px solid ${
+                          suggestion.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
+                        }`,
+                      }}
+                    />
+                  </>
+                )}
+                <button
+                  type="button"
+                  onClick={() => changeStatus(status)}
+                  aria-current={isCurrentStatus || undefined}
+                  className={`w-full cursor-pointer px-1 py-2 flex flex-col items-center gap-1 transition-colors ${
+                    idx > 0 ? 'border-l border-[var(--accent-6)]' : ''
+                  } ${isCurrentStatus ? '' : 'hover:bg-[var(--gray-a2)]'}`}
+                  style={{
+                    borderRadius:
+                      idx === 0
+                        ? '7px 0 0 7px'
+                        : idx === DRAFT_STATUS_ORDER.length - 1
+                          ? '0 7px 7px 0'
+                          : 0,
+                    ...(isCurrentStatus
+                      ? {
+                          background: `var(--${color}-a4)`,
+                          color: `var(--${color}-11)`,
+                          fontWeight: 600,
+                        }
+                      : {color: 'var(--gray-9)'}),
+                  }}
+                  data-testid={`draft-status-${status}`}
+                >
+                  <StatusGlyph status={status} />
+                  <Text size="1" align="center" style={{lineHeight: 1.2, color: 'inherit'}}>
+                    {DRAFT_STATUS_TEXT[status]}
+                  </Text>
+                </button>
+              </div>
+            );
+          })}
         </Flex>
       )}
     </Flex>

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -640,7 +640,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                       p="2"
                       // Edge segments anchor to the card edge so the bubble
                       // can't spill and cause a horizontal scrollbar.
-                      className={`absolute bottom-full mb-2 w-max max-w-[200px] z-10 ${
+                      className={`absolute top-full mt-2 w-max max-w-[200px] z-10 ${
                         idx === 0
                           ? 'left-0'
                           : idx === DRAFT_STATUS_ORDER.length - 1
@@ -675,11 +675,11 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                         the segment even when the bubble is edge-anchored. */}
                     <span
                       aria-hidden
-                      className="absolute bottom-full left-1/2 -translate-x-1/2 mb-[3px] size-[10px] rotate-45 z-[11]"
+                      className="absolute top-full left-1/2 -translate-x-1/2 mt-[3px] size-[10px] rotate-45 z-[11]"
                       style={{
                         background: suggestionBg,
-                        borderRight: suggestionBorder,
-                        borderBottom: suggestionBorder,
+                        borderLeft: suggestionBorder,
+                        borderTop: suggestionBorder,
                       }}
                     />
                   </>

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -404,14 +404,14 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
         ? [
             {label: 'Save now', onClick: () => startGuide(['save-button'])},
             {
-              label: 'find fragments',
+              label: 'find components',
               onClick: () => guideToValidation('Contiguity'),
             },
           ]
         : !contiguityUnavailable && contiguousZones < numDistricts
           ? [
               {
-                label: 'Find fragments',
+                label: 'Find components',
                 onClick: () => guideToValidation('Contiguity'),
               },
             ]
@@ -580,7 +580,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
               style={{minWidth: 0}}
             >
               {step.label}
-              <span className="inline-flex align-text-bottom ml-1">
+              <span className="inline-flex align-[-2px] mx-1">
                 <ItemMarker done={step.done && !step.muted} />
               </span>
               {/* Muted counts as unfinished here: a stale contiguity result

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -328,11 +328,11 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
 
   const scratchItems: ChecklistItem[] = [
     {
-      label: `All districts started? (${paintedZones}/${numDistricts})`,
+      label: `Are all districts started? (${paintedZones}/${numDistricts})`,
       done: paintedZones >= numDistricts,
     },
     {
-      label: `All population assigned?${
+      label: `Has all population been assigned to a district?${
         unassigned !== undefined && unassigned > 0
           ? ` (${formatNumber(unassigned, NUMBER_FORMATS.STRING)} left)`
           : ''
@@ -364,7 +364,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const balanced = maxDeviation !== undefined && maxDeviation <= BALANCE_DEVIATION;
   const refineItems: ChecklistItem[] = [
     {
-      label: `Districts balanced? (${
+      label: `Are districts roughly balanced? (${
         maxDeviation !== undefined
           ? `max ${formatNumber(maxDeviation, NUMBER_FORMATS.PERCENT)}, `
           : ''
@@ -393,10 +393,10 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       // Uncheckable/stale contiguity passes the gate (see the criteria hook)
       // but must not display as a confirmed pass.
       label: contiguityUnavailable
-        ? 'Districts contiguous? (not checked)'
+        ? 'Are districts contiguous? (not checked)'
         : contiguityStale
-          ? `Districts contiguous? (?/${numDistricts})`
-          : `Districts contiguous? (${contiguousZones}/${numDistricts})`,
+          ? `Are districts contiguous? (?/${numDistricts})`
+          : `Are districts contiguous? (${contiguousZones}/${numDistricts})`,
       done: contiguityUnavailable || contiguousZones >= numDistricts,
       muted: contiguityUnavailable || contiguityStale,
       // Stale result waits on a save; point at the save button as step one.

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -585,6 +585,9 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             const isCurrentStatus = status === currentStatus;
             const color = DRAFT_STATUS_COLORS[status];
             const suggested = showSuggestion && suggestion?.status === status;
+            // Forward moves must be earned; moving back is always allowed.
+            const unlockedStage = !scratchDone ? 0 : !inProgressDone || contiguityStale ? 1 : 2;
+            const locked = idx > statusStage && idx > unlockedStage;
             return (
               // relative anchors the bubble; no overflow-hidden on the row
               // (it would clip the bubble), so end segments round themselves.
@@ -653,10 +656,16 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                 <button
                   type="button"
                   onClick={() => changeStatus(status)}
+                  disabled={locked}
+                  title={locked ? 'Complete the current checklist first' : undefined}
                   aria-current={isCurrentStatus || undefined}
-                  className={`w-full cursor-pointer px-1 py-2 flex flex-col items-center gap-1 transition-colors ${
+                  className={`w-full px-1 py-2 flex flex-col items-center gap-1 transition-colors ${
                     idx > 0 ? 'border-l border-[var(--accent-6)]' : ''
-                  } ${isCurrentStatus ? '' : 'hover:bg-[var(--gray-a2)]'}`}
+                  } ${
+                    locked
+                      ? 'cursor-not-allowed opacity-50'
+                      : `cursor-pointer ${isCurrentStatus ? '' : 'hover:bg-[var(--gray-a2)]'}`
+                  }`}
                   style={{
                     borderRadius:
                       idx === 0

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -625,65 +625,9 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
           {DRAFT_STATUS_ORDER.map((status, idx) => {
             const isCurrentStatus = status === currentStatus;
             const color = DRAFT_STATUS_COLORS[status];
-            const suggested = showSuggestion && suggestion?.status === status;
             const locked = idx > statusStage && idx > unlockedStage;
             return (
-              // relative anchors the bubble; no overflow-hidden on the row
-              // (it would clip the bubble), so end segments round themselves.
               <div key={status} className="relative flex-1 min-w-0">
-                {suggested && suggestion && (
-                  <>
-                    <Flex
-                      role="status"
-                      align="start"
-                      gap="1"
-                      p="2"
-                      // Edge segments anchor to the card edge so the bubble
-                      // can't spill and cause a horizontal scrollbar.
-                      className={`absolute top-full mt-2 w-max max-w-[200px] z-10 ${
-                        idx === 0
-                          ? 'left-0'
-                          : idx === DRAFT_STATUS_ORDER.length - 1
-                            ? 'right-0'
-                            : 'left-1/2 -translate-x-1/2'
-                      }`}
-                      style={{
-                        background: suggestionBg,
-                        border: suggestionBorder,
-                        borderRadius: 6,
-                        boxShadow: 'var(--shadow-3)',
-                      }}
-                      data-testid="draft-status-suggestion"
-                    >
-                      <Text size="1">
-                        {suggestion.direction === 'forward'
-                          ? `Your plan looks ready — mark it “${DRAFT_STATUS_TEXT[status]}”.`
-                          : `Your plan no longer meets the checks for “${DRAFT_STATUS_TEXT[currentStatus]}” — consider moving back.`}
-                      </Text>
-                      <IconButton
-                        variant="ghost"
-                        color="gray"
-                        size="1"
-                        onClick={() => setDismissedSuggestion(suggestionKey)}
-                        aria-label="Dismiss suggestion"
-                        className="cursor-pointer shrink-0"
-                      >
-                        <Cross2Icon width={12} height={12} />
-                      </IconButton>
-                    </Flex>
-                    {/* Caret: a sibling of the bubble so it stays centered on
-                        the segment even when the bubble is edge-anchored. */}
-                    <span
-                      aria-hidden
-                      className="absolute top-full left-1/2 -translate-x-1/2 mt-[3px] size-[10px] rotate-45 z-[11]"
-                      style={{
-                        background: suggestionBg,
-                        borderLeft: suggestionBorder,
-                        borderTop: suggestionBorder,
-                      }}
-                    />
-                  </>
-                )}
                 <button
                   type="button"
                   onClick={() => changeStatus(status)}
@@ -723,6 +667,60 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             );
           })}
         </Flex>
+      )}
+      {/* Suggestion bubble in normal flow below the row (the overlay wrapper
+          scrolls, so an absolutely-hung bubble would be clipped). The caret
+          points up at the recommended segment's center. */}
+      {!collapsed && showSuggestion && suggestion && (
+        <div className="relative">
+          <span
+            aria-hidden
+            className="absolute -top-[3px] size-[10px] rotate-45 z-[1]"
+            style={{
+              left: `${((DRAFT_STATUS_ORDER.indexOf(suggestion.status) + 0.5) / DRAFT_STATUS_ORDER.length) * 100}%`,
+              transform: 'translateX(-50%) rotate(45deg)',
+              background: suggestionBg,
+              borderLeft: suggestionBorder,
+              borderTop: suggestionBorder,
+            }}
+          />
+          <Flex
+            role="status"
+            align="start"
+            gap="1"
+            p="2"
+            className={`w-max max-w-full ${
+              suggestion.status === DRAFT_STATUS_ORDER[0]
+                ? 'mr-auto'
+                : suggestion.status === DRAFT_STATUS_ORDER[DRAFT_STATUS_ORDER.length - 1]
+                  ? 'ml-auto'
+                  : 'mx-auto'
+            }`}
+            style={{
+              background: suggestionBg,
+              border: suggestionBorder,
+              borderRadius: 6,
+              boxShadow: 'var(--shadow-3)',
+            }}
+            data-testid="draft-status-suggestion"
+          >
+            <Text size="1">
+              {suggestion.direction === 'forward'
+                ? `Your plan looks ready — mark it “${DRAFT_STATUS_TEXT[suggestion.status]}”.`
+                : `Your plan no longer meets the checks for “${DRAFT_STATUS_TEXT[currentStatus]}” — consider moving back.`}
+            </Text>
+            <IconButton
+              variant="ghost"
+              color="gray"
+              size="1"
+              onClick={() => setDismissedSuggestion(suggestionKey)}
+              aria-label="Dismiss suggestion"
+              className="cursor-pointer shrink-0"
+            >
+              <Cross2Icon width={12} height={12} />
+            </IconButton>
+          </Flex>
+        </div>
       )}
     </Flex>
   );

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -36,11 +36,8 @@ const MOBILE_TAB_FOR_SECTION: Record<string, MapControlsStore['sidebarPanels'][n
   'stats-elections': 'election',
 };
 
-/** Dismissal is mode-dependent by design: dismissing in Super Draw sticks
- * across sessions (localStorage — an expert opted out for good), while
- * dismissing in plain Draw lasts only this session; the box returns on the
- * next visit. One store so every instance (map overlay, mobile guide button)
- * sees the same answer. */
+/** Dismissing in Super Draw persists (localStorage); in plain Draw it lasts
+ * only the session. One store so every instance sees the same answer. */
 const useHelperDismissal = create<{
   sessionDismissed: boolean;
   superDrawDismissed: boolean;
@@ -60,8 +57,7 @@ const useHelperDismissal = create<{
       set({sessionDismissed: true});
     }
   },
-  // Restore clears both variants: the user asked for the guide back, so no
-  // stale dismissal from the other draw mode should keep it hidden.
+  // Clears both variants so the other mode's dismissal can't keep it hidden.
   restore: () => {
     localStorage.removeItem(DISMISS_KEY);
     set({sessionDismissed: false, superDrawDismissed: false});
@@ -76,9 +72,8 @@ type ChecklistItem = {
    * stale or uncheckable, not a confirmed pass. */
   muted?: boolean;
   hints?: Hint[];
-  /** Hints are alternatives by default, dot-separated. `and` joins them into
-   * one sentence instead, for hints that are steps of a single operation —
-   * so the first doesn't read as the whole job. */
+  /** Hints are dot-separated alternatives; `and` joins steps of one operation
+   * into a sentence. */
   hintsJoin?: 'and';
 };
 
@@ -91,19 +86,15 @@ const InlineHintButton: React.FC<{
   <button
     type="button"
     onClick={onClick}
-    // Wraps with the sentence it sits in. It used to be nowrap so a link
-    // couldn't break across lines, but these labels are long enough
-    // ("Paint by counties to roughly draw districts") that nowrap pushed the
-    // card wider than the box instead.
+    // Wraps with its sentence — nowrap pushed the card wider than the box.
     className="inline cursor-pointer text-left hover:underline underline-offset-2 font-semibold text-districtrBlue"
   >
     {children}
   </button>
 );
 
-/** The topbar's own status glyph, wherever a control names a draft status.
- * Those icons hardcode a 24px size and their own indicator fill, so both are
- * overridden here to inherit from whatever the glyph sits in. */
+/** Topbar status glyph with its hardcoded 24px size and indicator fill
+ * overridden to inherit. */
 const StatusGlyph: React.FC<{status: DraftStatus}> = ({status}) => (
   <span className="inline-flex align-middle [&_svg]:size-[18px] [&_svg]:!fill-current" aria-hidden>
     {React.createElement(statusIcons[status])}
@@ -134,10 +125,9 @@ export const useDraftStatusHelperVisible = () => {
   return !dismissed && isEditing && mapMode === MAP_MODES.DISTRICTS && !!documentId;
 };
 
-/** Dismissal state + restore, for controls living outside the box itself
- * (the Map actions menu's "Show map guide" item). `dismissed` reflects the
- * current draw mode's variant; `restore` clears both, so the guide comes back
- * no matter which mode hid it. */
+/** Dismissal state + restore for controls outside the box (Map actions'
+ * "Show map guide"). `dismissed` is the current mode's variant; `restore`
+ * clears both. */
 export const useDraftStatusHelperDismissal = () => {
   const superDraw = useToolbarStore(state => state.superDraw);
   const sessionDismissed = useHelperDismissal(state => state.sessionDismissed);
@@ -183,16 +173,14 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const isDesktop = useIsDesktop();
   const visible = useDraftStatusHelperVisible();
   const superDraw = useToolbarStore(state => state.superDraw);
-  // The county brush is unavailable while broken into blocks (PaintByCounty
-  // disables itself there); the hint must not point at a dead end.
+  // County brush is disabled in block view; don't point the hint at a dead end.
   const inBlockView = useMapStore(state => state.captiveIds.size > 0);
   const request = useUiHintStore(state => state.request);
   const startGuide = useUiHintStore(state => state.startGuide);
   const flash = useUiHintStore(state => state.flash);
   const dismiss = useHelperDismissal(state => state.dismiss);
   const handleMetadataChange = useMetadataChange();
-  // Status changes land silently in the topbar otherwise; the pulse both
-  // confirms the change and teaches that the title icon is the status.
+  // Pulse the topbar status icon so the change doesn't land silently.
   const changeStatus = (status: DraftStatus) =>
     handleMetadataChange({draft_status: status}).then(() => flash('map-status-icon'));
   const {
@@ -204,11 +192,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
     counts,
   } = useDraftStatusCriteria();
 
-  // The shown stage follows the user-chosen status alone — it never regresses
-  // on its own when the stats fall below the bar. A plan whose criteria sit
-  // below its status (e.g. population unassigned while marked In Progress)
-  // keeps its stage; the only response is the dismissible step-back bubble
-  // over the status row.
+  // The shown stage follows the user-chosen status alone — unmet criteria only
+  // raise the step-back bubble, they never regress the stage.
   const statusStage =
     currentStatus === DRAFT_STATUSES.SCRATCH
       ? 0
@@ -225,9 +210,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
     const stored = localStorage.getItem(COLLAPSE_KEY);
     setStoredCollapsed(stored === null ? null : stored === '1');
   }, []);
-  // Reaching the final stage auto-collapses the box — the plan is done and the
-  // checklists no longer need map real estate; re-expanding is one click and
-  // sticks until the next mount at that stage.
+  // Final stage auto-collapses; re-expanding sticks until the next mount.
   const [autoCollapsed, setAutoCollapsed] = useState(false);
   const atFinalStage = statusStage === 2;
   useEffect(() => {
@@ -242,9 +225,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
 
   const previousStatus: DraftStatus =
     statusStage === 2 ? DRAFT_STATUSES.IN_PROGRESS : DRAFT_STATUSES.SCRATCH;
-  // A move forward is earned: only with the current stage's items done, not
-  // while its earlier criteria have regressed (the back-suggestion wins), and
-  // not while a stale contiguity result awaits the next save.
+  // Forward is earned: stage items done, nothing regressed, no stale
+  // contiguity result pending.
   const nextStatus: DraftStatus | null =
     statusStage === 0
       ? DRAFT_STATUSES.IN_PROGRESS
@@ -255,10 +237,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const canAdvance =
     !regressed && !!nextStatus && stageDone && !(statusStage === 1 && contiguityStale);
 
-  // What the stats say about the status row: earned criteria suggest the next
-  // status forward; a regressed plan suggests stepping back. The bubble is
-  // dismissible per suggestion — keyed on target and direction, so dismissing
-  // "mark it In Progress" doesn't also swallow a later "mark it Ready".
+  // Earned criteria suggest the next status; a regressed plan suggests
+  // stepping back. Bubble dismissal is keyed per suggestion.
   const suggestion: {status: DraftStatus; direction: 'forward' | 'back'} | null =
     canAdvance && nextStatus
       ? {status: nextStatus, direction: 'forward'}
@@ -278,12 +258,9 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       ? unassigned / (idealPopulation * numDistricts)
       : undefined;
 
-  /** Guide the user to a sidebar section: pulse the destination tab until
-   * they click it, then the section header (skipped automatically when
-   * already active/open — see the guide consumers in WorkflowTabs). Below lg
-   * the sidebar is hidden, so open the matching full-screen mobile panel
-   * instead; sections without one skip the jump — the hint's store change
-   * (tooltip on, overlay active) already took effect on the visible map. */
+  /** Guide to a sidebar section: tab, then section header, each on the user's
+   * click. Below lg the sidebar is hidden — open the matching mobile panel
+   * instead (sections without one skip the jump). */
   const guideToSection = (tab: 'stats' | 'mapLayers', sectionId: string) => {
     if (!isDesktop) {
       const mobileTab = MOBILE_TAB_FOR_SECTION[sectionId];
@@ -305,11 +282,9 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
     startGuide(['tab:stats', 'section:stats-validity', `validation:${tab}`]);
   };
 
-  /** Guide to a checkbox in the paint scaffold's tool controls (the county
-   * brush, the population tooltip). Those checkboxes disable themselves while
-   * no painting tool is armed (Pan, pre-break Shatter), so the guide starts
-   * one step earlier — at the brush button — unless a paint-capable tool is
-   * already active. */
+  /** Guide to a tool-controls checkbox. Those disable themselves while no
+   * painting tool is armed, so the guide starts at the brush button unless a
+   * paint-capable tool is already active. */
   const guideToBrushControl = (target: string) => {
     const {activeTool} = useMapControlsStore.getState();
     const paintCapable = activeTool === ACTIVE_TOOLS.BRUSH || activeTool === ACTIVE_TOOLS.ERASER;
@@ -362,8 +337,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       hints: !balanced
         ? [
             {
-              // The toggle lives in ToolControlsScaffold's right column, not
-              // inside any sidebar tab — the guide points there directly.
+              // The toggle lives in ToolControlsScaffold, outside any sidebar tab.
               label: 'Show population tooltips as you paint',
               onClick: () => guideToBrushControl('population-tooltip'),
             },
@@ -380,17 +354,11 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       label: contiguityUnavailable
         ? 'Are districts contiguous? (not checked for this map)'
         : contiguityStale
-          ? // No "— updates on save" here: the Save now hint below says it, and
-            // says it as something to click.
-            `Are districts contiguous? (?/${numDistricts})`
+          ? `Are districts contiguous? (?/${numDistricts})`
           : `Are districts contiguous? (${contiguousZones}/${numDistricts})`,
       done: contiguityUnavailable || contiguousZones >= numDistricts,
       muted: contiguityUnavailable || contiguityStale,
-      // A stale result is waiting on a save, and the forward suggestion stays
-      // withheld until it lands — so point at the save button right here
-      // rather than leaving "updates on save" as the only clue. The save
-      // alone settles nothing visible, so it's phrased as the first of two
-      // steps.
+      // Stale result waits on a save; point at the save button as step one.
       hints: contiguityStale
         ? [
             {label: 'Save now', onClick: () => startGuide(['save-button'])},
@@ -412,8 +380,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   ];
 
   const advancedPointers: Hint[] = [
-    // Guides only: pulse the real control (topbar dropdowns) and let the user
-    // do the clicking — nothing opens on their behalf.
+    // Guides only: nothing opens on the user's behalf.
     {label: 'Share your map', onClick: () => startGuide(['map-actions', 'map-actions-share'])},
     {
       label: 'Explore demographics',
@@ -449,21 +416,15 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       gap="2"
       p="3"
       flexShrink="0"
-      // Fixed width only while expanded; collapsed the card shrinks to its
-      // header so the right-anchored overlay hugs the map's top-right corner
-      // instead of holding a 360px slab open.
+      // Fixed width only while expanded so the collapsed header hugs the corner.
       className={`max-w-full ${collapsed ? '' : 'w-[360px]'}`}
-      // Accent-tinted chrome so the helper reads as its own layer over the
-      // map, distinct from the map pills and the white panels around it.
-      //
-      // minWidth 0 lets the card shrink inside its flex parent instead of
-      // being held open by its widest line; overflowWrap is inherited, so
-      // declaring it once here covers every string in the card — including
-      // ones with no space to break at, like a long map name.
+      // minWidth 0 lets the card shrink in its flex parent; overflowWrap here
+      // covers every string in the card, including ones with no break point.
       style={{
-        background: 'var(--accent-2)',
-        border: '1px solid var(--accent-6)',
+        background: 'white',
+        border: '1px solid var(--accent-8)',
         borderRadius: 10,
+        boxShadow: '0 4px 12px var(--gray-a6)',
         minWidth: 0,
         overflowWrap: 'anywhere',
       }}
@@ -478,9 +439,6 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
           style={{minWidth: 0}}
         >
           <Flex align="center" gap="2">
-            {/* The header names the current stage — the box shows one stage
-                at a time, so the title is the place the user reads where
-                they are. */}
             <Text size="3" weight="bold" style={{minWidth: 0}}>
               {stages[statusStage].title}
             </Text>
@@ -510,8 +468,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             </IconButton>
           )}
           {collapsible && (
-            // Confirmation first: dismissal can be persistent (Super Draw),
-            // so the dialog names the way back before anything disappears.
+            // Confirm first — dismissal can be persistent (Super Draw).
             <AlertDialog.Root>
               <AlertDialog.Trigger>
                 <IconButton
@@ -539,8 +496,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                   <AlertDialog.Action>
                     <Button
                       variant="solid"
-                      // Persistent in Super Draw, per-session in plain Draw
-                      // (see useHelperDismissal).
+                      // Persistent in Super Draw, per-session in plain Draw.
                       onClick={() => dismiss(superDraw)}
                       data-testid="confirm-dismiss-draft-status"
                     >
@@ -591,9 +547,6 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
               {(!step.done || step.muted) &&
                 step.hints?.map((hint, i) => (
                   <React.Fragment key={hint.label}>
-                    {/* Alternatives are dot-separated so adjacent links don't
-                        read as one phrase; steps of one operation are joined
-                        into a sentence instead. */}
                     {i === 0 ? (
                       ' '
                     ) : step.hintsJoin === 'and' ? (
@@ -614,12 +567,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             </Text>
           </Flex>
         ))}
-      {/* The status stepper: all three draft statuses across the bottom, the
-          current one lit in its own status color. Every segment is a free
-          choice — clicking sets that status — and the stats-earned nudge
-          (forward when the stage's criteria pass, backward when the plan has
-          regressed) arrives as a dismissible bubble anchored over the segment
-          it recommends. */}
+      {/* Status stepper: clicking any segment sets that status; the nudge
+          arrives as a dismissible bubble over the recommended segment. */}
       {!collapsed && (
         <Flex
           className="w-full"
@@ -637,9 +586,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             const color = DRAFT_STATUS_COLORS[status];
             const suggested = showSuggestion && suggestion?.status === status;
             return (
-              // relative so the suggestion bubble can anchor over the exact
-              // segment it recommends. No overflow-hidden on the row (it
-              // would clip the bubble), so the end segments round themselves.
+              // relative anchors the bubble; no overflow-hidden on the row
+              // (it would clip the bubble), so end segments round themselves.
               <div key={status} className="relative flex-1 min-w-0">
                 {suggested && suggestion && (
                   <>
@@ -648,9 +596,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                       align="start"
                       gap="1"
                       p="2"
-                      // Edge segments anchor the bubble to the card's own edge
-                      // instead of centering it, so it can't spill past the
-                      // card and hand the overlay a horizontal scrollbar.
+                      // Edge segments anchor to the card edge so the bubble
+                      // can't spill and cause a horizontal scrollbar.
                       className={`absolute bottom-full mb-2 w-max max-w-[200px] z-10 ${
                         idx === 0
                           ? 'left-0'
@@ -685,11 +632,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                         <Cross2Icon width={12} height={12} />
                       </IconButton>
                     </Flex>
-                    {/* Caret pointing down at the recommended segment — a
-                        sibling of the bubble (not a child), so it stays
-                        centered on the segment even when the bubble is
-                        edge-anchored. Border only on the two lower edges;
-                        the upper half hides under the bubble's body. */}
+                    {/* Caret: a sibling of the bubble so it stays centered on
+                        the segment even when the bubble is edge-anchored. */}
                     <span
                       aria-hidden
                       className="absolute bottom-full left-1/2 -translate-x-1/2 mb-[3px] size-[10px] rotate-45 z-[11]"

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -150,8 +150,9 @@ export const useDraftStatusHelperDismissal = () => {
  * that one stage's question checklist — the stage follows the status alone
  * and never moves on its own when the stats change. Across the bottom, the
  * three draft statuses lay out as a stepper row — the current one lit in its
- * status color, the others muted — and clicking a segment sets that status
- * (free choice, as everywhere else). The stats only ever suggest: earned
+ * status color, the others muted. Forward moves lock until the criteria are
+ * earned (the topbar status popover stays a free choice, so nobody can get
+ * stuck); moving back is always allowed. The stats only ever suggest: earned
  * criteria raise a dismissible bubble over the next status, and a plan that
  * no longer meets its status's checks raises one over the status to step
  * back to.
@@ -227,12 +228,13 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
     const stored = localStorage.getItem(COLLAPSE_KEY);
     setStoredCollapsed(stored === null ? null : stored === '1');
   }, []);
-  // Final stage auto-collapses; re-expanding sticks until the next mount.
+  // Final stage auto-collapses — unless the plan has regressed, so the
+  // step-back bubble stays visible instead of hiding behind the collapse.
   const [autoCollapsed, setAutoCollapsed] = useState(false);
   const atFinalStage = statusStage === 2;
   useEffect(() => {
-    if (atFinalStage) setAutoCollapsed(true);
-  }, [atFinalStage]);
+    if (atFinalStage) setAutoCollapsed(!regressed);
+  }, [atFinalStage, regressed]);
   const collapsed = collapsible && (autoCollapsed || (storedCollapsed ?? superDraw));
   const toggleCollapsed = () => {
     setAutoCollapsed(false);

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -11,6 +11,7 @@ import {useUiHintStore, type ValidationTab} from '@/app/store/uiHintStore';
 import {useDraftStatusCriteria, BALANCE_DEVIATION} from '@/app/hooks/useDraftStatusCriteria';
 import {useMetadataChange} from '@/app/hooks/useMetadataChange';
 import {statusIcons} from '@components/Topbar/MapStatus';
+import {useCountyPaintAvailable} from '@components/Toolbar/PaintByCounty';
 import {formatNumber} from '@utils/numbers';
 import {NUMBER_FORMATS} from '@constants/demography/format';
 import {
@@ -29,11 +30,15 @@ const DISMISS_KEY = 'districtr-draft-helper-dismissed';
 // rough drawing; below it, point at the unassigned-areas finder.
 const ROUGH_DRAW_UNASSIGNED_RATIO = 0.25;
 
-// Sidebar sections → the mobile full-screen panel holding the same content.
-const MOBILE_TAB_FOR_SECTION: Record<string, MapControlsStore['sidebarPanels'][number]> = {
+// Sidebar sections → the panel holding the same content in the other layouts:
+// the mobile full-screen tabs and Super Draw's stacked accordion share these
+// keys (sidebarPanels). The demographic map-layer controls render flat inside
+// the Demographics card in both, hence the layers-demographics entry.
+const PANEL_FOR_SECTION: Record<string, MapControlsStore['sidebarPanels'][number]> = {
   'stats-validity': 'mapValidation',
   'stats-demographics': 'demography',
   'stats-elections': 'election',
+  'layers-demographics': 'demography',
 };
 
 /** Dismissing in Super Draw persists (localStorage); in plain Draw it lasts
@@ -173,8 +178,20 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const isDesktop = useIsDesktop();
   const visible = useDraftStatusHelperVisible();
   const superDraw = useToolbarStore(state => state.superDraw);
-  // County brush is disabled in block view; don't point the hint at a dead end.
+  // Super Draw can swap the workflow tabs for the stacked accordion; guides
+  // must target whichever layout is actually mounted (see DataCards).
+  const stackedSidebar = useToolbarStore(state => state.stackedSidebar);
+  const stacked = superDraw && stackedSidebar;
+  // County brush is disabled in block view (and unavailable on some maps —
+  // see useCountyPaintAvailable); don't point the hint at a dead end.
   const inBlockView = useMapStore(state => state.captiveIds.size > 0);
+  const countyPaintAvailable = useCountyPaintAvailable();
+  // Hints that point at a toggle are suppressed once it's already on —
+  // guiding the user to a checked checkbox invites turning it off.
+  const paintByCounty = useMapControlsStore(state => !!state.mapOptions.paintByCounty);
+  const showPopulationTooltip = useMapControlsStore(
+    state => state.mapOptions.showPopulationTooltip === true
+  );
   const request = useUiHintStore(state => state.request);
   const startGuide = useUiHintStore(state => state.startGuide);
   const flash = useUiHintStore(state => state.flash);
@@ -260,11 +277,18 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
 
   /** Guide to a sidebar section: tab, then section header, each on the user's
    * click. Below lg the sidebar is hidden — open the matching mobile panel
-   * instead (sections without one skip the jump). */
+   * instead (sections without one skip the jump). In Super Draw's stacked
+   * layout the tabs/sections don't exist; the guide points at the stacked
+   * panel holding the same content (see StackedPanels' AccordionSection). */
   const guideToSection = (tab: 'stats' | 'mapLayers', sectionId: string) => {
     if (!isDesktop) {
-      const mobileTab = MOBILE_TAB_FOR_SECTION[sectionId];
+      const mobileTab = PANEL_FOR_SECTION[sectionId];
       if (mobileTab) request('mobileTab', mobileTab);
+      return;
+    }
+    if (stacked) {
+      const panel = PANEL_FOR_SECTION[sectionId];
+      if (panel) startGuide([`panel:${panel}`]);
       return;
     }
     startGuide([`tab:${tab}`, `section:${sectionId}`]);
@@ -272,11 +296,16 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
 
   /** Guide to a validation panel: tab → Validity section → the panel itself,
    * each step waiting on the user's own click. The mobile panel holds the
-   * validation checks directly, so only the last step applies there. */
+   * validation checks directly, so only the last step applies there; the
+   * stacked layout goes via its Validity accordion panel instead of the tab. */
   const guideToValidation = (tab: ValidationTab) => {
     if (!isDesktop) {
       request('mobileTab', 'mapValidation');
       startGuide([`validation:${tab}`]);
+      return;
+    }
+    if (stacked) {
+      startGuide(['panel:mapValidation', `validation:${tab}`]);
       return;
     }
     startGuide(['tab:stats', 'section:stats-validity', `validation:${tab}`]);
@@ -306,7 +335,13 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       hints:
         unassigned !== undefined && unassigned > 0
           ? [
+              // The rough-draw shortcut only when county painting is actually
+              // usable here (available on this map, not in block view, not
+              // already on) — otherwise the guide would point at a disabled,
+              // missing, or already-checked control.
               !inBlockView &&
+              countyPaintAvailable &&
+              !paintByCounty &&
               unassignedRatio !== undefined &&
               unassignedRatio > ROUGH_DRAW_UNASSIGNED_RATIO
                 ? {
@@ -336,11 +371,16 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       done: balanced,
       hints: !balanced
         ? [
-            {
-              // The toggle lives in ToolControlsScaffold, outside any sidebar tab.
-              label: 'Show population tooltips as you paint',
-              onClick: () => guideToBrushControl('population-tooltip'),
-            },
+            // The toggle lives in ToolControlsScaffold, outside any sidebar
+            // tab. Skipped once it's already on — nothing left to point at.
+            ...(showPopulationTooltip
+              ? []
+              : [
+                  {
+                    label: 'Show population tooltips as you paint',
+                    onClick: () => guideToBrushControl('population-tooltip'),
+                  },
+                ]),
             {
               label: 'Show the demographic map',
               onClick: () => guideToSection('mapLayers', 'layers-demographics'),

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -30,10 +30,8 @@ const DISMISS_KEY = 'districtr-draft-helper-dismissed';
 // rough drawing; below it, point at the unassigned-areas finder.
 const ROUGH_DRAW_UNASSIGNED_RATIO = 0.25;
 
-// Sidebar sections → the panel holding the same content in the other layouts:
-// the mobile full-screen tabs and Super Draw's stacked accordion share these
-// keys (sidebarPanels). The demographic map-layer controls render flat inside
-// the Demographics card in both, hence the layers-demographics entry.
+// Sidebar sections → the sidebarPanels key holding the same content in the
+// mobile tabs and Super Draw's stacked accordion.
 const PANEL_FOR_SECTION: Record<string, MapControlsStore['sidebarPanels'][number]> = {
   'stats-validity': 'mapValidation',
   'stats-demographics': 'demography',
@@ -267,6 +265,12 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const suggestionKey = suggestion ? `${suggestion.direction}:${suggestion.status}` : null;
   const [dismissedSuggestion, setDismissedSuggestion] = useState<string | null>(null);
   const showSuggestion = !!suggestionKey && dismissedSuggestion !== suggestionKey;
+  const suggestionBg = suggestion?.direction === 'forward' ? 'var(--accent-3)' : 'var(--amber-3)';
+  const suggestionBorder = `1px solid ${
+    suggestion?.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
+  }`;
+  // Forward moves must be earned; moving back is always allowed.
+  const unlockedStage = !scratchDone ? 0 : !inProgressDone || contiguityStale ? 1 : 2;
 
   if (!visible) return null;
 
@@ -337,10 +341,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       hints:
         unassigned !== undefined && unassigned > 0
           ? [
-              // The rough-draw shortcut only when county painting is actually
-              // usable here (available on this map, not in block view, not
-              // already on) — otherwise the guide would point at a disabled,
-              // missing, or already-checked control.
+              // Rough-draw shortcut only when county painting is usable
+              // here — never point at a disabled/missing/checked control.
               !inBlockView &&
               countyPaintAvailable &&
               !paintByCounty &&
@@ -627,8 +629,6 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
             const isCurrentStatus = status === currentStatus;
             const color = DRAFT_STATUS_COLORS[status];
             const suggested = showSuggestion && suggestion?.status === status;
-            // Forward moves must be earned; moving back is always allowed.
-            const unlockedStage = !scratchDone ? 0 : !inProgressDone || contiguityStale ? 1 : 2;
             const locked = idx > statusStage && idx > unlockedStage;
             return (
               // relative anchors the bubble; no overflow-hidden on the row
@@ -651,11 +651,8 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                             : 'left-1/2 -translate-x-1/2'
                       }`}
                       style={{
-                        background:
-                          suggestion.direction === 'forward' ? 'var(--accent-3)' : 'var(--amber-3)',
-                        border: `1px solid ${
-                          suggestion.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
-                        }`,
+                        background: suggestionBg,
+                        border: suggestionBorder,
                         borderRadius: 6,
                         boxShadow: 'var(--shadow-3)',
                       }}
@@ -683,14 +680,9 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
                       aria-hidden
                       className="absolute bottom-full left-1/2 -translate-x-1/2 mb-[3px] size-[10px] rotate-45 z-[11]"
                       style={{
-                        background:
-                          suggestion.direction === 'forward' ? 'var(--accent-3)' : 'var(--amber-3)',
-                        borderRight: `1px solid ${
-                          suggestion.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
-                        }`,
-                        borderBottom: `1px solid ${
-                          suggestion.direction === 'forward' ? 'var(--accent-7)' : 'var(--amber-7)'
-                        }`,
+                        background: suggestionBg,
+                        borderRight: suggestionBorder,
+                        borderBottom: suggestionBorder,
                       }}
                     />
                   </>

--- a/app/src/app/components/sidebar/DraftStatusHelper.tsx
+++ b/app/src/app/components/sidebar/DraftStatusHelper.tsx
@@ -328,13 +328,13 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
 
   const scratchItems: ChecklistItem[] = [
     {
-      label: `Are all districts started? (${paintedZones}/${numDistricts})`,
+      label: `All districts started? (${paintedZones}/${numDistricts})`,
       done: paintedZones >= numDistricts,
     },
     {
-      label: `Has all population been assigned to a district?${
+      label: `All population assigned?${
         unassigned !== undefined && unassigned > 0
-          ? ` (${formatNumber(unassigned, NUMBER_FORMATS.STRING)} remaining)`
+          ? ` (${formatNumber(unassigned, NUMBER_FORMATS.STRING)} left)`
           : ''
       }`,
       done: unassigned === 0,
@@ -349,7 +349,7 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
               unassignedRatio !== undefined &&
               unassignedRatio > ROUGH_DRAW_UNASSIGNED_RATIO
                 ? {
-                    label: 'Paint by counties to roughly draw districts',
+                    label: 'Paint by counties',
                     onClick: () => guideToBrushControl('county-brush'),
                   }
                 : {
@@ -364,14 +364,11 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
   const balanced = maxDeviation !== undefined && maxDeviation <= BALANCE_DEVIATION;
   const refineItems: ChecklistItem[] = [
     {
-      label: `Are districts roughly balanced? (within ${formatNumber(
-        BALANCE_DEVIATION,
-        NUMBER_FORMATS.PERCENT
-      )} of ideal${
+      label: `Districts balanced? (${
         maxDeviation !== undefined
-          ? `; largest deviation ${formatNumber(maxDeviation, NUMBER_FORMATS.PERCENT)}`
+          ? `max ${formatNumber(maxDeviation, NUMBER_FORMATS.PERCENT)}, `
           : ''
-      })`,
+      }target ≤${formatNumber(BALANCE_DEVIATION, NUMBER_FORMATS.PERCENT)})`,
       done: balanced,
       hints: !balanced
         ? [
@@ -381,12 +378,12 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
               ? []
               : [
                   {
-                    label: 'Show population tooltips as you paint',
+                    label: 'Show population tooltips',
                     onClick: () => guideToBrushControl('population-tooltip'),
                   },
                 ]),
             {
-              label: 'Show the demographic map',
+              label: 'Show demographic map',
               onClick: () => guideToSection('mapLayers', 'layers-demographics'),
             },
           ]
@@ -396,10 +393,10 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       // Uncheckable/stale contiguity passes the gate (see the criteria hook)
       // but must not display as a confirmed pass.
       label: contiguityUnavailable
-        ? 'Are districts contiguous? (not checked for this map)'
+        ? 'Districts contiguous? (not checked)'
         : contiguityStale
-          ? `Are districts contiguous? (?/${numDistricts})`
-          : `Are districts contiguous? (${contiguousZones}/${numDistricts})`,
+          ? `Districts contiguous? (?/${numDistricts})`
+          : `Districts contiguous? (${contiguousZones}/${numDistricts})`,
       done: contiguityUnavailable || contiguousZones >= numDistricts,
       muted: contiguityUnavailable || contiguityStale,
       // Stale result waits on a save; point at the save button as step one.
@@ -407,14 +404,14 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
         ? [
             {label: 'Save now', onClick: () => startGuide(['save-button'])},
             {
-              label: 'find disconnected fragments',
+              label: 'find fragments',
               onClick: () => guideToValidation('Contiguity'),
             },
           ]
         : !contiguityUnavailable && contiguousZones < numDistricts
           ? [
               {
-                label: 'Find disconnected fragments',
+                label: 'Find fragments',
                 onClick: () => guideToValidation('Contiguity'),
               },
             ]
@@ -577,15 +574,15 @@ export const DraftStatusHelper: React.FC<{onNavigate?: () => void; collapsible?:
       {!collapsed &&
         currentItems.map(step => (
           <Flex key={step.label} align="start" gap="2" minWidth="0">
-            <span className="pt-[3px] shrink-0">
-              <ItemMarker done={step.done && !step.muted} />
-            </span>
             <Text
               size="2"
               color={step.done || step.muted ? 'gray' : undefined}
               style={{minWidth: 0}}
             >
               {step.label}
+              <span className="inline-flex align-text-bottom ml-1">
+                <ItemMarker done={step.done && !step.muted} />
+              </span>
               {/* Muted counts as unfinished here: a stale contiguity result
                   displays as done but still needs its save. */}
               {(!step.done || step.muted) &&

--- a/app/src/app/components/sidebar/MapValidation/Contiguity.tsx
+++ b/app/src/app/components/sidebar/MapValidation/Contiguity.tsx
@@ -49,9 +49,9 @@ export const Contiguity = () => {
         });
       }
     }
-    const isBroken = (row: any) => row.contiguity !== null && row.contiguity > 1;
+    // Most components first; unchecked (null) districts sort last.
     cleanData.sort(
-      (a: any, b: any) => Number(isBroken(b)) - Number(isBroken(a)) || a.zone - b.zone
+      (a: any, b: any) => (b.contiguity ?? 0) - (a.contiguity ?? 0) || a.zone - b.zone
     );
     return cleanData;
   }, [data]);
@@ -76,7 +76,7 @@ export const Contiguity = () => {
               <Table.ColumnHeaderCell>
                 <Text>District</Text>
               </Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Number of pieces</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Number of components</Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>
 

--- a/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
+++ b/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
@@ -167,7 +167,7 @@ export const MapValidation = () => {
     : brokenDistricts > 0
       ? `${brokenDistricts} district${brokenDistricts === 1 ? '' : 's'} split into components`
       : contiguousDistricts >= numDistricts
-        ? 'All districts in one component'
+        ? 'Each district is one connected component'
         : `${unstartedDistricts} district${unstartedDistricts === 1 ? '' : 's'} not started`;
 
   useEffect(() => {

--- a/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
+++ b/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
@@ -151,7 +151,7 @@ export const MapValidation = () => {
   const contiguityDetail = !pieceCounts
     ? 'Not checked yet'
     : brokenDistricts > 0
-      ? `${brokenDistricts} district${brokenDistricts === 1 ? '' : 's'} split into components`
+      ? `${brokenDistricts} district${brokenDistricts === 1 ? '' : 's'} split into multiple components`
       : contiguousDistricts >= numDistricts
         ? 'Each district is one connected component'
         : `${unstartedDistricts} district${unstartedDistricts === 1 ? '' : 's'} not started`;

--- a/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
+++ b/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
@@ -62,16 +62,28 @@ export const MapValidation = () => {
   });
   const togglePanel = (panel: ValidationTab) =>
     setOpenPanels(prev => ({...prev, [panel]: !prev[panel]}));
-  // Helper-box hints jump straight to a validation panel; consuming at mount
-  // is deliberate here — the jump usually mounts this component.
-  const validationTabRequest = useUiHintStore(state => state.requests.validationTab);
-  const clearRequest = useUiHintStore(state => state.clear);
+  // Guided step (see uiHintStore.guideTargets): helper-box hints point at a
+  // validation panel and pulse its header until the user opens it themselves.
+  // A panel that's already open needs no click — advance past it with a
+  // one-shot confirmation pulse instead.
+  const guideTarget = useUiHintStore(state => state.guideTargets[0]);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const flash = useUiHintStore(state => state.flash);
+  const flashTarget = useUiHintStore(state => state.flashTarget);
+  const guidedPanel: ValidationTab | null =
+    guideTarget === 'validation:Contiguity'
+      ? 'Contiguity'
+      : guideTarget === 'validation:Completeness'
+        ? 'Completeness'
+        : null;
   useEffect(() => {
-    if (validationTabRequest) {
-      setOpenPanels(prev => ({...prev, [validationTabRequest]: true}));
-      clearRequest('validationTab');
+    if (guidedPanel && openPanels[guidedPanel]) {
+      advanceGuide(`validation:${guidedPanel}`);
+      flash(`validation:${guidedPanel}`);
     }
-  }, [validationTabRequest, clearRequest]);
+  }, [guidedPanel, openPanels, advanceGuide, flash]);
+  const panelHintClass = (panel: ValidationTab) =>
+    guidedPanel === panel ? 'ui-guide' : flashTarget === `validation:${panel}` ? 'ui-flash' : '';
   const mapDocument = useMapStore(state => state.mapDocument);
   const idbDocument = useIdbDocument(mapDocument?.document_id);
   const access = useMapStore(state => state.mapStatus?.access);
@@ -155,9 +167,9 @@ export const MapValidation = () => {
   const contiguityDetail = !pieceCounts
     ? 'Not checked yet'
     : brokenDistricts > 0
-      ? `${brokenDistricts} district${brokenDistricts === 1 ? '' : 's'} split into pieces`
+      ? `${brokenDistricts} district${brokenDistricts === 1 ? '' : 's'} split into components`
       : contiguousDistricts >= numDistricts
-        ? 'All districts in one piece'
+        ? 'All districts in one component'
         : `${unstartedDistricts} district${unstartedDistricts === 1 ? '' : 's'} not started`;
 
   useEffect(() => {
@@ -206,7 +218,7 @@ export const MapValidation = () => {
       <Expander
         open={openPanels.Completeness}
         onToggle={() => togglePanel('Completeness')}
-        buttonClassName="h-auto"
+        buttonClassName={`h-auto ${panelHintClass('Completeness')}`}
         label={
           <CheckHeader
             title="Completeness"
@@ -220,7 +232,7 @@ export const MapValidation = () => {
       <Expander
         open={openPanels.Contiguity}
         onToggle={() => togglePanel('Contiguity')}
-        buttonClassName="h-auto"
+        buttonClassName={`h-auto ${panelHintClass('Contiguity')}`}
         label={
           <CheckHeader title="Contiguity" status={contiguityStatus} detail={contiguityDetail} />
         }

--- a/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
+++ b/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
@@ -202,7 +202,8 @@ export const MapValidation = () => {
       <Expander
         open={openPanels.Completeness}
         onToggle={() => togglePanel('Completeness')}
-        buttonClassName={`h-auto ${panelHintClass('Completeness')}`}
+        buttonClassName="h-auto"
+        className={panelHintClass('Completeness')}
         label={
           <CheckHeader
             title="Completeness"
@@ -216,7 +217,8 @@ export const MapValidation = () => {
       <Expander
         open={openPanels.Contiguity}
         onToggle={() => togglePanel('Contiguity')}
-        buttonClassName={`h-auto ${panelHintClass('Contiguity')}`}
+        buttonClassName="h-auto"
+        className={panelHintClass('Contiguity')}
         label={
           <CheckHeader title="Contiguity" status={contiguityStatus} detail={contiguityDetail} />
         }

--- a/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
+++ b/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
@@ -62,10 +62,8 @@ export const MapValidation = () => {
   });
   const togglePanel = (panel: ValidationTab) =>
     setOpenPanels(prev => ({...prev, [panel]: !prev[panel]}));
-  // Guided step (see uiHintStore.guideTargets): helper-box hints point at a
-  // validation panel and pulse its header until the user opens it themselves.
-  // A panel that's already open needs no click — advance past it with a
-  // one-shot confirmation pulse instead.
+  // Guide target: pulses the panel header; already-open panels advance with
+  // a one-shot confirmation pulse.
   const guideTarget = useUiHintStore(state => state.guideTargets[0]);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
   const flash = useUiHintStore(state => state.flash);

--- a/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
+++ b/app/src/app/components/sidebar/MapValidation/MapValidation.tsx
@@ -15,7 +15,7 @@ import {useSummaryStats} from '@/app/hooks/useSummaryStats';
 import {useAssignmentsStore} from '@/app/store/assignmentsStore';
 import {useMapControlsStore} from '@/app/store/mapControlsStore';
 import {useUnassignedFeatures} from '@/app/hooks/useUnassignedFeatures';
-import {useUiHintStore, type ValidationTab} from '@/app/store/uiHintStore';
+import {useGuideTarget, type ValidationTab} from '@/app/store/uiHintStore';
 import {getContiguity} from '@utils/api/apiHandlers/getContiguity';
 import {formatNumber} from '@utils/numbers';
 import {NUMBER_FORMATS} from '@constants/demography/format';
@@ -62,26 +62,12 @@ export const MapValidation = () => {
   });
   const togglePanel = (panel: ValidationTab) =>
     setOpenPanels(prev => ({...prev, [panel]: !prev[panel]}));
-  // Guide target: pulses the panel header; already-open panels advance with
-  // a one-shot confirmation pulse.
-  const guideTarget = useUiHintStore(state => state.guideTargets[0]);
-  const advanceGuide = useUiHintStore(state => state.advanceGuide);
-  const flash = useUiHintStore(state => state.flash);
-  const flashTarget = useUiHintStore(state => state.flashTarget);
-  const guidedPanel: ValidationTab | null =
-    guideTarget === 'validation:Contiguity'
-      ? 'Contiguity'
-      : guideTarget === 'validation:Completeness'
-        ? 'Completeness'
-        : null;
-  useEffect(() => {
-    if (guidedPanel && openPanels[guidedPanel]) {
-      advanceGuide(`validation:${guidedPanel}`);
-      flash(`validation:${guidedPanel}`);
-    }
-  }, [guidedPanel, openPanels, advanceGuide, flash]);
+  const panelGuides = {
+    Contiguity: useGuideTarget('validation:Contiguity', openPanels.Contiguity),
+    Completeness: useGuideTarget('validation:Completeness', openPanels.Completeness),
+  };
   const panelHintClass = (panel: ValidationTab) =>
-    guidedPanel === panel ? 'ui-guide' : flashTarget === `validation:${panel}` ? 'ui-flash' : '';
+    panelGuides[panel].guiding ? 'ui-guide' : panelGuides[panel].flashing ? 'ui-flash' : '';
   const mapDocument = useMapStore(state => state.mapDocument);
   const idbDocument = useIdbDocument(mapDocument?.document_id);
   const access = useMapStore(state => state.mapStatus?.access);

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -19,6 +19,7 @@ import {useSelectCommunity} from '@/app/hooks/useSelectCommunity';
 import {ZoneDescriptionPopover} from './ZoneDescriptionPopover';
 import {ConditionalScrollArea, SCROLL_RESERVED_WIDTH} from '../ConditionalScrollArea';
 import {ShowAllDistrictsButton} from '../ShowAllDistrictsButton';
+import {PopulationPanelOptions} from './PopulationPanelOptions';
 import {formatNumber} from '@utils/numbers';
 import {HelpTip, HELP_TIP_FAST_DELAY} from '@components/HelpTip/HelpTip';
 import {NUMBER_FORMATS} from '@constants/demography/format';
@@ -562,12 +563,23 @@ export const DistrictMeters = () => {
               })}
             </Flex>
           </ConditionalScrollArea>
-          <ShowAllDistrictsButton
-            showAll={showAll}
-            onToggle={() => setShowAllOverride(!showAll)}
-            total={populationData.length}
-            hiddenCount={hiddenCount}
-          />
+          <Flex align="center" justify="between" mt="1">
+            <ShowAllDistrictsButton
+              showAll={showAll}
+              onToggle={() => setShowAllOverride(!showAll)}
+              total={populationData.length}
+              hiddenCount={hiddenCount}
+            />
+            {superDraw && (
+              <span style={{marginLeft: 'auto'}}>
+                <PopulationPanelOptions
+                  chartOptions={chartOptions}
+                  setChartOptions={setChartOptions}
+                  idealPopulation={idealPopulation}
+                />
+              </span>
+            )}
+          </Flex>
         </>
       )}
       {/* Plan-wide scoreboard: always visible, even with unstarted districts. */}

--- a/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/DistrictMeters.tsx
@@ -420,7 +420,7 @@ export const DistrictMeters = () => {
                     <button
                       type="button"
                       aria-label={`Select district ${d.zone}`}
-                      className="rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-8)]"
+                      className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-8)]"
                       style={{
                         flexGrow: 1,
                         height: BAR_HEIGHT,
@@ -433,10 +433,10 @@ export const DistrictMeters = () => {
                       }}
                     >
                       {offScale && tickFraction !== undefined ? (
-                        /* Off the scale: no pill track — the bar runs to the
-                           track's end and stops flat. Rounded cap on the left,
-                           darker shaft past the ideal line, and chevrons on the
-                           end: this district is off the chart. */
+                        /* Off the scale: the bar runs to the track's end and
+                           stops flat. Rounded cap on the left, darker shaft
+                           past the ideal line, and chevrons on the end: this
+                           district is off the chart. */
                         <>
                           <Box
                             style={{
@@ -462,25 +462,34 @@ export const DistrictMeters = () => {
                           <OffScaleChevrons count={chevrons} />
                         </>
                       ) : (
-                        <Box
-                          style={{
-                            position: 'absolute',
-                            inset: 0,
-                            borderRadius: 99,
-                            background: 'var(--gray-a4)',
-                            overflow: 'hidden',
-                          }}
-                        >
+                        <>
+                          {/* The track runs from the bar's start to the ideal
+                              line: rounded cap on the left, squared off exactly
+                              at ideal. */}
                           <Box
                             style={{
-                              width: `${Math.min(fill, tickFraction ?? 1) * 100}%`,
-                              height: '100%',
-                              background: color,
-                              transition: BAR_SPRING,
+                              position: 'absolute',
+                              top: 0,
+                              bottom: 0,
+                              left: 0,
+                              width: `${(tickFraction ?? 1) * 100}%`,
+                              borderRadius: '99px 0 0 99px',
+                              background: 'var(--gray-a4)',
+                              overflow: 'hidden',
                             }}
-                          />
-                          {/* Population past ideal crosses the tick in a darker
-                              shade of the district color. */}
+                          >
+                            <Box
+                              style={{
+                                width: `${Math.min(fill / (tickFraction ?? 1), 1) * 100}%`,
+                                height: '100%',
+                                background: color,
+                                transition: BAR_SPRING,
+                              }}
+                            />
+                          </Box>
+                          {/* Population past ideal extends beyond the track's
+                              square end in a darker shade of the district
+                              color. */}
                           {overflowsIdeal && tickFraction !== undefined && (
                             <Box
                               style={{
@@ -494,7 +503,7 @@ export const DistrictMeters = () => {
                               }}
                             />
                           )}
-                        </Box>
+                        </>
                       )}
                       {/* Target-deviation band bracketing the ideal line. */}
                       {band && (

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -127,20 +127,11 @@ export const PopulationPanel = () => {
     >
       {/* The Population tab already names the panel; only COI mode (with its
           different zone label) keeps a heading. */}
-      {(isCommunityMode || superDraw) && (
+      {isCommunityMode && (
         <Flex direction="row" gap={'2'} align="center">
-          {isCommunityMode && (
-            <Heading as="h3" size="3">
-              {`Total population by ${zoneLabel}`}
-            </Heading>
-          )}
-          {superDraw && (
-            <PopulationPanelOptions
-              chartOptions={chartOptions}
-              setChartOptions={setChartOptions}
-              idealPopulation={effectiveIdealPopulation}
-            />
-          )}
+          <Heading as="h3" size="3">
+            {`Total population by ${zoneLabel}`}
+          </Heading>
         </Flex>
       )}
       {/* Districts render as population meters; the visx bar chart remains for
@@ -255,6 +246,17 @@ export const PopulationPanel = () => {
             </ParentSize>
           </Flex>
         </>
+      )}
+      {/* Super Draw's advanced chart settings sit below the chart so the bars
+          stay the first thing in the panel. */}
+      {superDraw && (
+        <Flex direction="row" gap={'2'} align="center" mt="2">
+          <PopulationPanelOptions
+            chartOptions={chartOptions}
+            setChartOptions={setChartOptions}
+            idealPopulation={effectiveIdealPopulation}
+          />
+        </Flex>
       )}
       {editingCommunity && (
         <EditCommunityDialog

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanel.tsx
@@ -4,7 +4,6 @@ import {ParentSize} from '@visx/responsive'; // Import ParentSize
 import {useChartStore} from '@store/chartStore';
 import {useMapStore} from '@store/mapStore';
 import {useMapControlsStore} from '@store/mapControlsStore';
-import {useToolbarStore} from '@store/toolbarStore';
 import {
   PopulationChart,
   PopulationChartAxis,
@@ -15,7 +14,6 @@ import {
   getBarCenterY,
   getChartHeight,
 } from './PopulationChart/PopulationChart';
-import {PopulationPanelOptions} from './PopulationPanelOptions';
 import {DistrictMeters} from './DistrictMeters';
 import {Pencil1Icon} from '@radix-ui/react-icons';
 import {useZonePopulations} from '@/app/hooks/useDemography';
@@ -52,14 +50,12 @@ export const PopulationPanel = () => {
 
   const chartOptions = useChartStore(state => state.chartOptions);
   const showDistrictNumbers = chartOptions.popShowDistrictNumbers;
-  const setChartOptions = useChartStore(state => state.setChartOptions);
   const selectedZone = useMapControlsStore(state => state.selectedZone);
   const access = useMapStore(state => state.mapStatus?.access);
   const communities = useMapStore(state => state.communities);
   const updateCommunity = useMapStore(state => state.updateCommunity);
   const getZoneColor = useZoneColorGetter();
   const isEditing = useMapControlsStore(state => state.isEditing);
-  const superDraw = useToolbarStore(state => state.superDraw);
   const shouldUseScrollableRows = populationData.length > 10;
   const selectCommunity = useSelectCommunity();
   const colorScheme = useColorScheme();
@@ -246,17 +242,6 @@ export const PopulationPanel = () => {
             </ParentSize>
           </Flex>
         </>
-      )}
-      {/* Super Draw's advanced chart settings sit below the chart so the bars
-          stay the first thing in the panel. */}
-      {superDraw && (
-        <Flex direction="row" gap={'2'} align="center" mt="2">
-          <PopulationPanelOptions
-            chartOptions={chartOptions}
-            setChartOptions={setChartOptions}
-            idealPopulation={effectiveIdealPopulation}
-          />
-        </Flex>
       )}
       {editingCommunity && (
         <EditCommunityDialog

--- a/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
+++ b/app/src/app/components/sidebar/PopulationPanel/PopulationPanelOptions.tsx
@@ -41,7 +41,7 @@ export const PopulationPanelOptions: React.FC<{
     <>
       <Popover.Root>
         <Popover.Trigger>
-          <Button variant="outline" size="1" ml="2" aria-label="Open population chart settings">
+          <Button variant="outline" size="1" aria-label="Open population chart settings">
             Population chart settings
           </Button>
         </Popover.Trigger>

--- a/app/src/app/components/sidebar/Sidebar.tsx
+++ b/app/src/app/components/sidebar/Sidebar.tsx
@@ -9,7 +9,6 @@ import {styled} from '@stitches/react';
 import {MapContextComment} from './MapContextComment';
 import {CoiCommunityViewer} from './CoiCommunityViewer';
 import {DataCards} from './DataCards';
-import {DraftStatusHelper} from './DraftStatusHelper';
 
 const StyledScrollArea = styled(ScrollArea, {
   maxWidth: '100%',
@@ -104,7 +103,6 @@ export default function SidebarComponent() {
       </div>
       <Flex direction="column" gap="3" className="size-full">
         <div className="flex flex-col gap-3 pr-3">
-          <DraftStatusHelper />
           <ToolbarInSidebar />
           <CoiCommunityViewer />
           <MapContextComment />

--- a/app/src/app/components/sidebar/StackedPanels.tsx
+++ b/app/src/app/components/sidebar/StackedPanels.tsx
@@ -16,7 +16,7 @@ import {SummaryPanel} from './SummaryPanel';
 import {AnimatedCollapse} from './AnimatedCollapse';
 import {CoalitionExpander} from './CoalitionExpander';
 import {MapControlsStore, useMapControlsStore} from '@store/mapControlsStore';
-import {useUiHintStore} from '@store/uiHintStore';
+import {useGuideTarget} from '@store/uiHintStore';
 import {MAP_MODES} from '@constants/map/mode';
 import {SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
 import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
@@ -128,26 +128,12 @@ const AccordionSection: React.FC<{
   onToggle: () => void;
 }> = ({section, open, onToggle}) => {
   const Icon = section.icon;
-  // Guided step (see uiHintStore.guideTargets): in the stacked layout the
-  // draft helper points at whole panels (`panel:<key>`), pulsing the header
-  // until the user opens the section themselves. An already-open section
-  // needs no click — advance past it (and pulse it once as the landing
-  // confirmation when it ends the guide). Mirrors WorkflowTabs' TabSection.
-  const guideId = `panel:${section.key}`;
-  const guiding = useUiHintStore(state => state.guideTargets[0] === guideId);
-  const advanceGuide = useUiHintStore(state => state.advanceGuide);
-  const flash = useUiHintStore(state => state.flash);
-  const flashing = useUiHintStore(state => state.flashTarget === guideId);
+  // Stacked-layout twin of WorkflowTabs' TabSection guide consumer.
+  const {guiding, flashing} = useGuideTarget(`panel:${section.key}`, open);
   const sectionRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (!guiding) return;
-    sectionRef.current?.scrollIntoView({behavior: 'smooth', block: 'start'});
-    if (open) {
-      const lastStep = useUiHintStore.getState().guideTargets.length === 1;
-      advanceGuide(guideId);
-      if (lastStep) flash(guideId);
-    }
-  }, [guiding, open, guideId, advanceGuide, flash]);
+    if (guiding) sectionRef.current?.scrollIntoView({behavior: 'smooth', block: 'start'});
+  }, [guiding]);
   // A real <button>: the row holds only Icon/Text/ChevronDownIcon, no nested
   // interactive content, and its own onClick (toggling the accordion) survives
   // being cloned by HelpTip below the same way it would on a div.

--- a/app/src/app/components/sidebar/StackedPanels.tsx
+++ b/app/src/app/components/sidebar/StackedPanels.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {Flex, Text} from '@radix-ui/themes';
 import {
   CheckCircledIcon,
@@ -16,6 +16,7 @@ import {SummaryPanel} from './SummaryPanel';
 import {AnimatedCollapse} from './AnimatedCollapse';
 import {CoalitionExpander} from './CoalitionExpander';
 import {MapControlsStore, useMapControlsStore} from '@store/mapControlsStore';
+import {useUiHintStore} from '@store/uiHintStore';
 import {MAP_MODES} from '@constants/map/mode';
 import {SUMMARY_TYPES, type SummaryType} from '@constants/demography/summary';
 import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
@@ -127,6 +128,26 @@ const AccordionSection: React.FC<{
   onToggle: () => void;
 }> = ({section, open, onToggle}) => {
   const Icon = section.icon;
+  // Guided step (see uiHintStore.guideTargets): in the stacked layout the
+  // draft helper points at whole panels (`panel:<key>`), pulsing the header
+  // until the user opens the section themselves. An already-open section
+  // needs no click — advance past it (and pulse it once as the landing
+  // confirmation when it ends the guide). Mirrors WorkflowTabs' TabSection.
+  const guideId = `panel:${section.key}`;
+  const guiding = useUiHintStore(state => state.guideTargets[0] === guideId);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const flash = useUiHintStore(state => state.flash);
+  const flashing = useUiHintStore(state => state.flashTarget === guideId);
+  const sectionRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!guiding) return;
+    sectionRef.current?.scrollIntoView({behavior: 'smooth', block: 'start'});
+    if (open) {
+      const lastStep = useUiHintStore.getState().guideTargets.length === 1;
+      advanceGuide(guideId);
+      if (lastStep) flash(guideId);
+    }
+  }, [guiding, open, guideId, advanceGuide, flash]);
   // A real <button>: the row holds only Icon/Text/ChevronDownIcon, no nested
   // interactive content, and its own onClick (toggling the accordion) survives
   // being cloned by HelpTip below the same way it would on a div.
@@ -134,7 +155,9 @@ const AccordionSection: React.FC<{
     <button
       onClick={onToggle}
       aria-expanded={open}
-      className="w-full cursor-pointer text-left p-3 rounded-lg transition-colors hover:bg-blue-50"
+      className={`w-full cursor-pointer text-left p-3 rounded-lg transition-colors hover:bg-blue-50 ${
+        guiding ? 'ui-guide' : ''
+      }`}
     >
       <Flex gap="2" align="center">
         <Icon className="shrink-0" />
@@ -149,8 +172,9 @@ const AccordionSection: React.FC<{
   );
   return (
     <div
-      className="border border-gray-300 rounded-lg bg-white"
+      className={`border border-gray-300 rounded-lg bg-white ${flashing ? 'ui-flash' : ''}`}
       data-testid={`data-panel-${section.key}`}
+      ref={sectionRef}
     >
       {section.helpTip ? (
         <HelpTip tip={section.helpTip} openDelay={HELP_TIP_HOVER_DELAY}>

--- a/app/src/app/components/sidebar/WorkflowTabs.tsx
+++ b/app/src/app/components/sidebar/WorkflowTabs.tsx
@@ -30,13 +30,32 @@ const TabSection: React.FC<{
   const toggleTabSection = useMapControlsStore(state => state.toggleTabSection);
   // Helper hints pulse the section they just pointed the user at.
   const flashing = useUiHintStore(state => state.flashTarget === `section:${id}`);
+  // Guided step: pulse the header until the user expands the section
+  // themselves. An already-open section needs no click — advance past it (and
+  // pulse it once as the landing confirmation when it ends the guide).
+  const guideId = `section:${id}`;
+  const guiding = useUiHintStore(state => state.guideTargets[0] === guideId);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
+  const flash = useUiHintStore(state => state.flash);
+  const sectionRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!guiding) return;
+    sectionRef.current?.scrollIntoView({behavior: 'smooth', block: 'start'});
+    if (open) {
+      const lastStep = useUiHintStore.getState().guideTargets.length === 1;
+      advanceGuide(guideId);
+      if (lastStep) flash(guideId);
+    }
+  }, [guiding, open, guideId, advanceGuide, flash]);
   // -mx-2 + px-2 (matching the panels' px="2"): the hover wash spans the full
   // panel while the label shares the content's left edge.
   const headerRow = (
     <button
       onClick={() => toggleTabSection(id)}
       aria-expanded={open}
-      className="w-auto cursor-pointer text-left -mx-2 px-2 py-3 rounded transition-colors hover:bg-[var(--gray-2)]"
+      className={`w-auto cursor-pointer text-left -mx-2 px-2 py-3 rounded transition-colors hover:bg-[var(--gray-2)] ${
+        guiding ? 'ui-guide' : ''
+      }`}
     >
       <Flex align="center" justify="between">
         <Text size="3" className="font-semibold">
@@ -51,7 +70,12 @@ const TabSection: React.FC<{
     </button>
   );
   return (
-    <Flex direction="column" className={flashing ? 'ui-flash' : ''} data-section-id={id}>
+    <Flex
+      direction="column"
+      className={flashing ? 'ui-flash' : ''}
+      data-section-id={id}
+      ref={sectionRef}
+    >
       {helpTip ? (
         <HelpTip tip={helpTip} openDelay={HELP_TIP_HOVER_DELAY}>
           {headerRow}
@@ -164,20 +188,15 @@ export const WorkflowTabs: React.FC<{layoutToggle: React.ReactNode}> = ({layoutT
   // Mode switches can hide the current tab; fall back to the first visible one.
   const activeKey = visibleTabs.some(t => t.key === tab) ? tab : visibleTabs[0].key;
   const activeTab = visibleTabs.find(t => t.key === activeKey);
-  // One-shot tab request (see uiHintStore). Requests that arrived while the
-  // tabs were unmounted are stale: the first effect run after mount discards
-  // them instead of firing a surprise jump.
-  const sidebarTabRequest = useUiHintStore(state => state.requests.sidebarTab);
-  const clearRequest = useUiHintStore(state => state.clear);
   const flashTarget = useUiHintStore(state => state.flashTarget);
-  const tabRequestsLive = useRef(false);
+  // Guided step (see uiHintStore.guideTargets): pulse the destination tab
+  // until the user clicks it; a guide pointing at the already-active tab
+  // advances straight to its next step.
+  const guideTarget = useUiHintStore(state => state.guideTargets[0]);
+  const advanceGuide = useUiHintStore(state => state.advanceGuide);
   useEffect(() => {
-    const live = tabRequestsLive.current;
-    tabRequestsLive.current = true;
-    if (!sidebarTabRequest) return;
-    clearRequest('sidebarTab');
-    if (live) setTab(sidebarTabRequest);
-  }, [sidebarTabRequest, clearRequest]);
+    if (guideTarget === `tab:${activeKey}`) advanceGuide(guideTarget);
+  }, [guideTarget, activeKey, advanceGuide]);
 
   // A one-tab strip (COI) is noise; the Super Draw toggle must stay reachable.
   const showStrip = visibleTabs.length > 1;
@@ -198,9 +217,10 @@ export const WorkflowTabs: React.FC<{layoutToggle: React.ReactNode}> = ({layoutT
             <div className="flex gap-5 text-sm tracking-wider">
               {visibleTabs.map(t => {
                 const active = t.key === activeKey;
-                // Helper jumps pulse the destination tab label first (see
-                // jumpToSection) so the cut to another tab reads as a path.
+                // Flash is the one-shot confirmation pulse; guide keeps
+                // pulsing until the user clicks the tab themselves.
                 const flashing = flashTarget === `tab:${t.key}`;
+                const guiding = guideTarget === `tab:${t.key}`;
                 return (
                   <button
                     key={t.key}
@@ -212,7 +232,7 @@ export const WorkflowTabs: React.FC<{layoutToggle: React.ReactNode}> = ({layoutT
                       active
                         ? 'text-districtrBlue font-bold border-districtrBlue'
                         : 'text-gray-600 border-transparent'
-                    } ${flashing ? 'ui-flash' : ''}`}
+                    } ${flashing ? 'ui-flash' : ''} ${guiding ? 'ui-guide' : ''}`}
                   >
                     {/* Invisible bold twin reserves bold width so tabs don't
                         shift when the active weight changes. */}

--- a/app/src/app/components/sidebar/WorkflowTabs.tsx
+++ b/app/src/app/components/sidebar/WorkflowTabs.tsx
@@ -10,7 +10,7 @@ import {AnimatedCollapse} from './AnimatedCollapse';
 import {CoalitionExpander} from './CoalitionExpander';
 import {ToolSettings} from '../Toolbar/Settings';
 import {useMapControlsStore} from '@store/mapControlsStore';
-import {useUiHintStore} from '@store/uiHintStore';
+import {useUiHintStore, useGuideTarget} from '@store/uiHintStore';
 import {MAP_MODES} from '@constants/map/mode';
 import {SUMMARY_TYPES} from '@constants/demography/summary';
 import {HelpTip, HELP_TIP_HOVER_DELAY} from '@components/HelpTip/HelpTip';
@@ -28,24 +28,11 @@ const TabSection: React.FC<{
 }> = ({id, label, helpTip, children}) => {
   const open = useMapControlsStore(state => !state.collapsedTabSections.includes(id));
   const toggleTabSection = useMapControlsStore(state => state.toggleTabSection);
-  // Helper hints pulse the section they just pointed the user at.
-  const flashing = useUiHintStore(state => state.flashTarget === `section:${id}`);
-  // Guide target: pulses until the user expands the section; already-open
-  // sections advance immediately (with a confirmation flash if guide-final).
-  const guideId = `section:${id}`;
-  const guiding = useUiHintStore(state => state.guideTargets[0] === guideId);
-  const advanceGuide = useUiHintStore(state => state.advanceGuide);
-  const flash = useUiHintStore(state => state.flash);
+  const {guiding, flashing} = useGuideTarget(`section:${id}`, open);
   const sectionRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (!guiding) return;
-    sectionRef.current?.scrollIntoView({behavior: 'smooth', block: 'start'});
-    if (open) {
-      const lastStep = useUiHintStore.getState().guideTargets.length === 1;
-      advanceGuide(guideId);
-      if (lastStep) flash(guideId);
-    }
-  }, [guiding, open, guideId, advanceGuide, flash]);
+    if (guiding) sectionRef.current?.scrollIntoView({behavior: 'smooth', block: 'start'});
+  }, [guiding]);
   // -mx-2 + px-2 (matching the panels' px="2"): the hover wash spans the full
   // panel while the label shares the content's left edge.
   const headerRow = (

--- a/app/src/app/components/sidebar/WorkflowTabs.tsx
+++ b/app/src/app/components/sidebar/WorkflowTabs.tsx
@@ -30,9 +30,8 @@ const TabSection: React.FC<{
   const toggleTabSection = useMapControlsStore(state => state.toggleTabSection);
   // Helper hints pulse the section they just pointed the user at.
   const flashing = useUiHintStore(state => state.flashTarget === `section:${id}`);
-  // Guided step: pulse the header until the user expands the section
-  // themselves. An already-open section needs no click — advance past it (and
-  // pulse it once as the landing confirmation when it ends the guide).
+  // Guide target: pulses until the user expands the section; already-open
+  // sections advance immediately (with a confirmation flash if guide-final).
   const guideId = `section:${id}`;
   const guiding = useUiHintStore(state => state.guideTargets[0] === guideId);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
@@ -189,9 +188,7 @@ export const WorkflowTabs: React.FC<{layoutToggle: React.ReactNode}> = ({layoutT
   const activeKey = visibleTabs.some(t => t.key === tab) ? tab : visibleTabs[0].key;
   const activeTab = visibleTabs.find(t => t.key === activeKey);
   const flashTarget = useUiHintStore(state => state.flashTarget);
-  // Guided step (see uiHintStore.guideTargets): pulse the destination tab
-  // until the user clicks it; a guide pointing at the already-active tab
-  // advances straight to its next step.
+  // Guide target: pulses the destination tab; already-active tabs advance.
   const guideTarget = useUiHintStore(state => state.guideTargets[0]);
   const advanceGuide = useUiHintStore(state => state.advanceGuide);
   useEffect(() => {

--- a/app/src/app/constants/document/geoUnits.ts
+++ b/app/src/app/constants/document/geoUnits.ts
@@ -11,3 +11,11 @@ export const GEO_UNIT_LABELS: Record<GeoUnit, string> = {
   [GEO_UNITS.BLOCK_GROUP]: 'block groups',
   [GEO_UNITS.BLOCK]: 'blocks',
 };
+
+/** Singular, human-friendly unit names for instructional copy (e.g. the break
+ * tool's "Choose a precinct to break down into blocks" prompt). */
+export const GEO_UNIT_SINGULAR_NAMES: Record<GeoUnit, string> = {
+  [GEO_UNITS.VTD]: 'precinct',
+  [GEO_UNITS.BLOCK_GROUP]: 'block group',
+  [GEO_UNITS.BLOCK]: 'block',
+};

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -204,6 +204,14 @@ body {
   border-radius: 6px;
 }
 
+/* A highlighted Radix menu item keeps its white text while the pulse
+   animation replaces its dark background with the pale wash — force a
+   readable color for the pulse's duration. */
+.ui-flash[data-highlighted],
+.ui-guide[data-highlighted] {
+  color: var(--gray-12);
+}
+
 /* Stronger variant for tiny targets like the topbar status icon, where the
    standard wash is easy to miss. A saturated wash blink, fully inside the
    element's own box — the truncating title header's overflow rules clip

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -197,6 +197,14 @@ body {
   border-radius: 6px;
 }
 
+/* Persistent variant for guided sequences (uiHintStore.guideTargets): the
+   target keeps pulsing until the user clicks it themselves — the guide
+   points, it never clicks — so this loops instead of playing twice. */
+.ui-guide {
+  animation: ui-flash-pulse 1.4s ease-out infinite;
+  border-radius: 6px;
+}
+
 /* Stronger variant for tiny targets like the topbar status icon, where the
    standard wash is easy to miss. A saturated wash blink, fully inside the
    element's own box — the truncating title header's overflow rules clip

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -197,11 +197,10 @@ body {
   border-radius: 6px;
 }
 
-/* Persistent variant for guided sequences (uiHintStore.guideTargets): the
-   target keeps pulsing until the user clicks it themselves — the guide
-   points, it never clicks — so this loops instead of playing twice. */
+/* Guided-sequence variant (uiHintStore.guideTargets): ~10s of pulsing,
+   matching GUIDE_STEP_TIMEOUT_MS. */
 .ui-guide {
-  animation: ui-flash-pulse 1.4s ease-out infinite;
+  animation: ui-flash-pulse 1.4s ease-out 7;
   border-radius: 6px;
 }
 

--- a/app/src/app/hooks/useAltHeld.ts
+++ b/app/src/app/hooks/useAltHeld.ts
@@ -1,0 +1,31 @@
+'use client';
+import {useEffect, useState} from 'react';
+
+/**
+ * True while the Alt/Option key is held. Hides on window blur too, since
+ * alt-tab / app switching can swallow the keyup. Consumers only mount inside
+ * draw mode (the Toolbar subtree), so the listeners don't outlive it.
+ */
+export const useAltHeld = () => {
+  const [altHeld, setAltHeld] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Alt') setAltHeld(true);
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Alt') setAltHeld(false);
+    };
+    const hide = () => setAltHeld(false);
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', hide);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', hide);
+    };
+  }, []);
+
+  return altHeld;
+};

--- a/app/src/app/store/uiHintStore.ts
+++ b/app/src/app/store/uiHintStore.ts
@@ -22,9 +22,9 @@ const FLASH_DURATION_MS = 3000;
 const FLASH_RESTART_MS = 30;
 let flashSeq = 0;
 
-// An abandoned guide must not pulse its target forever; each step re-arms the
-// clock so a slow walk through a multi-step guide isn't cut off mid-way.
-const GUIDE_STEP_TIMEOUT_MS = 45000;
+// Per-step expiry, re-armed on each advance; keep in sync with .ui-guide's
+// animation length.
+const GUIDE_STEP_TIMEOUT_MS = 10000;
 let guideSeq = 0;
 
 interface UiHintStore {
@@ -36,13 +36,9 @@ interface UiHintStore {
    * are component-specific. Self-clears. */
   flashTarget: string | null;
   flash: (id: string) => void;
-  /** Guided sequences: an ordered list of highlight targets the user walks
-   * through by clicking each one themselves — the guide points, it never
-   * clicks on the user's behalf. The head of the list is the active target;
-   * its host component marks itself `.ui-guide` and calls `advanceGuide` on
-   * the user's own click, or immediately when the target is already satisfied
-   * (the pointed-at tab already active, the section already open). Each step
-   * self-expires so an abandoned guide can't pulse forever. */
+  /** Ordered highlight targets the user clicks through themselves. The head
+   * is active: its host marks itself `.ui-guide` and calls `advanceGuide` on
+   * the user's click (or immediately if already satisfied). Steps self-expire. */
   guideTargets: string[];
   startGuide: (targets: string[]) => void;
   /** Advance past `id` — a no-op unless `id` is the current head, so hosts

--- a/app/src/app/store/uiHintStore.ts
+++ b/app/src/app/store/uiHintStore.ts
@@ -1,26 +1,18 @@
 import {create} from 'zustand';
-import type {WorkflowTabKey} from '@components/sidebar/WorkflowTabs';
 import type {MapControlsStore} from '@store/mapControlsStore';
 
 export type ValidationTab = 'Contiguity' | 'Completeness';
 
-/** One-shot cross-component UI requests, mostly issued by the draft-status
- * helper box. Each key is consumed (and cleared) by one component: sidebarTab
- * by WorkflowTabs, validationTab by MapValidation, shareModal by
- * MapActionsDropdown, modeMenu by ModeSwitcher (opens the dropdown without
- * changing modes). A request is honored only if its consumer is mounted when
- * it arrives — stale requests are discarded at the consumer's next mount
- * rather than firing late, so callers that need one from another context
- * (stacked layout, eval view) must switch there first. */
+/** One-shot cross-component UI requests, issued by the draft-status helper
+ * box. Each key is consumed (and cleared) by one component. A request is
+ * honored only if its consumer is mounted when it arrives — stale requests
+ * are discarded at the consumer's next mount rather than firing late, so
+ * callers that need one from another context (stacked layout, eval view)
+ * must switch there first. */
 type UiHintRequests = {
-  sidebarTab: WorkflowTabKey;
   /** Below lg the sidebar is hidden; helper jumps open the matching
    * full-screen mobile panel instead. Consumed by MobileDataTabs. */
   mobileTab: MapControlsStore['sidebarPanels'][number];
-  validationTab: ValidationTab;
-  shareModal: true;
-  /** Which mode item the opened dropdown should pulse. */
-  modeMenu: 'superdraw' | 'evaluate';
 };
 
 const FLASH_DURATION_MS = 3000;
@@ -29,6 +21,11 @@ const FLASH_DURATION_MS = 3000;
 // flash's clear timer.
 const FLASH_RESTART_MS = 30;
 let flashSeq = 0;
+
+// An abandoned guide must not pulse its target forever; each step re-arms the
+// clock so a slow walk through a multi-step guide isn't cut off mid-way.
+const GUIDE_STEP_TIMEOUT_MS = 45000;
+let guideSeq = 0;
 
 interface UiHintStore {
   requests: Partial<UiHintRequests>;
@@ -39,6 +36,19 @@ interface UiHintStore {
    * are component-specific. Self-clears. */
   flashTarget: string | null;
   flash: (id: string) => void;
+  /** Guided sequences: an ordered list of highlight targets the user walks
+   * through by clicking each one themselves — the guide points, it never
+   * clicks on the user's behalf. The head of the list is the active target;
+   * its host component marks itself `.ui-guide` and calls `advanceGuide` on
+   * the user's own click, or immediately when the target is already satisfied
+   * (the pointed-at tab already active, the section already open). Each step
+   * self-expires so an abandoned guide can't pulse forever. */
+  guideTargets: string[];
+  startGuide: (targets: string[]) => void;
+  /** Advance past `id` — a no-op unless `id` is the current head, so hosts
+   * can call it unconditionally from their click handlers. */
+  advanceGuide: (id: string) => void;
+  cancelGuide: () => void;
 }
 
 export const useUiHintStore = create<UiHintStore>((set, get) => ({
@@ -59,5 +69,26 @@ export const useUiHintStore = create<UiHintStore>((set, get) => ({
     setTimeout(() => {
       if (seq === flashSeq) set({flashTarget: null});
     }, FLASH_DURATION_MS);
+  },
+  guideTargets: [],
+  startGuide: targets => {
+    const seq = ++guideSeq;
+    set({guideTargets: targets});
+    setTimeout(() => {
+      if (seq === guideSeq) set({guideTargets: []});
+    }, GUIDE_STEP_TIMEOUT_MS);
+  },
+  advanceGuide: id => {
+    if (get().guideTargets[0] !== id) return;
+    const seq = ++guideSeq;
+    set(state => ({guideTargets: state.guideTargets.slice(1)}));
+    setTimeout(() => {
+      if (seq === guideSeq) set({guideTargets: []});
+    }, GUIDE_STEP_TIMEOUT_MS);
+  },
+  cancelGuide: () => {
+    // Invalidate pending expiries so a later guide isn't cleared by them.
+    ++guideSeq;
+    set({guideTargets: []});
   },
 }));

--- a/app/src/app/store/uiHintStore.ts
+++ b/app/src/app/store/uiHintStore.ts
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {create} from 'zustand';
 import type {MapControlsStore} from '@store/mapControlsStore';
 
@@ -88,3 +89,20 @@ export const useUiHintStore = create<UiHintStore>((set, get) => ({
     set({guideTargets: []});
   },
 }));
+
+/** Guide-consumer hook: `guiding` while `id` is the active guide head (mark
+ * the host `.ui-guide`), `flashing` for the one-shot `.ui-flash` pulse. When
+ * `satisfied` (target already open/on/active), the step advances itself,
+ * flashing as confirmation if it ended the guide. */
+export const useGuideTarget = (id: string, satisfied = false) => {
+  const guiding = useUiHintStore(state => state.guideTargets[0] === id);
+  const flashing = useUiHintStore(state => state.flashTarget === id);
+  useEffect(() => {
+    if (!guiding || !satisfied) return;
+    const {guideTargets, advanceGuide, flash} = useUiHintStore.getState();
+    const lastStep = guideTargets.length === 1;
+    advanceGuide(id);
+    if (lastStep) flash(id);
+  }, [guiding, satisfied, id]);
+  return {guiding, flashing};
+};


### PR DESCRIPTION
- Contiguity
    - Use wording components instead of pieces
    - Sort by most components first, then district number when tied
- Population chart
    - Square off at ideal population, no rounded end to pill at all
    - Super draw pop chart move advanced options to bottom of chart area
- Get started draft status box
    - Show all status and highlight current. Show an arrow when ready to move to next step
    - Collapse in super draw
        - Add option to dismiss
        - Memory for super draw, draw dismiss every time
    - Auto collapse when getting to final step 
    - Remove hint to go to super draw when in super draw
    - Move start box to top right of map area
    - Text updates - make questions
        - Get started
            - Are all districts started?
            - Have all population been assigned to a district?
        - Refine
            - Are districts roughly balanced?
            - Are districts contiguous?
    - Multi-step hints should show, not click for users (eg. Find fragments should show stats until stats is clicked, then on a second click highlight contiguity
    - Share map just highlight dropdown, not click it
- Wording
    - Change ‘only paint unassigned areas’ to ‘Forbid paint-over’
    - Change ‘County brush’ to ‘Paint by county’
- Show hotkeys in draw mode on press of alt/option
- Break tool
    - Change wording to “Choose a ‘precinct|block group’ to break down into blocks” based on units for map
- Restore units to brush slider
- Change page title after load (from SSR warning)