### PR TITLE
Cutover §3.3: make the apex canonical

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,18 +4,22 @@
 secretsprovider: awskms://alias/districtr-pulumi-secrets?region=us-east-2
 config:
   aws:region: us-east-2
-  districtr-infra:appDomain: beta.districtr.org
-  districtr-infra:apiDomain: api.beta.districtr.org
+  # The apex is the canonical host. appDomain also sets APP_BASE_URL — the
+  # Auth0 callback base and metadataBase — so until this flipped, pages served
+  # at districtr.org still sent sign-ins and canonical URLs to beta.
+  districtr-infra:appDomain: districtr.org
+  districtr-infra:apiDomain: api.districtr.org
+  # Same six names as before the flip, just re-sorted around the new
+  # domainName — the cert covers old and new until beta is retired.
   districtr-infra:extraDomains:
-    - www.beta.districtr.org
-    - districtr.org
     - www.districtr.org
-    - api.districtr.org
-  # Routes api.districtr.org to the backend before apiDomain flips to it, so
-  # the name works the moment DNS points here. Becomes api.beta.districtr.org
-  # on flip day (cached bundles keep calling the old one).
+    - beta.districtr.org
+    - www.beta.districtr.org
+    - api.beta.districtr.org
+  # Bundles built before the API URL flip still call the beta host; this keeps
+  # them reaching the backend (and under the API rate limit) until they age out.
   districtr-infra:extraApiDomains:
-    - api.districtr.org
+    - api.beta.districtr.org
   districtr-infra:corsOrigins: https://beta.districtr.org,https://www.beta.districtr.org,https://districtr.org,https://www.districtr.org
   districtr-infra:s3BucketName:
     secure: v1:MS8AzWKQiTmtjfkB:oz6SV4+k43qsx7zvx/cdwVO4Be+fhIJd1wMaghY7OLAHbWwTV3gzHrTg


### PR DESCRIPTION
Completes the domain cutover. #700 landed the prep (§2.3/§2.4/§2.7) but not the flip, so `districtr.org` has been serving publicly with `appDomain` still set to beta:

- `APP_BASE_URL` = `https://beta.districtr.org`, which is the Auth0 callback base — signing in from the apex redirects to the old host.
- `metadataBase` follows it, so apex pages declare beta canonical/OG URLs, pointing search engines at the host we're retiring.

`appDomain`/`apiDomain` now name the apex. The beta hostnames move into `extraDomains` (cert) and `extraApiDomains` (backend routing + API rate limit), so nothing in flight breaks — bundles built before the API URL flip keep calling `api.beta.districtr.org` and keep reaching FastAPI.

**Deploy note:** the cert covers the same six names, but `appDomain` is the ACM `domainName`, so `pulumi up` replaces the certificate and blocks at `CertificateValidation`. Every validation CNAME is already in the zone, so it should clear in a minute or two rather than the first run's wait.

Runbook: `infra/DOMAIN-CUTOVER.md` §3.3.

Still outstanding after this: §3.2 (`API_URL_PROD` repo variable → `https://api.districtr.org`, then an app rebuild — it's baked in at build time) and §4 (beta → apex 301, www canonicalization).